### PR TITLE
[ME][KKS] Fixed a crash bug when loading broken zipmods

### DIFF
--- a/src/MaterialEditor.Base/NormalMapManager.cs
+++ b/src/MaterialEditor.Base/NormalMapManager.cs
@@ -41,8 +41,8 @@ namespace MaterialEditorAPI
             if (!NormalMapProperties.Contains(propertyName))
                 return false;
 
-            if (tex == null || !tex.GetType().IsSubclassOf(typeof(Texture)))
-                return false;   // zipmod is broken ???   I used IsSubclassOf() because [tex is Texture] couldn't determine it.
+            if (tex == null || IsBrokenTexture(tex))
+                return false;
 
             Texture normalTex;
 
@@ -83,6 +83,21 @@ namespace MaterialEditorAPI
 
             tex = normalTex;
             return true;
+        }
+
+        /// <summary>
+        /// Determine if the texture has been broken.
+        /// 
+        /// An object that is not a texture is set as a texture property.
+        /// zipmod is broken.
+        /// </summary>
+        static bool IsBrokenTexture( Texture tex )
+        {
+            //This code does not check.
+            //return !(tex is Texture);
+
+            //If it is not a texture, return true.
+            return !tex.GetType().IsSubclassOf(typeof(Texture));
         }
 
         /// <summary>

--- a/src/MaterialEditor.Base/NormalMapManager.cs
+++ b/src/MaterialEditor.Base/NormalMapManager.cs
@@ -93,7 +93,7 @@ namespace MaterialEditorAPI
         /// </summary>
         static bool IsBrokenTexture( Texture tex )
         {
-            //This code does not check.
+            //This check does not work when dealing with corrupted Objects (a different object type is stored as Texture, which causes a crash on native side)
             //return !(tex is Texture);
 
             //If it is not a texture, return true.

--- a/src/MaterialEditor.Base/NormalMapManager.cs
+++ b/src/MaterialEditor.Base/NormalMapManager.cs
@@ -41,6 +41,9 @@ namespace MaterialEditorAPI
             if (!NormalMapProperties.Contains(propertyName))
                 return false;
 
+            if (tex == null || !tex.GetType().IsSubclassOf(typeof(Texture)))
+                return false;   // zipmod is broken ???   I used IsSubclassOf() because [tex is Texture] couldn't determine it.
+
             Texture normalTex;
 
             if ( _convertedNormalMap.TryGetValue(tex, out var normalMapRef) )


### PR DESCRIPTION
Fixed a crash bug when loading certain coordinates.
Please merge.

UnityEngine.Transform was stored in Texture.

Coordination of Issues:
https://www.pixiv.net/artworks/112877241
https://www.pixiv.net/artworks/112859050
from https://discord.com/channels/447114928785063977/1217559284598964254