### PR TITLE
[ME] Disable Cache and Cache-clear methods

### DIFF
--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -50,10 +50,17 @@ namespace KK_Plugins.MaterialEditor
         }
 
         private static readonly Dictionary<GameObject, List<Renderer>> _RendererLookup = new Dictionary<GameObject, List<Renderer>>();
+
+        internal static void ClearCache(GameObject gameObject = null)
+        {
+            if (gameObject == null) _RendererLookup.Clear();
+            else if (_RendererLookup.ContainsKey(gameObject)) _RendererLookup.Remove(gameObject);
+        }
+
         [HarmonyPrefix, HarmonyPatch(typeof(MaterialEditorAPI.MaterialAPI), nameof(MaterialEditorAPI.MaterialAPI.GetRendererList))]
         private static bool MaterialAPI_GetRendererList(ref IEnumerable<Renderer> __result, GameObject gameObject)
         {
-            if (gameObject == null)
+            if (!MaterialEditorPlugin.RendererCachingEnabled.Value || gameObject == null)
                 return true;
 
             if (_RendererLookup.TryGetValue(gameObject, out var cached))

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -54,7 +54,7 @@ namespace KK_Plugins.MaterialEditor
         internal static void ClearCache(GameObject gameObject = null)
         {
             if (gameObject == null) _RendererLookup.Clear();
-            else if (_RendererLookup.ContainsKey(gameObject)) _RendererLookup.Remove(gameObject);
+            else _RendererLookup.Remove(gameObject);
         }
 
         [HarmonyPrefix, HarmonyPatch(typeof(MaterialEditorAPI.MaterialAPI), nameof(MaterialEditorAPI.MaterialAPI.GetRendererList))]

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -153,7 +153,7 @@ namespace KK_Plugins.MaterialEditor
             //Disable ShaderOptimization since it doesn't work properly
             ShaderOptimization.Value = false;
 #endif
-            RendererCachingEnabled = Config.Bind("Config", "Renderer Cache Enabled", true, "Turning this off will fix cache related issues but may have a negative impact on performance.");
+            RendererCachingEnabled = Config.Bind("Config", "Renderer Cache", true, "Turning this off will fix cache related issues but may have a negative impact on performance.");
         }
 
         internal void Main()

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -58,7 +58,7 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// MaterialEditor plugin version
         /// </summary>
-        public const string PluginVersion = "3.3.0";
+        public const string PluginVersion = "3.4.0";
 
         /// <summary>
         /// Material which is used in normal map conversion
@@ -80,6 +80,8 @@ namespace KK_Plugins.MaterialEditor
         internal static ConfigEntry<KeyboardShortcut> EnableReceiveShadows { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> ResetReceiveShadows { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> PasteEditsHotkey { get; private set; }
+
+        internal static ConfigEntry<bool> RendererCachingEnabled { get; private set; }
 
         /// <summary>
         /// Parts of the body
@@ -151,6 +153,7 @@ namespace KK_Plugins.MaterialEditor
             //Disable ShaderOptimization since it doesn't work properly
             ShaderOptimization.Value = false;
 #endif
+            RendererCachingEnabled = Config.Bind("Config", "Renderer Cache Enabled", true, "Turning this off will fix cache related issues but may have a negative impact on performance.");
         }
 
         internal void Main()
@@ -998,5 +1001,22 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="chaControl"></param>
         /// <returns>KKAPI character controller</returns>
         public static MaterialEditorCharaController GetCharaController(ChaControl chaControl) => chaControl == null ? null : chaControl.gameObject.GetComponent<MaterialEditorCharaController>();
+
+        /// <summary>
+        /// Clears all GameObjects from the Renderer Cache.
+        /// </summary>
+        public static void ClearCache()
+        {
+            Hooks.ClearCache();
+        }
+
+        /// <summary>
+        /// Clears a specific GameObject from the RendererCache.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        public static void ClearCache(GameObject gameObject)
+        {
+            Hooks.ClearCache(gameObject);
+        }
     }
 }


### PR DESCRIPTION
Adds a plugin config entry for disabling the cache and public methods to clear the entire or a specific game object from the Renderer cache. 
This aims to solve issues that are related to the caching, like the multi mesh issue with ObjImport.
Users can disable the cache to see if it fixes whatever issue they are having, or call the cache clear method with RUE, modders can specifically clear the cache for their GameObjects if they change the renderers.