### PR TITLE
Tesselation shader swap config option

### DIFF
--- a/src/ShaderSwapper.Core/ShaderSwapper.cs
+++ b/src/ShaderSwapper.Core/ShaderSwapper.cs
@@ -22,6 +22,7 @@ namespace KK_Plugins
         internal static new ManualLogSource Logger;
 
         internal static ConfigEntry<KeyboardShortcut> SwapShadersHotkey { get; private set; }
+        internal static ConfigEntry<float> TesselationSlider { get; private set; }
 
         private readonly Dictionary<string, string> VanillaPlusShaders = new Dictionary<string, string>
         {
@@ -44,10 +45,36 @@ namespace KK_Plugins
             {"Koikano/main_clothes_item", "xukmi/MainItemPlus" },
         };
 
+        private readonly Dictionary<string, string> VanillaPlusTesselationShaders = new Dictionary<string, string>
+        {
+            {"Shader Forge/main_skin", "xukmi/SkinPlusTess" },
+            {"Koikano/main_skin", "xukmi/SkinPlusTess" },
+            {"Shader Forge/main_hair", "xukmi/HairPlus" },
+            {"Koikano/hair_main_sun", "xukmi/HairPlus" },
+            {"Shader Forge/main_hair_front", "xukmi/HairFrontPlus" },
+            {"Koikano/hair_main_sun_front", "xukmi/HairFrontPlus" },
+            {"Shader Forge/toon_eye_lod0", "xukmi/EyePlus" },
+            {"Koikano/main_eye", "xukmi/EyePlus" },
+            {"Shader Forge/toon_eyew_lod0", "xukmi/EyeWPlus" },
+            {"Koikano/main_eyew", "xukmi/EyeWPlus" },
+            {"Shader Forge/main_opaque", "xukmi/MainOpaquePlusTess" },
+            {"Shader Forge/main_opaque2", "xukmi/MainOpaquePlusTess" },
+            {"Koikano/main_clothes_opaque", "xukmi/MainOpaquePlusTess" },
+            {"Shader Forge/main_alpha", "xukmi/MainAlphaPlusTess" },
+            {"Koikano/main_clothes_alpha", "xukmi/MainAlphaPlusTess" },
+            {"Shader Forge/main_item", "xukmi/MainItemPlus" },
+            {"Koikano/main_clothes_item", "xukmi/MainItemPlus" },
+        };
+
         private void Awake()
         {
             Logger = base.Logger;
             SwapShadersHotkey = Config.Bind("Keyboard Shortcuts", "Swap Shaders", new KeyboardShortcut(KeyCode.P, KeyCode.RightControl), "Swap all shaders to the equivalent Vanilla+ shader.");
+            TesselationSlider = Config.Bind("Tesselation", "Tesselation", 0f, 
+                new ConfigDescription("The amount of tesselation to apply.  Leave at 0% to use the regular Vanilla+ shaders without tesselation.",
+                    new AcceptableValueRange<float>(0f, 1f)
+                )
+            );
         }
 
         private void Update()
@@ -90,8 +117,19 @@ namespace KK_Plugins
         private void SwapToVanillaPlus(MaterialEditorCharaController controller, int slot, ObjectType objectType, Material mat, GameObject go)
         {
             if (controller.GetMaterialShader(slot, ObjectType.Clothing, mat, go) == null)
-            {
-                if (VanillaPlusShaders.TryGetValue(mat.shader.name, out var vanillaPlusShaderName))
+            {                
+                if (TesselationSlider.Value > 0 && VanillaPlusTesselationShaders.TryGetValue(mat.shader.name, out var vanillaPlusTesShaderName))
+                {
+                    int renderQueue = mat.renderQueue;
+                    controller.SetMaterialShader(slot, objectType, mat, vanillaPlusTesShaderName, go);
+                    controller.SetMaterialShaderRenderQueue(slot, objectType, mat, renderQueue, go);
+                    if (mat.shader.name == "xukmi/MainAlphaPlus")
+                        controller.SetMaterialFloatProperty(slot, objectType, mat, "Cutoff", 0.1f, go);
+
+                    SetTesselationValue(mat);
+                }
+
+                if (TesselationSlider.Value == 0 && VanillaPlusShaders.TryGetValue(mat.shader.name, out var vanillaPlusShaderName))
                 {
                     int renderQueue = mat.renderQueue;
                     controller.SetMaterialShader(slot, objectType, mat, vanillaPlusShaderName, go);
@@ -129,6 +167,15 @@ namespace KK_Plugins
             foreach (var renderer in GetRendererList(controller.ChaControl.gameObject))
                 foreach (var material in GetMaterials(controller.ChaControl.gameObject, renderer))
                     SwapToVanillaPlus(controller, 0, ObjectType.Character, material, controller.ChaControl.gameObject);
+        }
+
+        private void SetTesselationValue(Material mat) 
+        {
+            if (mat == null || !mat.HasProperty("_TessSmooth"))
+                return;
+                
+            //Adjust the weight of the tesselation
+            mat.SetFloat("_TessSmooth", TesselationSlider.Value);                        
         }
     }
 }


### PR DESCRIPTION
Added a tesselation plugin config slider.  

When the value is set above 0% (default) the Valilla+ shaders that have tesselation will be used, and the tesselation set automatically.



Ignore my last pull request mixed in here too.  One day I will level up on merging correctly ¯\_(ツ)_/¯