### PR TITLE
[KKS] FreeHRandom include default cards from DefaultData folders

### DIFF
--- a/src/FreeHRandom.Core/FreeHRandom.cs
+++ b/src/FreeHRandom.Core/FreeHRandom.cs
@@ -29,6 +29,10 @@ namespace KK_Plugins
             //KK Party may not have these directories when first run, create them to avoid errors
             Directory.CreateDirectory(CC.Paths.FemaleCardPath);
             Directory.CreateDirectory(CC.Paths.MaleCardPath);
+#if KKS
+            Directory.CreateDirectory(CC.Paths.DefaultFemaleCardPath);
+            Directory.CreateDirectory(CC.Paths.DefaultMaleCardPath);
+#endif
 
             SceneManager.sceneLoaded += (s, lsm) => InitUI(s.name);
         }
@@ -101,9 +105,19 @@ namespace KK_Plugins
 
             //Get some random cards
             if (characterType == CharacterType.Player)
+            {
                 folderAssist.CreateFolderInfoEx(CC.Paths.MaleCardPath, new[] { "*.png" });
+#if KKS
+                folderAssist.CreateFolderInfoEx(CC.Paths.DefaultMaleCardPath, new[] { "*.png" }, false);
+#endif
+            }
             else
+            {
                 folderAssist.CreateFolderInfoEx(CC.Paths.FemaleCardPath, new[] { "*.png" });
+#if KKS
+                folderAssist.CreateFolderInfoEx(CC.Paths.DefaultFemaleCardPath, new[] { "*.png" }, false);
+#endif
+            }
 
             //Different fields for different versions of the game, get the correct one
             var listFileObj = folderAssist.GetType().GetField("_lstFile", AccessTools.all)?.GetValue(folderAssist);

--- a/src/Shared/Shared.CommonCode.cs
+++ b/src/Shared/Shared.CommonCode.cs
@@ -87,6 +87,10 @@ namespace KK_Plugins
             internal static readonly string FemaleCardPath = Path.Combine(UserData.Path, "chara/female/");
             internal static readonly string MaleCardPath = Path.Combine(UserData.Path, "chara/male/");
             internal static readonly string CoordinateCardPath = Path.Combine(UserData.Path, "coordinate/");
+#if KKS
+            internal static readonly string DefaultFemaleCardPath = Path.Combine(Localize.Translate.Manager.DefaultData.PATH, "chara/female/");
+            internal static readonly string DefaultMaleCardPath = Path.Combine(Localize.Translate.Manager.DefaultData.PATH, "chara/male/");
+#endif
         }
     }
 }


### PR DESCRIPTION
Looks like Koikatsu Sunshine is storing the default cards in `DefaultData/chara/female` and `DefaultData/chara/male`.
This PR makes it so the plugin also includes them in the random card picker.