### PR TITLE
Fix shader keywords not working with copy/paste.

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -671,8 +671,7 @@ namespace KK_Plugins.MaterialEditor
             for (var i = 0; i < CopyData.MaterialKeywordPropertyList.Count; i++)
             {
                 var materialKeywordProperty = CopyData.MaterialKeywordPropertyList[i];
-                if (material.HasProperty($"_{materialKeywordProperty.Property}"))
-                    SetMaterialKeywordProperty(id, material, materialKeywordProperty.Property, materialKeywordProperty.Value, setProperty);
+                SetMaterialKeywordProperty(id, material, materialKeywordProperty.Property, materialKeywordProperty.Value, setProperty);
             }
             for (var i = 0; i < CopyData.MaterialColorPropertyList.Count; i++)
             {

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -1245,8 +1245,7 @@ namespace KK_Plugins.MaterialEditor
             for (var i = 0; i < CopyData.MaterialKeywordPropertyList.Count; i++)
             {
                 var materialKeywordProperty = CopyData.MaterialKeywordPropertyList[i];
-                if (material.IsKeywordEnabled($"_{materialKeywordProperty.Property}"))
-                    SetMaterialKeywordProperty(slot, objectType, material, materialKeywordProperty.Property, materialKeywordProperty.Value, go, setProperty);
+                SetMaterialKeywordProperty(slot, objectType, material, materialKeywordProperty.Property, materialKeywordProperty.Value, go, setProperty);
             }
             for (var i = 0; i < CopyData.MaterialColorPropertyList.Count; i++)
             {


### PR DESCRIPTION
Looks like I forgot that there's no way to tell if a shader has a given keyword, so I've removed the non-working checks.