### PR TITLE
[PT] Fixed UI corruption of unsupported files

### DIFF
--- a/src/PoseTools.Core/Core.PoseTools.Hooks.cs
+++ b/src/PoseTools.Core/Core.PoseTools.Hooks.cs
@@ -43,8 +43,17 @@ namespace KK_Plugins.PoseTools
                 {
                     __instance.OnClickSelect(no);
                 };
-                component.text = PauseCtrl.LoadName(__instance.listPath[j]);
                 __instance.dicNode.Add(j, component);
+                string name;
+                try
+                {
+                    name = PauseCtrl.LoadName(__instance.listPath[j]);
+                }
+                catch
+                {
+                    name = "UNSUPPORTED: " + Path.GetFileName(__instance.listPath[j]);
+                }
+                component.text = name;
             }
             return false;
         }


### PR DESCRIPTION
Fixed a bug that broke the UI when unsupported pose files were included.
Deleting the file would have done it, but it was somewhat inconvenient, so I fixed it. 
Please merge when you have time. 

Fix before:
![スクリーンショット 2023-12-21 180753](https://github.com/IllusionMods/KK_Plugins/assets/4230203/2c3ab676-445b-4886-9d93-0fac43d7a416)


Fix after:
![スクリーンショット 2023-12-21 181715](https://github.com/IllusionMods/KK_Plugins/assets/4230203/41adc7ad-0c72-47ac-b5e5-2748396d5d41)
