### PR TITLE
Subtitles: use worldPositionStays=false when moving UI item

### DIFF
--- a/src/Subtitles.Core/Core.Subtitles.Caption.cs
+++ b/src/Subtitles.Core/Core.Subtitles.Caption.cs
@@ -164,7 +164,7 @@ namespace KK_Plugins
                 fsize = (int)(fsize < 0 ? (fsize * Screen.height / -100.0) : fsize);
 
                 GameObject subtitle = new GameObject("SubtitleText");
-                subtitle.transform.SetParent(Pane.transform);
+                subtitle.transform.SetParent(Pane.transform, false);
 
                 var rect = subtitle.GetOrAddComponent<RectTransform>();
                 rect.pivot = new Vector2(0.5f, 0);


### PR DESCRIPTION
Setting `worldPositionStays` to false seems to be considered a best practice for reparenting a `RectTransform`.

By itself this change shouldn't make any difference in behavior, but it improves interaction with other plugins that set the `renderMode` of the canvas to `ScreenSpaceCamera`. This includes <a href=https://github.com/mosirnik/KK_MainGameVR>my version of the VR plugin for Koikatu</a> and probably other VR plugins. Without this change, the presence of such a plugin causes subtitles to have the (very) wrong scale.