### PR TITLE
[ME] Fix the debug build

### DIFF
--- a/src/MaterialEditor.API/API.MaterialEditor.csproj
+++ b/src/MaterialEditor.API/API.MaterialEditor.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;API</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
It looks like 8404ba5 forgot to add the `API` conditional compilation symbol for the Debug build, causing build failure:

> The name 'TimelineCompatibilityHelper' does not exist in the current context