### PR TITLE
Stop game from deleting hiPoly characters

### DIFF
--- a/src/ForceHighPoly.Core/ForceHighPoly.Hooks.cs
+++ b/src/ForceHighPoly.Core/ForceHighPoly.Hooks.cs
@@ -147,12 +147,12 @@ namespace KK_Plugins
 #if KK
                 foreach (var item in Manager.Character.Instance.dictEntryChara)
                 {
-                    logSource.Log(cha == item.Value ? BepInEx.Logging.LogLevel.Fatal : BepInEx.Logging.LogLevel.Warning, $"{item.Key} {item.Value.fileParam.fullname} MainGame heroine? {Manager.Game.Instance.actScene.npcList.FirstOrDefault(x => x.heroine.chaCtrl == item.Value) != null}\n\tDontDelete {ForcedControls.Any(x => x == item.Value)} count {ForcedControls.Count}\n\thiPoly: {item.Value.hiPoly}");
+                    logSource.Log(cha == item.Value ? BepInEx.Logging.LogLevel.Fatal : BepInEx.Logging.LogLevel.Warning, $"{item.Key} {item.Value.fileParam.fullname} MainGame heroine? {Manager.Game.Instance.actScene.npcList.FirstOrDefault(x => x.heroine.chaCtrl == item.Value) != null}\n\tDontDelete {ForcedControls.Contains(item.Value)} count {ForcedControls.Count}\n\thiPoly: {item.Value.hiPoly}");
                 }
 #elif KKS
                 foreach (var item in Manager.Character.dictEntryChara)
                 {
-                    logSource.Log(cha == item.Value ? BepInEx.Logging.LogLevel.Fatal : BepInEx.Logging.LogLevel.Warning, $"{item.Key} {item.Value.fileParam.fullname} MainGame heroine? {ActionScene.instance.npcList.FirstOrDefault(x => x.heroine.chaCtrl == item.Value) != null}\n\tDontDelete {ForcedControls.Any(x => x == item.Value)} count {ForcedControls.Count}\n\thiPoly: {item.Value.hiPoly}");
+                    logSource.Log(cha == item.Value ? BepInEx.Logging.LogLevel.Fatal : BepInEx.Logging.LogLevel.Warning, $"{item.Key} {item.Value.fileParam.fullname} MainGame heroine? {ActionScene.instance.npcList.FirstOrDefault(x => x.heroine.chaCtrl == item.Value) != null}\n\tDontDelete {ForcedControls.Contains(item.Value)} count {ForcedControls.Count}\n\thiPoly: {item.Value.hiPoly}");
                 }
 #endif
 #endif
@@ -161,7 +161,7 @@ namespace KK_Plugins
 #elif KKS
                 var getNPC = ActionScene.instance.npcList.FirstOrDefault(x => x.heroine.chaCtrl == cha);
 #endif
-                if (getNPC != null && ForcedControls.Any(x => x == cha))
+                if (getNPC != null && ForcedControls.Contains(cha))
                 {
                     getNPC.heroine.chaCtrl = null;
                     cha.StartCoroutine(ReassignHeroine(cha, getNPC.heroine));

--- a/src/ForceHighPoly.Core/ForceHighPoly.cs
+++ b/src/ForceHighPoly.Core/ForceHighPoly.cs
@@ -14,11 +14,17 @@ namespace KK_Plugins
         public const string GUID = "com.deathweasel.bepinex.forcehighpoly";
         public const string PluginName = "Force High Poly";
         public const string PluginNameInternal = Constants.Prefix + "_ForceHighPoly";
-        public const string Version = "2.0";
+        public const string Version = "2.1";
         public static ConfigEntry<bool> Enabled { get; private set; }
         public static ConfigEntry<PolyMode> PolySetting { get; private set; }
+#if DEBUG
+        internal static BepInEx.Logging.ManualLogSource logSource;
+#endif
         internal void Main()
         {
+#if DEBUG
+            logSource = Logger;
+#endif
             var hasEnoughRam = KKAPI.Utilities.MemoryInfo.GetCurrentStatus().ullTotalPhys > 16L * 1000L * 1000L * 1000L; // At least 16GB
             PolySetting = Config.Bind("Config", "Force High Poly Models", hasEnoughRam ? PolyMode.Full : PolyMode.Partial, "Whether or not to load high poly models in the main game roaming mode (has no effect outside of that). Improves quality of characters and fixes some modded items not appearing.\nMay require exiting to main menu to take effect.\nNone: Original behavior - Some characters may throw errors and walk around with glitched clothing.\nPartial: Use high poly models only if necessary. Higher resource usage and longer load times when using some modded clothes.\nFull: Always use high poly models. Best quality but very high resource usage. At least 8GB of RAM is recommended with ~10 characters. Load times can be 3x longer.");
             PolySetting.SettingChanged += PolySetting_SettingChanged;

--- a/src/ForceHighPoly.Core/ForceHighPoly.cs
+++ b/src/ForceHighPoly.Core/ForceHighPoly.cs
@@ -29,23 +29,7 @@ namespace KK_Plugins
             PolySetting = Config.Bind("Config", "Force High Poly Models", hasEnoughRam ? PolyMode.Full : PolyMode.Partial, "Whether or not to load high poly models in the main game roaming mode (has no effect outside of that). Improves quality of characters and fixes some modded items not appearing.\nMay require exiting to main menu to take effect.\nNone: Original behavior - Some characters may throw errors and walk around with glitched clothing.\nPartial: Use high poly models only if necessary. Higher resource usage and longer load times when using some modded clothes.\nFull: Always use high poly models. Best quality but very high resource usage. At least 8GB of RAM is recommended with ~10 characters. Load times can be 3x longer.");
             PolySetting.SettingChanged += PolySetting_SettingChanged;
             Enabled = Config.Bind("Config", "High poly mode", hasEnoughRam, new ConfigDescription("Original setting kept due to external dependency, no longer used.\nUse the 'Force High Poly Models' setting instead.", null, new ConfigurationManagerAttributes() { Browsable = false }));
-            Enabled.SettingChanged += Enabled_SettingChanged;
             HarmonyLib.Harmony.CreateAndPatchAll(typeof(Hooks));
-        }
-
-
-        private static bool LoopCheck = false;// stops having to click partial twice when swapping out
-
-        /// <summary>
-        /// Update PolySetting when setting is changed.
-        /// </summary>
-        private void Enabled_SettingChanged(object sender, System.EventArgs e)
-        {
-            if (LoopCheck) return;
-            LoopCheck = true;
-            PolySetting.Value = (Enabled.Value) ? PolyMode.Full : PolyMode.None;
-            Config.Save();
-            LoopCheck = false;
         }
 
         /// <summary>
@@ -53,11 +37,8 @@ namespace KK_Plugins
         /// </summary>
         private void PolySetting_SettingChanged(object sender, System.EventArgs e)
         {
-            if (LoopCheck) return;
-            LoopCheck = true;
             Enabled.Value = PolySetting.Value == PolyMode.Full;
             Config.Save();
-            LoopCheck = false;
         }
 
         public enum PolyMode


### PR DESCRIPTION
Did a prefix override on one of the `Manager.Character.Delete` method to prevent the deletion via actionscene calls.
Needed a coroutine to reassign the chacontrol to its heroine, due to one section of code waiting for `heroine.chactrl == null`