### PR TITLE
[ME] Add more ShadowCasting toggle hotkeys

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -185,7 +185,7 @@ namespace KK_Plugins.MaterialEditor
                             MaterialFloatPropertyList.Add(new MaterialFloatProperty(MEStudio.GetObjectID(objectCtrlInfo), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
                 }
             }
-            
+
             if (data.data.TryGetValue(nameof(MaterialKeywordPropertyList), out var materialKeywordProperties) && materialKeywordProperties != null)
             {
                 var properties = MessagePackSerializer.Deserialize<List<MaterialKeywordProperty>>((byte[])materialKeywordProperties);
@@ -376,6 +376,24 @@ namespace KK_Plugins.MaterialEditor
                 if (count > 0)
                     MaterialEditorPlugin.Logger.LogMessage($"Enabled ShadowCasting for {count} items");
             }
+            else if (MaterialEditorPlugin.TwoSidedShadowCastingHotkey.Value.IsDown())
+            {
+                int count = 0;
+                TreeNodeObject[] selectNodes = Singleton<Studio.Studio>.Instance.treeNodeCtrl.selectNodes;
+                for (int i = 0; i < selectNodes.Length; i++)
+                    SetRendererPropertyRecursive(selectNodes[i], RendererProperties.ShadowCastingMode, "2", ref count);
+                if (count > 0)
+                    MaterialEditorPlugin.Logger.LogMessage($"Two Sided ShadowCasting for {count} items");
+            }
+            else if (MaterialEditorPlugin.ShadowsOnlyShadowCastingHotkey.Value.IsDown())
+            {
+                int count = 0;
+                TreeNodeObject[] selectNodes = Singleton<Studio.Studio>.Instance.treeNodeCtrl.selectNodes;
+                for (int i = 0; i < selectNodes.Length; i++)
+                    SetRendererPropertyRecursive(selectNodes[i], RendererProperties.ShadowCastingMode, "3", ref count);
+                if (count > 0)
+                    MaterialEditorPlugin.Logger.LogMessage($"Shadows Only ShadowCasting for {count} items");
+            }
             else if (MaterialEditorPlugin.ResetShadowCastingHotkey.Value.IsDown())
             {
                 int count = 0;
@@ -455,6 +473,12 @@ namespace KK_Plugins.MaterialEditor
                         {
                             if (value == "-1")
                                 controller.RemoveRendererProperty(0, MaterialEditorCharaController.ObjectType.Character, rend, RendererProperties.Enabled, chaControl.gameObject);
+                            //keep consistency in the casted shadow with how it would normally look
+                            else if (value == "2" | value == "3")
+                            {
+                                controller.RemoveRendererProperty(0, MaterialEditorCharaController.ObjectType.Character, rend, RendererProperties.Enabled, chaControl.gameObject);
+                                controller.SetRendererProperty(0, MaterialEditorCharaController.ObjectType.Character, rend, property, value, chaControl.gameObject);
+                            }
                             else
                                 controller.SetRendererProperty(0, MaterialEditorCharaController.ObjectType.Character, rend, RendererProperties.Enabled, value, chaControl.gameObject);
                         }

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -58,7 +58,7 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// MaterialEditor plugin version
         /// </summary>
-        public const string PluginVersion = "3.1.23";
+        public const string PluginVersion = "3.1.24";
 
         /// <summary>
         /// Material which is used in normal map conversion
@@ -73,6 +73,8 @@ namespace KK_Plugins.MaterialEditor
 #endif
         internal static ConfigEntry<KeyboardShortcut> DisableShadowCastingHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> EnableShadowCastingHotkey { get; private set; }
+        internal static ConfigEntry<KeyboardShortcut> TwoSidedShadowCastingHotkey { get; private set; }
+        internal static ConfigEntry<KeyboardShortcut> ShadowsOnlyShadowCastingHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> ResetShadowCastingHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> DisableReceiveShadows { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> EnableReceiveShadows { get; private set; }
@@ -138,6 +140,8 @@ namespace KK_Plugins.MaterialEditor
 #endif
             DisableShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Disable ShadowCasting", new KeyboardShortcut(KeyCode.M, KeyCode.LeftControl), "Disable ShadowCasting for all selected items and their child items in Studio");
             EnableShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Enable ShadowCasting", new KeyboardShortcut(KeyCode.M, KeyCode.LeftAlt), "Enable ShadowCasting for all selected items and their child items in Studio");
+            TwoSidedShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Two Sided ShadowCasting", new KeyboardShortcut(KeyCode.K, KeyCode.LeftAlt), "Set ShadowCasting to 'Two Sided' for all selected items and their child items in Studio");
+            ShadowsOnlyShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Shadows Only ShadowCasting", new KeyboardShortcut(KeyCode.L, KeyCode.LeftAlt), "Set ShadowCasting to 'Shadows Only' for all selected items and their child items in Studio");
             ResetShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Reset ShadowCasting", new KeyboardShortcut(KeyCode.M, KeyCode.LeftControl, KeyCode.LeftAlt), "Reset ShadowCasting for all selected items and their child items in Studio");
             DisableReceiveShadows = Config.Bind("Keyboard Shortcuts", "Disable ReceiveShadows", new KeyboardShortcut(KeyCode.N, KeyCode.LeftControl), "Disable ReceiveShadows for all selected items and their child items in Studio");
             EnableReceiveShadows = Config.Bind("Keyboard Shortcuts", "Enable ReceiveShadows", new KeyboardShortcut(KeyCode.N, KeyCode.LeftAlt), "Enable ReceiveShadows for all selected items and their child items in Studio");


### PR DESCRIPTION
Adds two new toggle shortcuts to set shadow casting mode to "Shadows Only" or "Two Sided". Also handles the shadowcaster renderer settings to keep consistent shadows between on and shadows only/two sided states