### PR TITLE
Fix some missing or misplaced buttons of PH_ME

### DIFF
--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -140,14 +140,15 @@ namespace KK_Plugins.MaterialEditor
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Bottoms, this)).OnClick.AddListener(() => UpdateUIClothes(1));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Bra, this)).OnClick.AddListener(() => UpdateUIClothes(2));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Shorts, this)).OnClick.AddListener(() => UpdateUIClothes(3));
-            e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.SwimWear, this)).OnClick.AddListener(() => UpdateUIClothes(4));
-            e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.SwimTops, this)).OnClick.AddListener(() => UpdateUIClothes(5));
+            e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.SwimTops, this)).OnClick.AddListener(() => UpdateUIClothes(4));
+            e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.SwimBottoms, this)).OnClick.AddListener(() => UpdateUIClothes(5));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.SwimWear, this)).OnClick.AddListener(() => UpdateUIClothes(6));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Glove, this)).OnClick.AddListener(() => UpdateUIClothes(7));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Panst, this)).OnClick.AddListener(() => UpdateUIClothes(8));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Socks, this)).OnClick.AddListener(() => UpdateUIClothes(9));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Wear.Shoes, this)).OnClick.AddListener(() => UpdateUIClothes(10));
 
+            e.AddControl(new MakerButton("Material Editor", MakerConstants.Hair.Set, this)).OnClick.AddListener(() => UpdateUIHair(0));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Hair.Back, this)).OnClick.AddListener(() => UpdateUIHair(0));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Hair.Front, this)).OnClick.AddListener(() => UpdateUIHair(1));
             e.AddControl(new MakerButton("Material Editor", MakerConstants.Hair.Side, this)).OnClick.AddListener(() => UpdateUIHair(2));


### PR DESCRIPTION
For some reason, In the vanila game (except for Bepinex, RuntimeUnityEditor)

"EditMode/Canvas/Wear/Main/`Swim Tops`" GameObject -> calls `SWIM` Wear_Type (index:4) related stuff 
"EditMode/Canvas/Wear/Main/`Swim Bottoms`" ->  `SWIM_TOP` (index:5)
"EditMode/Canvas/Wear/Main/`Swim Wear`" ->  `SWIM_BOTTOM` (index:6)

Thanks