### PR TITLE
[ME] Add toggle for UpdateWhenOffscreen MeshRenderer property

### DIFF
--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -282,6 +282,8 @@ namespace MaterialEditorAPI
                 return SetRendererShadowCastingMode(gameObject, rendererName, (UnityEngine.Rendering.ShadowCastingMode)value);
             if (propertyName == RendererProperties.ReceiveShadows)
                 return SetRendererReceiveShadows(gameObject, rendererName, value == 1);
+            if (propertyName == RendererProperties.UpdateWhenOffscreen)
+                return SetRendererUpdateWhenOffscreen(gameObject, rendererName, value == 1);
             if (propertyName == RendererProperties.RecalculateNormals)
                 return SetRendererRecalculateNormals(gameObject, rendererName, value == 1);
             return false;
@@ -344,6 +346,27 @@ namespace MaterialEditorAPI
                 if (renderer.NameFormatted() == rendererName)
                 {
                     renderer.receiveShadows = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        /// <summary>
+        /// Set the ReceiveShadows property of a renderer
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="rendererName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
+        public static bool SetRendererUpdateWhenOffscreen(GameObject gameObject, string rendererName, bool value)
+        {
+            bool didSet = false;
+            foreach (var renderer in GetRendererList(gameObject))
+            {
+                if (renderer is SkinnedMeshRenderer meshRenderer && renderer.NameFormatted() == rendererName)
+                {
+                    meshRenderer.updateWhenOffscreen = value;
                     didSet = true;
                 }
             }
@@ -596,7 +619,11 @@ namespace MaterialEditorAPI
             /// <summary>
             /// Whether the renderer should recalculate the normals on itself
             /// </summary>
-            RecalculateNormals
+            RecalculateNormals,
+            /// <summary>
+            /// Whether the renderer updates while off-screen
+            /// </summary>
+            UpdateWhenOffscreen
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.ItemInfo.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemInfo.cs
@@ -28,6 +28,11 @@ namespace MaterialEditorAPI
         public Action<bool> RendererReceiveShadowsOnChange { get; set; }
         public Action RendererReceiveShadowsOnReset { get; set; }
 
+        public bool RendererUpdateWhenOffscreen { get; set; }
+        public bool RendererUpdateWhenOffscreenOriginal { get; set; }
+        public Action<bool> RendererUpdateWhenOffscreenOnChange { get; set; }
+        public Action RendererUpdateWhenOffscreenOnReset { get; set; }
+
         public bool RendererRecalculateNormals { get; set; }
         public bool RendererRecalculateNormalsOriginal { get; set; }
         public Action<bool> RendererRecalculateNormalsOnChange { get; set; }
@@ -93,6 +98,6 @@ namespace MaterialEditorAPI
             LabelText = labelText;
         }
 
-        public enum RowItemType { Renderer, RendererEnabled, RendererShadowCastingMode, RendererReceiveShadows, RendererRecalculateNormals, Material, Shader, ShaderRenderQueue, TextureProperty, TextureOffsetScale, ColorProperty, FloatProperty, KeywordProperty }
+        public enum RowItemType { Renderer, RendererEnabled, RendererShadowCastingMode, RendererReceiveShadows, RendererUpdateWhenOffscreen, RendererRecalculateNormals, Material, Shader, ShaderRenderQueue, TextureProperty, TextureOffsetScale, ColorProperty, FloatProperty, KeywordProperty }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -135,6 +135,32 @@ namespace MaterialEditorAPI
                 resetLE.flexibleWidth = 0;
             }
 
