### PR TITLE
Added texture manager - Share identical textures across characters

### DIFF
--- a/src/Shared.TextureContainer/Shared.TextureContainer.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainer.cs
@@ -9,7 +9,7 @@ namespace KK_Plugins
     /// </summary>
     public sealed class TextureContainer : IDisposable
     {
-        private TextureContainerManager.TextureHolder _holder;
+        private TextureContainerManager.Token _token;
 
         /// <summary>
         /// Load a byte array containing texture data.
@@ -17,7 +17,7 @@ namespace KK_Plugins
         /// <param name="data"></param>
         public TextureContainer(byte[] data)
         {
-            _holder = TextureContainerManager.Acquire(data);
+            _token = TextureContainerManager.Acquire(data);
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace KK_Plugins
         /// <param name="filePath">Path of the file to load</param>
         public TextureContainer(string filePath)
         {
-            _holder = TextureContainerManager.Acquire(filePath);
+            _token = TextureContainerManager.Acquire(filePath);
         }
 
         /// <summary>
@@ -34,13 +34,13 @@ namespace KK_Plugins
         /// </summary>
         public byte[] Data
         {
-            get => _holder.key.data;
+            get => _token.Data;
 
             set
             {
-                var newHolder = TextureContainerManager.Acquire(value);
-                TextureContainerManager.Release(_holder);
-                _holder = newHolder;
+                var newToken = TextureContainerManager.Acquire(value);
+                TextureContainerManager.Release(_token);
+                _token = newToken;
             }
         }
 
@@ -51,16 +51,16 @@ namespace KK_Plugins
         {
             get
             {
-                return _holder.Texture;
+                return _token.Texture;
             }
         }
 
         /// <summary>
-        /// Dispose of the texture data. Does not dispose of the byte array. Texture data will be recreated when accessing the Texture property, if needed.
+        /// Dispose of the texture data.
         /// </summary>
         public void Dispose()
         {
-            TextureContainerManager.Release(_holder);
+            TextureContainerManager.Release(_token);
         }
     }
 }

--- a/src/Shared.TextureContainer/Shared.TextureContainer.projitems
+++ b/src/Shared.TextureContainer/Shared.TextureContainer.projitems
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Shared.TextureContainer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Shared.TextureContainerManager.cs" />
   </ItemGroup>
 </Project>

