### PR TITLE
[ME] Initial display of the shader currently selected in the drop-down

### DIFF
--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.AutoScrollToCenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ItemInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ItemTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ListEntry.cs" />

--- a/src/MaterialEditor.Base/UI/UI.AutoScrollToCenter.cs
+++ b/src/MaterialEditor.Base/UI/UI.AutoScrollToCenter.cs
@@ -1,0 +1,94 @@
+﻿using BepInEx;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UILib;
+using UnityEngine;
+using UnityEngine.UI;
+using static MaterialEditorAPI.MaterialAPI;
+using static MaterialEditorAPI.MaterialEditorPluginBase;
+
+namespace MaterialEditor.API.UI
+{
+    /// <summary>
+    /// Set the initial scroll position of the dropdown to the position of the selected item.
+    /// </summary>
+    class AutoScrollToSelectionWithDropdown : MonoBehaviour
+    {
+        public static void Setup( Dropdown dropdown )
+        {
+            var scrollbar = dropdown.GetComponentInChildren<Scrollbar>(true);
+
+            if (scrollbar == null)
+                return;
+
+            scrollbar.GetOrAddComponent<AutoScrollToSelectionWithDropdown>().Target = dropdown;
+        }
+
+        [SerializeField]
+        private Dropdown Target = null;
+
+        private bool AutoScrolled = false;
+
+        void OnEnable()
+        {
+            //No scrolling until LateUpdate when internal setup is complete
+            AutoScrolled = false;
+        }
+
+        void LateUpdate()
+        {
+            if( !AutoScrolled )
+            {
+                AutoScrolled = true;
+                AutoScroll();
+            }            
+        }
+
+        void AutoScroll()
+        {
+            if (Target == null)
+                return;
+
+            int items = Target.options.Count;
+
+            if (items <= 1)
+                return;
+
+            var scrollbar = GetComponent<Scrollbar>();
+
+            if (scrollbar == null)
+                return;
+
+            //x = 0, y = 1
+            int axis = (scrollbar.direction < Scrollbar.Direction.BottomToTop ? 0 : 1);
+            
+            var scrollRect = Target.template.GetComponent<ScrollRect>();
+
+            float viewSize = scrollRect.viewport.rect.size[axis];
+            float itemSize = 20f;
+
+            if ( Target.itemText != null )
+            {
+                var itemRect = (RectTransform)Target.itemText.transform.parent;
+                itemSize = itemRect.rect.size[axis];
+            }
+            else if( Target.itemImage != null )
+            {
+                var itemRect = (RectTransform)Target.itemImage.transform.parent;
+                itemSize = itemRect.rect.size[axis];
+            }
+
+            float viewAreaRatio = (viewSize / itemSize) / items;
+
+            float scroll = (float)Target.value / items - viewAreaRatio * 0.5f;
+            scroll = Mathf.Clamp(scroll, 0f, 1f - viewAreaRatio);
+            scroll = Mathf.InverseLerp(0, 1f - viewAreaRatio, scroll);
+
+            scrollbar.value = Mathf.Clamp01(1.0f - scroll);
+        }
+    }
+}

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -264,6 +264,8 @@ namespace MaterialEditorAPI
                         SelectInterpolableShaderButton.onClick.RemoveAllListeners();
                         SelectInterpolableShaderButton.onClick.AddListener(() => item.SelectInterpolableButtonShaderOnClick());
 
+                        MaterialEditor.API.UI.AutoScrollToSelectionWithDropdown.Setup(ShaderDropdown);
+
                         break;
                     case ItemInfo.RowItemType.ShaderRenderQueue:
                         ShowShaderRenderQueue();


### PR DESCRIPTION
The currently selected shader will be initially displayed in the center of the dropdown.

I implemented the following issues.
https://github.com/IllusionMods/KK_Plugins/issues/185

The following use cases have been useful to me
- When switching to a similar shader in the vicinity on the list
- When I miss-selected a shader

The operation was checked at KK, KKS, and HS2 studios.
If you can use it, please merge it.