### PR TITLE
[StudioWindowResize] Fix Animations panels overflowing

### DIFF
--- a/src/StudioWindowResize.Core/StudioWindowResizePlugin.cs
+++ b/src/StudioWindowResize.Core/StudioWindowResizePlugin.cs
@@ -121,9 +121,9 @@ namespace KK_Plugins
                 if (Config.Bind("Expand", "Animation lists", true, "Increase height of the anim/Animation lists.").Value)
                 {
                     var manipulateAnime = manipulateMenu.Find("03_Anime");
-                    ResizeScrollRect(manipulateAnime.Find("Group Panel"), ADD_ITEM);
-                    ResizeScrollRect(manipulateAnime.Find("Category Panel"), ADD_ITEM);
-                    ResizeScrollRect(manipulateAnime.Find("Anime Panel"), ADD_ITEM);
+                    ResizeScrollRectStrict(manipulateAnime.Find("Group Panel"), ADD_ITEM, 20, -20);
+                    ResizeScrollRectStrict(manipulateAnime.Find("Category Panel"), ADD_ITEM, 20, -20);
+                    ResizeScrollRectStrict(manipulateAnime.Find("Anime Panel"), ADD_ITEM, 20, -20);
                 }
             }
 


### PR DESCRIPTION
Not sure if this is a common issue or just me. The items in the Animation panels are overflowing.

![animations panels overflow](https://user-images.githubusercontent.com/8879012/165160418-29179bc0-272b-42cb-a407-48fb07b0ed3e.png)

Changing those from ResizeScrollRect to ResizeScrollRectStrict and setting offsetMin.y as 20 seems to work.

Also, as a side note. This plugin works nicely in HS2.