+            //Renderer RendererUpdateWhenOffscreen
+            {
+                var itemPanel = UIUtility.CreatePanel("RendererUpdateWhenOffscreenPanel", contentList.transform);
+                itemPanel.gameObject.AddComponent<CanvasGroup>();
+                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
+                itemPanel.color = ItemColor;
+
+                var label = UIUtility.CreateText("RendererUpdateWhenOffscreenLabel", itemPanel.transform, "");
+                label.alignment = TextAnchor.MiddleLeft;
+                label.color = Color.black;
+                var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.preferredWidth = LabelWidth;
+                labelLE.flexibleWidth = LabelWidth;
+
+                Toggle toggleRendererUpdateWhenOffscreen = UIUtility.CreateToggle("RendererUpdateWhenOffscreenToggle", itemPanel.transform, "");
+                var toggleRendererUpdateWhenOffscreenLE = toggleRendererUpdateWhenOffscreen.gameObject.AddComponent<LayoutElement>();
+                toggleRendererUpdateWhenOffscreenLE.preferredWidth = 12;
+                toggleRendererUpdateWhenOffscreenLE.flexibleWidth = 0;
+                toggleRendererUpdateWhenOffscreen.isOn = false;
+
+                var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "Reset");
+                var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.preferredWidth = ResetButtonWidth;
+                resetLE.flexibleWidth = 0;
+            }
+
             //Renderer RecalulateNormals
             {
                 var itemPanel = UIUtility.CreatePanel("RendererRecalculateNormalsPanel", contentList.transform);

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -29,6 +29,11 @@ namespace MaterialEditorAPI
         public Toggle RendererReceiveShadowsToggle;
         public Button RendererReceiveShadowsResetButton;
 
+        public CanvasGroup RendererUpdateWhenOffscreenPanel;
+        public Text RendererUpdateWhenOffscreenLabel;
+        public Toggle RendererUpdateWhenOffscreenToggle;
+        public Button RendererUpdateWhenOffscreenResetButton;
+
         public CanvasGroup RendererRecalculateNormalsPanel;
         public Text RendererRecalculateNormalsLabel;
         public Toggle RendererRecalculateNormalsToggle;
@@ -183,6 +188,25 @@ namespace MaterialEditorAPI
 
                         RendererReceiveShadowsResetButton.onClick.RemoveAllListeners();
                         RendererReceiveShadowsResetButton.onClick.AddListener(() => RendererReceiveShadowsToggle.isOn = item.RendererReceiveShadowsOriginal);
+
+                        break;
+                    case ItemInfo.RowItemType.RendererUpdateWhenOffscreen:
+                        ShowRendererUpdateWhenOffscreen();
+                        SetLabelText(RendererUpdateWhenOffscreenLabel, item.LabelText, item.RendererUpdateWhenOffscreen != item.RendererUpdateWhenOffscreenOriginal);
+                        RendererUpdateWhenOffscreenToggle.onValueChanged.RemoveAllListeners();
+                        RendererUpdateWhenOffscreenToggle.isOn = item.RendererUpdateWhenOffscreen;
+                        RendererUpdateWhenOffscreenToggle.onValueChanged.AddListener(value =>
+                        {
+                            item.RendererUpdateWhenOffscreen = value;
+                            if (item.RendererUpdateWhenOffscreen != item.RendererUpdateWhenOffscreenOriginal)
+                                item.RendererUpdateWhenOffscreenOnChange(value);
+                            else
+                                item.RendererUpdateWhenOffscreenOnReset();
+                            SetLabelText(RendererUpdateWhenOffscreenLabel, item.LabelText, item.RendererUpdateWhenOffscreen != item.RendererUpdateWhenOffscreenOriginal);
+                        });
+
+                        RendererUpdateWhenOffscreenResetButton.onClick.RemoveAllListeners();
+                        RendererUpdateWhenOffscreenResetButton.onClick.AddListener(() => RendererUpdateWhenOffscreenToggle.isOn = item.RendererUpdateWhenOffscreenOriginal);
 
                         break;
                     case ItemInfo.RowItemType.RendererRecalculateNormals:
@@ -713,6 +737,7 @@ namespace MaterialEditorAPI
             ShowRendererEnabled(false);
             ShowRendererShadowCastingMode(false);
             ShowRendererReceiveShadows(false);
+            ShowRendererUpdateWhenOffscreen(false);
             ShowRendererRecalculateNormals(false);
             ShowMaterial(false);
             ShowShader(false);
@@ -744,6 +769,11 @@ namespace MaterialEditorAPI
         {
             RendererReceiveShadowsPanel.alpha = visible ? 1 : 0;
             RendererReceiveShadowsPanel.blocksRaycasts = visible;
+        }
+        private void ShowRendererUpdateWhenOffscreen(bool visible = true)
+        {
+            RendererUpdateWhenOffscreenPanel.alpha = visible ? 1 : 0;
+            RendererUpdateWhenOffscreenPanel.blocksRaycasts = visible;
         }
         private void ShowRendererRecalculateNormals(bool visible = true)
         {

--- a/src/MaterialEditor.Base/UI/UI.VirtualList.cs
+++ b/src/MaterialEditor.Base/UI/UI.VirtualList.cs
@@ -75,6 +75,11 @@ namespace MaterialEditorAPI
             listEntry.RendererReceiveShadowsToggle = listEntry.GetUIComponent<Toggle>("RendererReceiveShadowsToggle");
             listEntry.RendererReceiveShadowsResetButton = listEntry.GetUIComponent<Button>("RendererReceiveShadowsResetButton");
 
+            listEntry.RendererUpdateWhenOffscreenPanel = listEntry.GetUIComponent<CanvasGroup>("RendererUpdateWhenOffscreenPanel");
+            listEntry.RendererUpdateWhenOffscreenLabel = listEntry.GetUIComponent<Text>("RendererUpdateWhenOffscreenLabel");
+            listEntry.RendererUpdateWhenOffscreenToggle = listEntry.GetUIComponent<Toggle>("RendererUpdateWhenOffscreenToggle");
+            listEntry.RendererUpdateWhenOffscreenResetButton = listEntry.GetUIComponent<Button>("RendererUpdateWhenOffscreenResetButton");
+
             listEntry.RendererRecalculateNormalsPanel = listEntry.GetUIComponent<CanvasGroup>("RendererRecalculateNormalsPanel");
             listEntry.RendererRecalculateNormalsLabel = listEntry.GetUIComponent<Text>("RendererRecalculateNormalsLabel");
             listEntry.RendererRecalculateNormalsToggle = listEntry.GetUIComponent<Toggle>("RendererRecalculateNormalsToggle");

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -320,9 +320,23 @@ namespace MaterialEditorAPI
                 };
                 items.Add(rendererReceiveShadowsItem);
 
-                //Renderer RecalculateNormals
-                if (rend is SkinnedMeshRenderer) // recalculate normals should only exist on skinned renderers
+                if (rend is SkinnedMeshRenderer meshRenderer) // recalculate normals should only exist on skinned renderers
                 {
+                    //Renderer UpdateWhenOffscreen
+                    bool valueUpdateWhenOffscreenOriginal = meshRenderer.updateWhenOffscreen;
+                    temp = GetRendererPropertyValueOriginal(data, rend, RendererProperties.UpdateWhenOffscreen, go);
+                    if (!temp.IsNullOrEmpty())
+                        valueUpdateWhenOffscreenOriginal = temp == "1";
+                    var rendererUpdateWhenOffscreenItem = new ItemInfo(ItemInfo.RowItemType.RendererUpdateWhenOffscreen, "Update When Off-Screen")
+                    {
+                        RendererUpdateWhenOffscreen = meshRenderer.updateWhenOffscreen,
+                        RendererUpdateWhenOffscreenOriginal = valueUpdateWhenOffscreenOriginal,
+                        RendererUpdateWhenOffscreenOnChange = value => SetRendererProperty(data, rend, RendererProperties.UpdateWhenOffscreen, (value ? 1 : 0).ToString(), go),
+                        RendererUpdateWhenOffscreenOnReset = () => RemoveRendererProperty(data, rend, RendererProperties.UpdateWhenOffscreen, go)
+                    };
+                    items.Add(rendererUpdateWhenOffscreenItem);
+
+                    //Renderer RecalculateNormals
                     bool valueRecalculateNormalsOriginal = false; // this is not a real renderproperty so I cannot be true by default
                     temp = GetRendererPropertyValueOriginal(data, rend, RendererProperties.RecalculateNormals, go);
                     if (!temp.IsNullOrEmpty())

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -798,6 +798,10 @@ namespace KK_Plugins.MaterialEditor
                     valueOriginal = renderer.receiveShadows ? "1" : "0";
                 else if (property == RendererProperties.ShadowCastingMode)
                     valueOriginal = ((int)renderer.shadowCastingMode).ToString();
+                else if (property == RendererProperties.UpdateWhenOffscreen)
+                    if (renderer is SkinnedMeshRenderer meshRenderer)
+                        valueOriginal = meshRenderer.updateWhenOffscreen ? "1" : "0";
+                    else valueOriginal = "0";
                 else if (property == RendererProperties.RecalculateNormals)
                     valueOriginal = "0"; // this property cannot be set by default
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -1304,6 +1304,10 @@ namespace KK_Plugins.MaterialEditor
                     valueOriginal = renderer.receiveShadows ? "1" : "0";
                 else if (property == RendererProperties.ShadowCastingMode)
                     valueOriginal = ((int)renderer.shadowCastingMode).ToString();
+                else if (property == RendererProperties.UpdateWhenOffscreen)
+                    if (renderer is SkinnedMeshRenderer meshRenderer)
+                        valueOriginal = meshRenderer.updateWhenOffscreen ? "1" : "0";
+                    else valueOriginal = "0";
                 else if (property == RendererProperties.RecalculateNormals)
                     valueOriginal = "0"; // this property cannot be set by default
 


### PR DESCRIPTION
Some MeshRenderers like to suddenly dissapear when partly off-screen. This property _can_ be set in the mod itself, but some mods don't test if it's needed or not I guess. So useful to have when you do encounter such an item/accessory/clothing/etc.

Only shows on renderers that are MeshRenderers 