### PR TITLE
Reduced radius of AI/HS2 colliders

### DIFF
--- a/src/Colliders.Core/Core.Colliders.Constants.cs
+++ b/src/Colliders.Core/Core.Colliders.Constants.cs
@@ -7,14 +7,23 @@ namespace KK_Plugins
     {
 #if AI || HS2
         internal static ColliderData FloorColliderData = new ColliderData("cf_J_Root", 100f, 0f, new Vector3(0, -100.01f, 0f));
+/*      AIS default colliders for future reference:
+            "cf_J_Hand_s_L", 0.3f, 1f, new Vector3(-0.25f, 0f, 0f)
+            "cf_J_Hand_s_R", 0.3f, 1f, new Vector3(0.25f, 0f, 0f)
+            "cf_J_ArmLow01_s_L", 0.4f, 1.5f, new Vector3(-0.35f, 0f, 0f)
+            "cf_J_ArmLow01_s_R", 0.4f, 1.5f, new Vector3(0.35f, 0f, 0f)
+            "cf_J_ArmLow02_s_L", 0.3f, 1f, new Vector3(0f, 0f, 0f)
+            "cf_J_ArmLow02_s_R", 0.3f, 1f, new Vector3(0f, 0f, 0f)
+            "cf_J_ArmUp02_s_L", 0.45f, 3f, new Vector3(0f, 0f, 0f)
+            "cf_J_ArmUp02_s_R", 0.45f, 3f, new Vector3(0f, 0f, 0f) */      
         internal static readonly List<ColliderData> ArmColliderDataList = new List<ColliderData>
         {
-            new ColliderData("cf_J_Hand_s_L", 0.20f, 0.75f, new Vector3(-0.3f, -0.05f, 0f)),
-            new ColliderData("cf_J_Hand_s_R", 0.20f, 0.75f, new Vector3(0.3f, -0.05f, 0f)),
-            new ColliderData("cf_J_ArmLow02_s_L", 0.25f, 2.5f, new Vector3(0f, 0f, 0f)),
-            new ColliderData("cf_J_ArmLow02_s_R", 0.25f, 2.5f, new Vector3(0f, 0f, 0f)),
-            new ColliderData("cf_J_ArmUp02_s_L", 0.25f, 2.5f, new Vector3(0f, 0f, 0f)),
-            new ColliderData("cf_J_ArmUp02_s_R", 0.25f, 2.5f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_Hand_s_L", 0.05f, 0.75f, new Vector3(-0.3f, -0.05f, 0f)),
+            new ColliderData("cf_J_Hand_s_R", 0.05f, 0.75f, new Vector3(0.3f, -0.05f, 0f)),
+            new ColliderData("cf_J_ArmLow02_s_L", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_ArmLow02_s_R", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_ArmUp02_s_L", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_ArmUp02_s_R", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
         };
         internal static readonly HashSet<string> BreastDBComments = new HashSet<string> { "Mune_L", "Mune_R" };
 #elif KK || KKS

--- a/src/Colliders.Core/Core.Colliders.Constants.cs
+++ b/src/Colliders.Core/Core.Colliders.Constants.cs
@@ -11,8 +11,8 @@ namespace KK_Plugins
         {
             new ColliderData("cf_J_Hand_s_L", 0.3f, 1f, new Vector3(-0.25f, 0f, 0f)),
             new ColliderData("cf_J_Hand_s_R", 0.3f, 1f, new Vector3(0.25f, 0f, 0f)),
-            new ColliderData("cf_J_ArmLow01_s_L", 0.4f, 1.5f, new Vector3(-0.35f, 0f, 0f)),
-            new ColliderData("cf_J_ArmLow01_s_R", 0.4f, 1.5f, new Vector3(0.35f, 0f, 0f)),
+//            new ColliderData("cf_J_ArmLow01_s_L", 0.4f, 1.5f, new Vector3(-0.35f, 0f, 0f)),
+//            new ColliderData("cf_J_ArmLow01_s_R", 0.4f, 1.5f, new Vector3(0.35f, 0f, 0f)),
             new ColliderData("cf_J_ArmLow02_s_L", 0.3f, 1f, new Vector3(0f, 0f, 0f)),
             new ColliderData("cf_J_ArmLow02_s_R", 0.3f, 1f, new Vector3(0f, 0f, 0f)),
             new ColliderData("cf_J_ArmUp02_s_L", 0.45f, 3f, new Vector3(0f, 0f, 0f)),

--- a/src/Colliders.Core/Core.Colliders.Constants.cs
+++ b/src/Colliders.Core/Core.Colliders.Constants.cs
@@ -7,23 +7,16 @@ namespace KK_Plugins
     {
 #if AI || HS2
         internal static ColliderData FloorColliderData = new ColliderData("cf_J_Root", 100f, 0f, new Vector3(0, -100.01f, 0f));
-/*      AIS default colliders for future reference:
-            "cf_J_Hand_s_L", 0.3f, 1f, new Vector3(-0.25f, 0f, 0f)
-            "cf_J_Hand_s_R", 0.3f, 1f, new Vector3(0.25f, 0f, 0f)
-            "cf_J_ArmLow01_s_L", 0.4f, 1.5f, new Vector3(-0.35f, 0f, 0f)
-            "cf_J_ArmLow01_s_R", 0.4f, 1.5f, new Vector3(0.35f, 0f, 0f)
-            "cf_J_ArmLow02_s_L", 0.3f, 1f, new Vector3(0f, 0f, 0f)
-            "cf_J_ArmLow02_s_R", 0.3f, 1f, new Vector3(0f, 0f, 0f)
-            "cf_J_ArmUp02_s_L", 0.45f, 3f, new Vector3(0f, 0f, 0f)
-            "cf_J_ArmUp02_s_R", 0.45f, 3f, new Vector3(0f, 0f, 0f) */      
         internal static readonly List<ColliderData> ArmColliderDataList = new List<ColliderData>
         {
-            new ColliderData("cf_J_Hand_s_L", 0.05f, 0.75f, new Vector3(-0.3f, -0.05f, 0f)),
-            new ColliderData("cf_J_Hand_s_R", 0.05f, 0.75f, new Vector3(0.3f, -0.05f, 0f)),
-            new ColliderData("cf_J_ArmLow02_s_L", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
-            new ColliderData("cf_J_ArmLow02_s_R", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
-            new ColliderData("cf_J_ArmUp02_s_L", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
-            new ColliderData("cf_J_ArmUp02_s_R", 0.05f, 2.5f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_Hand_s_L", 0.3f, 1f, new Vector3(-0.25f, 0f, 0f)),
+            new ColliderData("cf_J_Hand_s_R", 0.3f, 1f, new Vector3(0.25f, 0f, 0f)),
+            new ColliderData("cf_J_ArmLow01_s_L", 0.4f, 1.5f, new Vector3(-0.35f, 0f, 0f)),
+            new ColliderData("cf_J_ArmLow01_s_R", 0.4f, 1.5f, new Vector3(0.35f, 0f, 0f)),
+            new ColliderData("cf_J_ArmLow02_s_L", 0.3f, 1f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_ArmLow02_s_R", 0.3f, 1f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_ArmUp02_s_L", 0.45f, 3f, new Vector3(0f, 0f, 0f)),
+            new ColliderData("cf_J_ArmUp02_s_R", 0.45f, 3f, new Vector3(0f, 0f, 0f)),
         };
         internal static readonly HashSet<string> BreastDBComments = new HashSet<string> { "Mune_L", "Mune_R" };
 #elif KK || KKS

--- a/src/Colliders.Core/Core.Colliders.Controller.cs
+++ b/src/Colliders.Core/Core.Colliders.Controller.cs
@@ -284,7 +284,7 @@ namespace KK_Plugins
                     pat.Params[0].CollisionRadius = BreastCollidersEnabled ? 0.10f * BreastSize : 0;
                     pat.Params[1].CollisionRadius = BreastCollidersEnabled ? 0.08f * BreastSize : 0;
 #elif AI || HS2
-                    pat.Params[2].CollisionRadius = BreastCollidersEnabled ? 1.0f * BreastSize : 0;
+                    pat.Params[2].CollisionRadius = BreastCollidersEnabled ? 0.6f * BreastSize : 0;
                     pat.Params[3].CollisionRadius = BreastCollidersEnabled ? 0.8f * BreastSize : 0;
 #endif
                 }

--- a/src/Colliders.Core/Core.Colliders.Controller.cs
+++ b/src/Colliders.Core/Core.Colliders.Controller.cs
@@ -44,8 +44,10 @@ namespace KK_Plugins
                 FloorCollider = AddCollider(FloorColliderData);
 
                 //Add the arm and hand colliders
+#if !AI
                 for (var i = 0; i < ArmColliderDataList.Count; i++)
                     ArmColliders.Add(AddCollider(ArmColliderDataList[i]));
+#endif
 
 #if KK || KKS
                 //Add the leg colliders for skirts


### PR DESCRIPTION
Reduced the radius of all AI/HS2 colliders to 0.05. This assists with visible distortion in larger breasts in H scenes when using animations that have the arms close to the body (eg Standing, Standing Missionary/Lifting, Table/Desk Missionary, and Femdom Cowgirl, all in "low" variant) but does not correct it entirely (particularly past 90 size). Some clipping is introduced. NB This has no effect on AI as the existing colliders are active with this plugin and they have a larger radius.

The issue preventing a more complete solution appears to stem from the H scene skeleton having the arm bones in a different place to everywhere else in the game (and studio). As I lack the tools to visualise them in-scene I can only speculate, but it appears as though they are further forward and towards the centre line than they should be. As the bones rotate for some animations (particularly the forearms), offsets on the colliders cannot be used to reliably correct for the disparity.

I have included remarks containing the default AI colliders for posterity. If the skeleton issue can be identified and corrected these would be better values than the ones I have set.