### PR TITLE
[ME] Don't trigger character card reload for coordinate change in Roaming

### DIFF
--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -855,7 +855,7 @@ namespace KK_Plugins.MaterialEditor
         internal void CoordinateChangedEvent()
         {
             //In H if a coordinate is loaded the data will be overwritten. When switching coordinates the ExtSave data must be reloaded to restore the original.
-            if (KoikatuAPI.GetCurrentGameMode() == GameMode.MainGame)
+            if (KKAPI.MainGame.GameAPI.InsideHScene)
                 LoadCharacterExtSaveData();
 
             ChaControl.StartCoroutine(LoadData(true, true, false));


### PR DESCRIPTION
As stated in the comment, a character card reload is only necessary in an H scene. In the Roaming scene, this causes a noticeable stutter and should be avoided.