### PR TITLE
[ME] Do not cache renderes for partially loaded ChaControl

### DIFF
--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -82,7 +82,12 @@ namespace KK_Plugins.MaterialEditor
                     List<Renderer> rendList = new List<Renderer>();
                     GetBodyRendererList(chaControl.gameObject, rendList);
                     __result = rendList;
-                    if (rendList.Count > 0)
+#if PH
+                    var fullyLoaded = true;
+#else
+                    var fullyLoaded = chaControl.loadEnd;
+#endif
+                    if (rendList.Count > 0 && fullyLoaded)
                         _RendererLookup[gameObject] = rendList;
                     return false;
                 }


### PR DESCRIPTION
This fixes #183 by ensuring that a renderer list for a ChaControl don't get cached until it's fully loaded.