--- a/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using UnityEngine;
+
+namespace KK_Plugins
+{
+    public sealed class TextureContainerManager
+    {
+        static Dictionary<TextureHolderKey, TextureHolder> _textureHolder = new Dictionary<TextureHolderKey, TextureHolder>();
+
+        public class TextureHolderKey
+        {
+            public readonly byte[] data;
+            public readonly uint dataHash;
+            public readonly TextureFormat format;
+            public readonly bool mipmaps;
+
+            public TextureHolderKey(byte[] data, TextureFormat format = TextureFormat.ARGB32, bool mipmaps = true)
+            {
+                this.data = data;
+                //First part of the data is sufficient to calculate the hash.
+                dataHash = CRC32Calculator.CalculateCRC32(data, 1 << 10);
+                this.format = format;
+                this.mipmaps = mipmaps;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is TextureHolderKey)
+                {
+                    var other = (TextureHolderKey)obj;
+
+                    return
+                        other.dataHash == dataHash &&
+                        other.format == format &&
+                        other.mipmaps == mipmaps &&
+                        other.data.SequenceEqual(data);
+                }
+
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return (int)dataHash ^ format.GetHashCode() ^ mipmaps.GetHashCode();
+            }
+        }
+
+        public class TextureHolder
+        {
+            internal int refCount;
+            internal TextureHolderKey key;
+            private Texture _texture;
+
+            public TextureHolder(TextureHolderKey key)
+            {
+                this.key = key;
+            }
+
+            public Texture Texture
+            {
+                get
+                {
+                    if (_texture == null && key.data != null)
+                        _texture = TextureFromBytes(key.data, key.format, key.mipmaps);
+                    return _texture;
+                }
+            }
+            
+            public void Destroy()
+            {
+                if (_texture != null)
+                {
+                    UnityEngine.Object.Destroy(_texture);
+                    _texture = null;
+                }   
+            }
+        }
+
+        public static TextureHolder Acquire( string filePath )
+        {
+            return Acquire(LoadTextureBytes(filePath));
+        }
+
+        public static TextureHolder Acquire( byte[] texBytes )
+        {
+            if (texBytes == null)
+                throw new ArgumentNullException(nameof(texBytes));
+
+            TextureHolderKey key = new TextureHolderKey(texBytes);
+            if (!_textureHolder.TryGetValue(key, out var holder))
+                holder = _textureHolder[key] = new TextureHolder(key);
+
+            ++holder.refCount;
+            return holder;
+        }
+
+        public static void Release( TextureHolder holder )
+        {
+            if (--holder.refCount > 0)
+                return;
+
+            holder.Destroy();
+            _textureHolder.Remove(holder.key);
+        }
+
+        /// <summary>
+        /// Convert a byte array to Texture2D.
+        /// </summary>
+        /// <param name="texBytes">Byte array containing the image</param>
+        /// <param name="format">TextureFormat</param>
+        /// <param name="mipmaps">Whether to generate mipmaps</param>
+        /// <returns></returns>
+        private static Texture TextureFromBytes(byte[] texBytes, TextureFormat format, bool mipmaps)
+        {
+            if (texBytes == null || texBytes.Length == 0) return null;
+
+            //LoadImage automatically resizes the texture so the texture size doesn't matter here
+            Texture2D tex = new Texture2D(2, 2, format, mipmaps);
+
+            try
+            {
+                tex.LoadImage(texBytes);
+
+                RenderTexture rt = new RenderTexture(tex.width, tex.height, 0);
+                rt.useMipMap = mipmaps;
+                Graphics.Blit(tex, rt);
+                return rt;
+            }
+            finally
+            {
+                UnityEngine.Object.Destroy(tex);
+            }
+        }
+
+        /// <summary>
+        /// Read the specified file and return a byte array.
+        /// </summary>
+        /// <param name="filePath">Path of the file to load</param>
+        /// <returns>Byte array with texture data</returns>
+        private static byte[] LoadTextureBytes(string filePath)
+        {
+            return File.ReadAllBytes(filePath);
+        }
+    }
+
+    public class CRC32Calculator
+    {
+        private static readonly uint[] Crc32Table;
+
+        static CRC32Calculator()
+        {
+            // Initialize CRC32 table
+            Crc32Table = GenerateCrc32Table();
+        }
+
+        public static uint CalculateCRC32(byte[] data, int size)
+        {
+            uint crc32 = 0xFFFFFFFF; // Set initial value
+            size = Mathf.Min(data.Length, size);
+
+            for( int i = 0; i < size; ++i )
+            {
+                crc32 = (crc32 >> 8) ^ Crc32Table[(crc32 ^ data[i]) & 0xFF];
+            }
+
+            return crc32 ^ 0xFFFFFFFF; // Invert the final result
+        }
+
+        private static uint[] GenerateCrc32Table()
+        {
+            uint[] table = new uint[256];
+
+            for (uint i = 0; i < 256; i++)
+            {
+                uint crc = i;
+                for (int j = 0; j < 8; j++)
+                {
+                    crc = (crc & 1) == 1 ? (crc >> 1) ^ 0xEDB88320 : crc >> 1;
+                }
+                table[i] = crc;
+            }
+
+            return table;
+        }
+    }
+}

--- a/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
@@ -142,7 +142,7 @@ namespace KK_Plugins
         }
 
         /// <summary>
-        /// Convert a byte array to Texture2D.
+        /// Convert a byte array to Texture.
         /// </summary>
         /// <param name="texBytes">Byte array containing the image</param>
         /// <param name="format">TextureFormat</param>

--- a/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
@@ -159,6 +159,7 @@ namespace KK_Plugins
             {
                 tex.LoadImage(texBytes);
 
+                //Transfer to GPU memory and delete data in normal memory
                 RenderTexture rt = new RenderTexture(tex.width, tex.height, 0);
                 rt.useMipMap = mipmaps;
                 Graphics.Blit(tex, rt);
@@ -166,6 +167,7 @@ namespace KK_Plugins
             }
             finally
             {
+                // delete data in normal memory
                 UnityEngine.Object.Destroy(tex);
             }
         }


### PR DESCRIPTION
There is still room to organize the code. Like adding comments.
But before I do, I wanted to get your opinion on whether these changes are safe or not, so I made this PR.

@ManlyMarco 
I created a class to manage the textures that TextureContainer had. Is this safe?

If it matches the byte[] of the already loaded texture, it does not create a Texture, but returns the already created Texture.
This is similar to MaterialEdtor's texture management, but MaterialEditor's is treated as individual textures when the same texture is loaded for multiple characters. This change uses the same texture for all of them.

The advantages and disadvantages are as follows.

Advantages:
Load times are reduced by several tens of percent in the case of scenes with many identical characters. Memory usage is also reduced by several hundred MB.
In the scene I tested, the load time was reduced from 75 seconds to 50 seconds.

Disadvantages:
If there are plug-ins that change textures individually, it will not work correctly.
If there are no identical textures, there is no change. In fact, it slows things down slightly.
When there is a code that forgets to Dispose the TextureContainer, the texture will not disappear with UnloadUnusedAssets.

Do you think it's a good idea to include this change?
If it looks OK, I'll clean up the source. If it's a problem, close PR and be done with it.