### PR TITLE
[ME] [KK/KKS] Fix hair edits not loading in Maker.

### DIFF
--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -313,15 +313,22 @@ namespace KK_Plugins.MaterialEditor
                 controller.ChangeAccessoryEvent(slotNo, type);
         }
 
+#if KK || EC || KKS
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairBack))]
+        private static void ChangeHairBack(ChaControl __instance, int kind) => ChangeHair(__instance, 0);
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairFront))]
+        private static void ChangeHairFront(ChaControl __instance, int kind) => ChangeHair(__instance, 1);
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairSide))]
+        private static void ChangeHairSide(ChaControl __instance, int kind) => ChangeHair(__instance, 2);
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairOption))]
+        private static void ChangeHairOption(ChaControl __instance, int kind) => ChangeHair(__instance, 3);
+#else
         [HarmonyPostfix]
         [HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairAsync), typeof(int), typeof(int), typeof(bool), typeof(bool))]
         private static void ChangeHair(ChaControl __instance, int kind, ref IEnumerator __result)
         {
             __result = __result.AppendCo(() => ChangeHair(__instance, kind));
         }
-#if KKS
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairNoAsync), typeof(int), typeof(int), typeof(bool))]
 #endif
         private static void ChangeHair(ChaControl __instance, int kind)
         {

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -315,13 +315,13 @@ namespace KK_Plugins.MaterialEditor
 
 #if KK || EC || KKS
         [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairBack))]
-        private static void ChangeHairBack(ChaControl __instance, int kind) => ChangeHair(__instance, 0);
+        private static void ChangeHairBack(ChaControl __instance) => ChangeHair(__instance, 0);
         [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairFront))]
-        private static void ChangeHairFront(ChaControl __instance, int kind) => ChangeHair(__instance, 1);
+        private static void ChangeHairFront(ChaControl __instance) => ChangeHair(__instance, 1);
         [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairSide))]
-        private static void ChangeHairSide(ChaControl __instance, int kind) => ChangeHair(__instance, 2);
+        private static void ChangeHairSide(ChaControl __instance) => ChangeHair(__instance, 2);
         [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairOption))]
-        private static void ChangeHairOption(ChaControl __instance, int kind) => ChangeHair(__instance, 3);
+        private static void ChangeHairOption(ChaControl __instance) => ChangeHair(__instance, 3);
 #else
         [HarmonyPostfix]
         [HarmonyPatch(typeof(ChaControl), nameof(ChaControl.ChangeHairAsync), typeof(int), typeof(int), typeof(bool), typeof(bool))]


### PR DESCRIPTION
For some reason, when in Maker, KKAPI will fire OnReload immediately after LoadFile, instead of ReloadAsync. So when ReloadAsync does finally run, it'll run ChangeHairAsync, which is hooked by ChangeHairEvent, clearing all hair material edits.

Instead I've decided to hook functions that only run when a hair is changed using maker UI.

Only tested in KK but I assume it works in EC and KKS. The old code works for HS2 so I didn't change it.