### PR TITLE
[ME] Improve search with wildcards, material property filtering and filter persistence

### DIFF
--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -363,7 +363,7 @@ namespace MaterialEditorAPI
                     string propertyName = property.Key;
                     if (Instance.CheckBlacklist(materialName, propertyName)) continue;
 
-                    bool showProperty = filterListProperties.Count == 0 ? true : false;
+                    bool showProperty = filterListProperties.Count == 0;
                     foreach (string filterWord in filterListProperties)
                         if (WildCardSearch(propertyName, filterWord))
                         {

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UILib;
 using UnityEngine;
 using UnityEngine.UI;
@@ -175,6 +176,18 @@ namespace MaterialEditorAPI
         }
 
         /// <summary>
+        /// Search text using wildcards.
+        /// </summary>
+        /// <param name="text">Text to search in</param>
+        /// <param name="filter">Filter with which to search the text</param>
+        private bool WildCardSearch(string text, string filter)
+        {
+            string regex = "^.*" + Regex.Escape(filter).Replace("\\?", ".").Replace("\\*", ".*") + ".*$";
+            Logger.LogInfo(filter);
+            return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        }
+
+        /// <summary>
         /// Populate the MaterialEditor UI
         /// </summary>
         /// <param name="go">GameObject for which to read the renderers and materials</param>
@@ -209,22 +222,14 @@ namespace MaterialEditorAPI
             else
                 foreach (var rend in rendListFull)
                 {
-                    for (var j = 0; j < filterList.Count; j++)
-                    {
-                        var filterWord = filterList[j];
-                        if (rend.NameFormatted().ToLower().Contains(filterWord.Trim().ToLower()) && !rendList.Contains(rend))
+                    foreach (string filterWord in filterList)
+                        if (WildCardSearch(rend.NameFormatted(), filterWord.Trim()) && !rendList.Contains(rend))
                             rendList.Add(rend);
-                    }
 
                     foreach (var mat in GetMaterials(go, rend))
-                    {
-                        for (var k = 0; k < filterList.Count; k++)
-                        {
-                            var filterWord = filterList[k];
-                            if (mat.NameFormatted().ToLower().Contains(filterWord.Trim().ToLower()))
+                        foreach (string filterWord in filterList)
+                            if (WildCardSearch(mat.NameFormatted(), filterWord.Trim()))
                                 matList[mat.NameFormatted()] = mat;
-                        }
-                    }
                 }
 
             for (var i = 0; i < rendList.Count; i++)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -185,7 +185,7 @@ namespace MaterialEditorAPI
         private bool WildCardSearch(string text, string filter)
         {
             string regex = "^.*" + Regex.Escape(filter).Replace("\\?", ".").Replace("\\*", ".*") + ".*$";
-            return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase);
         }
 
         /// <summary>

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -1,4 +1,5 @@
 ﻿using BepInEx;
+using KK_Plugins.MaterialEditor;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -195,7 +196,12 @@ namespace MaterialEditorAPI
         /// <param name="filter">Comma separated list of text to filter the results</param>
         protected void PopulateList(GameObject go, object data, string filter = null)
         {
-            if (filter == null) filter = CurrentFilter;
+            if (filter == null)
+            {
+                if (MaterialEditorPlugin.PersistFilter.Value) filter = CurrentFilter;
+                else filter = "";
+            }
+
             MaterialEditorWindow.gameObject.SetActive(true);
             MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);
             SetMainRectWithMemory(0.05f, 0.05f, UIWidth.Value * UIScale.Value, UIHeight.Value * UIScale.Value);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -62,7 +62,7 @@ namespace MaterialEditorAPI
 
         private GameObject CurrentGameObject;
         private object CurrentData;
-        private string CurrentFilter = "";
+        private static string CurrentFilter = "";
         private bool DoObjExport = false;
         private Renderer ObjRenderer;
 
@@ -95,6 +95,7 @@ namespace MaterialEditorAPI
             nametext.alignment = TextAnchor.MiddleCenter;
 
             FilterInputField = UIUtility.CreateInputField("Filter", DragPanel.transform, "Filter");
+            FilterInputField.text = CurrentFilter;
             FilterInputField.transform.SetRect(0f, 0f, 0f, 1f, 1f, 1f, 100f, -1f);
             FilterInputField.onValueChanged.AddListener(RefreshUI);
 
@@ -192,8 +193,9 @@ namespace MaterialEditorAPI
         /// <param name="go">GameObject for which to read the renderers and materials</param>
         /// <param name="data">Object that will be passed through to the get/set/reset events</param>
         /// <param name="filter">Comma separated list of text to filter the results</param>
-        protected void PopulateList(GameObject go, object data, string filter = "")
+        protected void PopulateList(GameObject go, object data, string filter = null)
         {
+            if (filter == null) filter = CurrentFilter;
             MaterialEditorWindow.gameObject.SetActive(true);
             MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);
             SetMainRectWithMemory(0.05f, 0.05f, UIWidth.Value * UIScale.Value, UIHeight.Value * UIScale.Value);

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -71,6 +71,7 @@ namespace KK_Plugins.MaterialEditor
 #if EC || KKS
         internal static ConfigEntry<bool> ConfigConvertNormalMaps { get; private set; }
 #endif
+        internal static ConfigEntry<bool> PersistFilter { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> DisableShadowCastingHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> EnableShadowCastingHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> ResetShadowCastingHotkey { get; private set; }
@@ -136,6 +137,7 @@ namespace KK_Plugins.MaterialEditor
 #if EC || KKS
             ConfigConvertNormalMaps = Config.Bind("Config", "Convert Normal Maps", true, new ConfigDescription("Convert grey normal maps to red normal maps for compatibility with Koikatsu mods.", null, new ConfigurationManagerAttributes { Order = 1 }));
 #endif
+            PersistFilter = Config.Bind("Config", "Persist Filter", false, "Persist search filter across editor windows");
             DisableShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Disable ShadowCasting", new KeyboardShortcut(KeyCode.M, KeyCode.LeftControl), "Disable ShadowCasting for all selected items and their child items in Studio");
             EnableShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Enable ShadowCasting", new KeyboardShortcut(KeyCode.M, KeyCode.LeftAlt), "Enable ShadowCasting for all selected items and their child items in Studio");
             ResetShadowCastingHotkey = Config.Bind("Keyboard Shortcuts", "Reset ShadowCasting", new KeyboardShortcut(KeyCode.M, KeyCode.LeftControl, KeyCode.LeftAlt), "Reset ShadowCasting for all selected items and their child items in Studio");


### PR DESCRIPTION
wildcard support: translate "*" and "?" to regex (".*" and ".") in the background for search.
property filtering: Searches prefixed with an underscore will be used to filter for properties instead, without it will behave as normal
filter persistence: Added a setting to allow the filter text to persist between windows. Allows for easier mass editing between objects

Added it all in one go since it's all search related