### PR TITLE
Fixed a bug where the man's position was not reset 

### DIFF
--- a/src/HCharaAdjustment.Core/HCharaAdjustment.Hooks.cs
+++ b/src/HCharaAdjustment.Core/HCharaAdjustment.Hooks.cs
@@ -27,9 +27,25 @@ namespace KK_Plugins
             [HarmonyPrefix, HarmonyPatch(typeof(HSceneProc), nameof(HSceneProc.GotoPointMoveScene))]
             private static void GotoPointMoveScene(HSceneProc __instance)
             {
-                var heroines = __instance.flags.lstHeroine;
-                for (var i = 0; i < heroines.Count; i++)
-                    GetController(heroines[i].chaCtrl).HideGuideObject();
+                HideGuideObjects();
+            }
+
+#if KKS
+            /// <summary>
+            /// Hide guide objects when changing H-points due to animation changes
+            /// </summary>
+            /// <param name="__instance"></param>
+            [HarmonyPostfix, HarmonyPatch(typeof(HSceneProc), nameof(HSceneProc.MovePointByChangeAnim))]
+            private static void MovePointByChangeAnim(HSceneProc __instance)
+            {
+                HideGuideObjects();
+            }
+#endif
+
+            private static void HideGuideObjects()
+            {
+                foreach (var controller in GetAllControllers())
+                    controller.HideGuideObject();
             }
 
             /// <summary>
@@ -39,9 +55,8 @@ namespace KK_Plugins
             [HarmonyPostfix, HarmonyPatch(typeof(HSceneProc), nameof(HSceneProc.ChangeCategory))]
             private static void ChangeCategory(HSceneProc __instance)
             {
-                var heroines = __instance.flags.lstHeroine;
-                for (var i = 0; i < heroines.Count; i++)
-                    GetController(heroines[i].chaCtrl).SetGuideObjectOriginalPosition();
+                foreach (var controller in GetAllControllers())
+                    controller.SetGuideObjectOriginalPosition();
             }
         }
     }

--- a/src/HCharaAdjustment.Core/HCharaAdjustment.cs
+++ b/src/HCharaAdjustment.Core/HCharaAdjustment.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 using KKAPI;
 using KKAPI.Chara;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace KK_Plugins
 {
@@ -44,5 +45,7 @@ namespace KK_Plugins
         }
 
         public static HCharaAdjustmentController GetController(ChaControl chaControl) => chaControl.GetComponent<HCharaAdjustmentController>();
+
+        public static IEnumerable<HCharaAdjustmentController> GetAllControllers() => GameObject.FindObjectsOfType<HCharaAdjustmentController>();
     }
 }


### PR DESCRIPTION
This is a bug fix for HCharaAdjustment.
Merge if you like. This is the first time I'm submitting a pull request. Please let me know if there are any flaws.

Fixed that when changing the position, the male character was not the target of the reset.

The reproduction procedure is as follows
1. start the free H mode of the game
2. start any sex
3. press O and I keys to move the character
4. move to another location
5. start any sex
6. the man appears in his previous position

A video recording of the reproduction is placed below.
https://drive.google.com/file/d/1K0erVZt-vj8Suc65WLS0u3-7Xy5qAfI5/view

The process at the beginning of Update does not reset the position of the guide object until the guide object is hidden.
When the position is changed by in-game operations, the process to hide the guide object was only running on the heroine. This fix extends that process to all controllers.
