### PR TITLE
[ShaderSwapper] Upgrade for StudioItems

### DIFF
--- a/src/ShaderSwapper.Core/ShaderSwapper.cs
+++ b/src/ShaderSwapper.Core/ShaderSwapper.cs
@@ -225,7 +225,7 @@ namespace KK_Plugins
                     }
                 }
 
-                if (AutoEnableOutline.Value && mat.HasProperty("OutlineOn"))
+                if (AutoEnableOutline.Value && mat.HasProperty("_OutlineOn"))
                 {
                     controller.SetMaterialFloatProperty(id, mat, "OutlineOn", 1f);
                 }
@@ -281,7 +281,7 @@ namespace KK_Plugins
                     }
                 }
 
-                if (AutoEnableOutline.Value && mat.HasProperty("OutlineOn"))
+                if (AutoEnableOutline.Value && mat.HasProperty("_OutlineOn"))
                 {
                     controller.SetMaterialFloatProperty(slot, objectType, mat, "OutlineOn", 1f, go);
                 }


### PR DESCRIPTION
- added mappings for shaders commonly used by studio items
- added swapping capabilities for studio items
- added setting whether to swap the "studio shaders" on characters (some hair apparently use main_item_studio_alpha for a semi transparent look that is not possible with any other shader. People don't want that swapped. 
- added setting to toggle automatically setting the "OutlineOn" property on shaders to 1. 