### PR TITLE
Fix texture leaks

### DIFF
--- a/src/PoseTools.Core/Core.PoseTools.Hooks.cs
+++ b/src/PoseTools.Core/Core.PoseTools.Hooks.cs
@@ -121,8 +121,10 @@ namespace KK_Plugins.PoseTools
 #endif
 
                     Texture2D screenshot = TextureFromBytes(buffer, mipmaps: false);
-                    screenshot = OverwriteTexture(screenshot, Watermark, 0, screenshot.height - Watermark.height);
-                    buffer = screenshot.EncodeToPNG();
+                    Texture2D overwrite = OverwriteTexture(screenshot, Watermark, 0, screenshot.height - Watermark.height);
+                    buffer = overwrite.EncodeToPNG();
+                    Texture2D.Destroy(screenshot);
+                    Texture2D.Destroy(overwrite);
 
                     binaryWriter.Write(buffer);
                     binaryWriter.Write(PauseCtrl.saveIdentifyingCode);

--- a/src/PoseTools.Core/Core.PoseTools.cs
+++ b/src/PoseTools.Core/Core.PoseTools.cs
@@ -225,16 +225,29 @@ namespace KK_Plugins.PoseTools
         {
             if (texBytes == null || texBytes.Length == 0) return null;
 
-            //LoadImage automatically resizes the texture so the texture size doesn't matter here
-            var tex = new Texture2D(2, 2, format, mipmaps);
-            tex.LoadImage(texBytes);
+            Texture2D tex = null;
+            RenderTexture rt = null;
 
-            RenderTexture rt = new RenderTexture(tex.width, tex.height, 0);
-            rt.useMipMap = mipmaps;
-            RenderTexture.active = rt;
-            Graphics.Blit(tex, rt);
+            try
+            {
+                //LoadImage automatically resizes the texture so the texture size doesn't matter here
+                tex = new Texture2D(2, 2, format, mipmaps);
+                tex.LoadImage(texBytes);
 
-            return GetT2D(rt);
+                rt = new RenderTexture(tex.width, tex.height, 0);
+                rt.useMipMap = mipmaps;
+                Graphics.Blit(tex, rt);
+
+                return GetT2D(rt);
+            }
+            finally
+            {
+                if( rt != null )
+                    UnityEngine.Object.Destroy(rt);
+
+                if (tex != null)
+                    UnityEngine.Object.Destroy(tex);
+            }
         }
 
         internal static void LoadWatermark()

--- a/src/Shared.TextureContainer/Shared.TextureContainer.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainer.cs
@@ -93,15 +93,21 @@ namespace KK_Plugins
             if (texBytes == null || texBytes.Length == 0) return null;
 
             //LoadImage automatically resizes the texture so the texture size doesn't matter here
-            var tex = new Texture2D(2, 2, format, mipmaps);
-            tex.LoadImage(texBytes);
+            Texture2D tex = new Texture2D(2, 2, format, mipmaps);
 
-            RenderTexture rt = new RenderTexture(tex.width, tex.height, 0);
-            rt.useMipMap = mipmaps;
-            RenderTexture.active = rt;
-            Graphics.Blit(tex, rt);
+            try
+            {
+                tex.LoadImage(texBytes);
 
-            return rt;
+                RenderTexture rt = new RenderTexture(tex.width, tex.height, 0);
+                rt.useMipMap = mipmaps;
+                Graphics.Blit(tex, rt);
+                return rt;
+            }
+            finally
+            {
+                UnityEngine.Object.Destroy(tex);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed code that was not releasing generated temporary textures. Please merge.
PoseTool seems to be calling UnloadUnused at the caller. So it is not affected. However, I fixed it because of bad manners.

Since this is a resource that will be recovered by UnloadUnusedAssets, there will be no long-term impact from the modification. In the short term, memory usage peaks should be somewhat reduced when textures are changed at high frequency.