### PR TITLE
[C2A] Fixed linear search of dictionaries

### DIFF
--- a/src/ClothesToAccessories.Common/ClothesToAccessoriesPlugin.cs
+++ b/src/ClothesToAccessories.Common/ClothesToAccessoriesPlugin.cs
@@ -616,14 +616,8 @@ namespace KK_Plugins
                         {
                             if (dynamicBone.m_Root)
                             {
-                                foreach (var keyValuePair in dictBone)
-                                {
-                                    if (keyValuePair.Key == dynamicBone.m_Root.name)
-                                    {
-                                        dynamicBone.m_Root = keyValuePair.Value.transform;
-                                        break;
-                                    }
-                                }
+                                if( dictBone.TryGetValue(dynamicBone.m_Root.name, out var gobj) )
+                                    dynamicBone.m_Root = gobj.transform;
                             }
 
                             if (dynamicBone.m_Exclusions != null && dynamicBone.m_Exclusions.Count != 0)
@@ -632,14 +626,8 @@ namespace KK_Plugins
                                 {
                                     if (null != dynamicBone.m_Exclusions[j])
                                     {
-                                        foreach (var keyValuePair2 in dictBone)
-                                        {
-                                            if (keyValuePair2.Key == dynamicBone.m_Exclusions[j].name)
-                                            {
-                                                dynamicBone.m_Exclusions[j] = keyValuePair2.Value.transform;
-                                                break;
-                                            }
-                                        }
+                                        if( dictBone.TryGetValue(dynamicBone.m_Exclusions[j].name, out var gobj) )
+                                            dynamicBone.m_Exclusions[j] = gobj.transform;
                                     }
                                 }
                             }
@@ -650,14 +638,8 @@ namespace KK_Plugins
                                 {
                                     if (null != dynamicBone.m_notRolls[k])
                                     {
-                                        foreach (var keyValuePair3 in dictBone)
-                                        {
-                                            if (keyValuePair3.Key == dynamicBone.m_notRolls[k].name)
-                                            {
-                                                dynamicBone.m_notRolls[k] = keyValuePair3.Value.transform;
-                                                break;
-                                            }
-                                        }
+                                        if( dictBone.TryGetValue(dynamicBone.m_notRolls[k].name, out var gobj) )
+                                            dynamicBone.m_notRolls[k] = gobj.transform;
                                     }
                                 }
                             }
@@ -665,10 +647,7 @@ namespace KK_Plugins
                             if (dynamicBone.m_Colliders != null)
                             {
                                 dynamicBone.m_Colliders.Clear();
-                                for (var l = 0; l < componentsInChildren2.Length; l++)
-                                {
-                                    dynamicBone.m_Colliders.Add(componentsInChildren2[l]);
-                                }
+                                dynamicBone.m_Colliders.AddRange(componentsInChildren2);
                             }
                         }
                     }


### PR DESCRIPTION
Fixed a linear search of the dictionary.
Please merge if you like.

I don't normally fix these details, but this time I fixed it based on the following conditions.
- Shorten several hundred ms when the number of bones is large.
- The code is simply cleaner.

For one object, this modification reduced the processing time of UpdateAcesoryMoveFromInfoAndReassignBones from 400 ms to 200 ms.
It was probably due to the fact that it was fitted with something with a specially high number of bones.
For other calls, there were three cases of tens of milliseconds and hundreds of cases of less than 1 ms.


The contribution to loading time is approximately 1% for the scenes tested.

before ave: 38.04

```
Scene loading completed: 38.7[s]
Scene loading completed: 37.5[s]
Scene loading completed: 37.9[s]
Scene loading completed: 38.0[s]
Scene loading completed: 38.1[s]
```

after ave: 37.62 (-0.42)

```
Scene loading completed: 37.8[s]
Scene loading completed: 37.6[s]
Scene loading completed: 37.1[s]
Scene loading completed: 38.0[s]
Scene loading completed: 37.6[s]
```

This should be beneficial as a correction to reduce processing time in worst case situations with many bones.