### PR TITLE
[ME] Add texture changing to timeline support

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -589,7 +589,7 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// Finds the texture bytes in the dictionary of textures and returns its ID. If not found, adds the texture to the dictionary and returns the ID of the added texture.
         /// </summary>
-        public static int SetAndGetTextureID(byte[] textureBytes)
+        internal static int SetAndGetTextureID(byte[] textureBytes)
         {
             int highestID = 0;
             foreach (var tex in TextureDictionary)
@@ -607,7 +607,7 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// Finds the texture in the dictionary of textures by its ID. Returns null if not found.
         /// </summary>
-        public static Texture GetTextureByDictionaryID(int id)
+        internal static Texture GetTextureByDictionaryID(int id)
         {
             TextureDictionary.TryGetValue(id, out TextureContainer textureContainer);
             if (textureContainer != null) return textureContainer.Texture;
@@ -617,7 +617,7 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// Add texture ID to a list to prevent them from being purged on save. List is cleared on scene load and reset.
         /// </summary>
-        public static void AddExternallyReferencedTextureID(int id)
+        internal static void AddExternallyReferencedTextureID(int id)
         {
             ExternallyReferencedTextureIDs.Add(id);
         }

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
@@ -1,5 +1,6 @@
 ﻿using KKAPI.Utilities;
 using Studio;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
@@ -7,6 +8,7 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using static MaterialEditorAPI.MaterialAPI;
 using static MaterialEditorAPI.MaterialEditorUI;
+using static KK_Plugins.MaterialEditor.SceneController;
 
 namespace MaterialEditorAPI
 {
@@ -108,6 +110,28 @@ namespace MaterialEditorAPI
                    checkIntegrity: (oci, parameter, leftValue, rightValue) => CheckIntegrity(oci, parameter, leftValue, rightValue, ItemInfo.RowItemType.Shader),
                    getFinalName: (currentName, oci, parameter) => $"{currentName}: {parameter.materialName}",
                    isCompatibleWithTarget: (oci) => IsCompatibleWithTarget(ItemInfo.RowItemType.Shader)
+               );
+
+            //Texture value
+            TimelineCompatibility.AddInterpolableModelDynamic(
+                   owner: "MaterialEditor",
+                   id: "textureProperty",
+                   name: "Texture Property",
+                   interpolateBefore: (oci, parameter, leftValue, rightValue, factor) => SetTexture(parameter.GetGameObject(oci), parameter.materialName, parameter.propertyName, GetTextureByDictionaryID(leftValue)),
+                   interpolateAfter: null,
+                   getValue: (oci, parameter) => SetAndGetTextureID(parameter.GetMaterial(oci).GetTexture($"_{parameter.propertyName}").ToTexture2D().EncodeToPNG()),
+                   readValueFromXml: (parameter, node) => XmlConvert.ToInt32(node.Attributes["value"].Value),
+                   writeValueToXml: (parameter, writer, value) =>
+                   {
+                       AddExternallyReferencedTextureID(value);
+                       writer.WriteAttributeString("value", XmlConvert.ToString(value));
+                   },
+                   getParameter: GetMaterialInfoParameter,
+                   readParameterFromXml: ReadMaterialInfoXml,
+                   writeParameterToXml: WriteMaterialInfoXml,
+                   checkIntegrity: (oci, parameter, leftValue, rightValue) => CheckIntegrity(oci, parameter, leftValue, rightValue, ItemInfo.RowItemType.TextureProperty),
+                   getFinalName: (currentName, oci, parameter) => $"{parameter.propertyName}: {parameter.materialName}",
+                   isCompatibleWithTarget: (oci) => IsCompatibleWithTarget(ItemInfo.RowItemType.TextureProperty)
                );
 
             //Texture scale value

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
@@ -118,7 +118,14 @@ namespace MaterialEditorAPI
                    name: "Texture Property",
                    interpolateBefore: (oci, parameter, leftValue, rightValue, factor) => SetTexture(parameter.GetGameObject(oci), parameter.materialName, parameter.propertyName, GetTextureByDictionaryID(leftValue)),
                    interpolateAfter: null,
-                   getValue: (oci, parameter) => SetAndGetTextureID(parameter.GetMaterial(oci).GetTexture($"_{parameter.propertyName}").ToTexture2D().EncodeToPNG()),
+                   getValue: (oci, parameter) =>
+                   {
+                       var tex = parameter.GetMaterial(oci).GetTexture($"_{parameter.propertyName}");
+                       //When no texture is set (by default or custom) return -1 to prevent a null reference when trying to convert the texture to bytes
+                       //-1 will never exist in the texture dictionary and null will be used as a texture, which functions the same as the default empty texture
+                       if (tex == null) return -1;
+                       return SetAndGetTextureID(tex.ToTexture2D().EncodeToPNG());
+                   },
                    readValueFromXml: (parameter, node) => XmlConvert.ToInt32(node.Attributes["value"].Value),
                    writeValueToXml: (parameter, writer, value) =>
                    {

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
@@ -1,6 +1,5 @@
 ﻿using KKAPI.Utilities;
 using Studio;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Xml;


### PR DESCRIPTION
Was able to make the changing of textures in timeline work without touching timeline itself. I just had to move the getting of the actual texture to when the value is actually being set (`interpolateBefore`), instead of doing it on load (`readValueFromXml`).

Textures are saved in ME's texture dictionary and are prevented from being purged so long as keyframes exist that reference the ID.

I did have to make a private method public, and add some public methods to access a private variable. Couldn't think of a better way to handle this, since I need direct access to the texture ID's in order to save them in timeline.