### PR TITLE
[ME] Add renderer and material filter lists

### DIFF
--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -24,7 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ItemInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ItemTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ListEntry.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.SelectListEntryTemplate.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.SelectListPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.VirtualList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities.cs" />
   </ItemGroup>

--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ItemInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ItemTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ListEntry.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.SelectListEntryTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.VirtualList.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities.cs" />
   </ItemGroup>

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -42,6 +42,7 @@ namespace MaterialEditorAPI
         public static ConfigEntry<float> UIScale { get; set; }
         public static ConfigEntry<float> UIWidth { get; set; }
         public static ConfigEntry<float> UIHeight { get; set; }
+        public static ConfigEntry<float> UIListWidth { get; set; }
         public static ConfigEntry<bool> WatchTexChanges { get; set; }
         public static ConfigEntry<bool> ShaderOptimization { get; set; }
         public static ConfigEntry<bool> ExportBakedMesh { get; set; }
@@ -59,6 +60,7 @@ namespace MaterialEditorAPI
             UIScale = Config.Bind("Config", "UI Scale", 1.75f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(1f, 3f), new ConfigurationManagerAttributes { Order = 5 }));
             UIWidth = Config.Bind("Config", "UI Width", 0.3f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { Order = 4, ShowRangeAsPercent = false }));
             UIHeight = Config.Bind("Config", "UI Height", 0.3f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { Order = 3, ShowRangeAsPercent = false }));
+            UIListWidth = Config.Bind("Config", "UI List Width", 180f, new ConfigDescription("Controls width of the renderer/materials lists to the side of the window", new AcceptableValueRange<float>(100f, 500f), new ConfigurationManagerAttributes { Order = 2, ShowRangeAsPercent = false }));
             WatchTexChanges = Config.Bind("Config", "Watch File Changes", true, new ConfigDescription("Watch for file changes and reload textures on change. Can be toggled in the UI.", null, new ConfigurationManagerAttributes { Order = 2 }));
             ShaderOptimization = Config.Bind("Config", "Shader Optimization", true, new ConfigDescription("Replaces every loaded shader with the MaterialEditor copy of the shader. Reduces the number of copies of shaders loaded which reduces RAM usage and improves performance.", null, new ConfigurationManagerAttributes { Order = 1 }));
             ExportBakedMesh = Config.Bind("Config", "Export Baked Mesh", false, new ConfigDescription("When enabled, skinned meshes will be exported in their current state with all customization applied as well as in the current pose.", null, new ConfigurationManagerAttributes { Order = 1 }));
@@ -70,6 +72,7 @@ namespace MaterialEditorAPI
             UIScale.SettingChanged += MaterialEditorUI.UISettingChanged;
             UIWidth.SettingChanged += MaterialEditorUI.UISettingChanged;
             UIHeight.SettingChanged += MaterialEditorUI.UISettingChanged;
+            UIListWidth.SettingChanged += MaterialEditorUI.UISettingChanged;
             WatchTexChanges.SettingChanged += WatchTexChanges_SettingChanged;
             ShaderOptimization.SettingChanged += ShaderOptimization_SettingChanged;
             ConfigExportPath.SettingChanged += ConfigExportPath_SettingChanged;

--- a/src/MaterialEditor.Base/UI/UI.SelectListEntryTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.SelectListEntryTemplate.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UILib;
+using UniRx.Triggers;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -36,7 +37,7 @@ namespace MaterialEditorAPI
             filterInputField.onValueChanged.AddListener(FilterList);
 
             ScrollRect = UIUtility.CreateScrollView(name, Panel.transform);
-            ScrollRect.transform.SetRect(0f, 0f, 1f, 1f, 2f, 2f, -2f, -MaterialEditorUI.HeaderSize - 2f);
+            ScrollRect.transform.SetRect(0f, 0f, 1f, 1f, 2f, 2f, -2f, -MaterialEditorUI.HeaderSize);
             ScrollRect.gameObject.AddComponent<Mask>();
             ScrollRect.content.gameObject.AddComponent<VerticalLayoutGroup>();
             ScrollRect.content.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
@@ -66,8 +67,7 @@ namespace MaterialEditorAPI
 
             Toggle toggle = UIUtility.CreateToggle($"{this.Name}Toggle", itemPanel.transform, name);
             var toggleLE = toggle.gameObject.AddComponent<LayoutElement>();
-            toggleLE.preferredWidth = 12;
-            toggleLE.flexibleWidth = 0;
+            toggle.gameObject.GetComponentInChildren<CanvasRenderer>(true).transform.SetRect(0f, 1f, 0f, 1f, 1f, -18f, 18f, -1f);
             toggle.isOn = false;
             toggle.group = ToggleGroup;
             toggle.onValueChanged.AddListener(value => onValueChanged(value));

--- a/src/MaterialEditor.Base/UI/UI.SelectListEntryTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.SelectListEntryTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UILib;
 using UnityEngine;
 using UnityEngine.UI;
@@ -11,13 +12,31 @@ namespace MaterialEditorAPI
         public Transform Parent { get; }
         public ToggleGroup ToggleGroup { get; }
         public ScrollRect ScrollRect { get; }
+        public Image Panel { get; }
 
-        internal SelectListEntryTemplate(Transform parent, string name)
+        private InputField filterInputField;
+        private Dictionary<string, Image> listItems;
+
+        internal SelectListEntryTemplate(Transform parent, string name, string title)
         {
+            listItems = new Dictionary<string, Image>();
             this.Parent = parent;
             this.Name = name;
 
-            ScrollRect = UIUtility.CreateScrollView(name, parent);
+            Panel = UIUtility.CreatePanel($"{name}Panel", parent);
+            Panel.color = new Color(0.42f, 0.42f, 0.42f);
+
+            var nametext = UIUtility.CreateText($"{name}Title", Panel.transform, title);
+            nametext.transform.SetRect(0f, 1f, 0.4f, 1f, 5f, -MaterialEditorUI.HeaderSize, -2f, -2f);
+            nametext.alignment = TextAnchor.UpperLeft;
+
+            filterInputField = UIUtility.CreateInputField($"{name}Filter", Panel.transform, "Filter");
+            filterInputField.text = "";
+            filterInputField.transform.SetRect(0.4f, 1f, 1f, 1f, 2f, -MaterialEditorUI.HeaderSize, -2f, -2f);
+            filterInputField.onValueChanged.AddListener(FilterList);
+
+            ScrollRect = UIUtility.CreateScrollView(name, Panel.transform);
+            ScrollRect.transform.SetRect(0f, 0f, 1f, 1f, 2f, 2f, -2f, -MaterialEditorUI.HeaderSize - 2f);
             ScrollRect.gameObject.AddComponent<Mask>();
             ScrollRect.content.gameObject.AddComponent<VerticalLayoutGroup>();
             ScrollRect.content.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
@@ -32,6 +51,9 @@ namespace MaterialEditorAPI
 
         internal void AddEntry(string name, Action<bool> onValueChanged)
         {
+            if (listItems.ContainsKey(name))
+                return;
+
             var contentList = UIUtility.CreatePanel($"{this.Name}Entry", ScrollRect.content.transform);
             contentList.gameObject.AddComponent<LayoutElement>().preferredHeight = MaterialEditorUI.PanelHeight;
             contentList.gameObject.AddComponent<Mask>();
@@ -51,14 +73,27 @@ namespace MaterialEditorAPI
             toggle.onValueChanged.AddListener(value => onValueChanged(value));
 
             itemPanel.gameObject.AddComponent<Button>().onClick.AddListener(() => toggle.isOn = !toggle.isOn);
+
+            listItems[name] = contentList;
         }
 
         internal void ClearList()
         {
+            filterInputField.Set("");
+            listItems.Clear();
             foreach (Transform child in ScrollRect.content.transform)
-            {
                 UnityEngine.Object.Destroy(child.gameObject);
-            }
+        }
+
+        internal void ToggleVisibility(bool visible)
+        {
+            Panel.gameObject.SetActive(visible);
+        }
+
+        private void FilterList(string filter)
+        {
+            foreach (var name in listItems.Keys)
+                listItems[name].gameObject.SetActive(MaterialEditorUI.WildCardSearch(name, filter));
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.SelectListEntryTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.SelectListEntryTemplate.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using UILib;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MaterialEditorAPI
+{
+    internal class SelectListEntryTemplate
+    {
+        public string Name { get; }
+        public Transform Parent { get; }
+        public ToggleGroup ToggleGroup { get; }
+        public ScrollRect ScrollRect { get; }
+
+        internal SelectListEntryTemplate(Transform parent, string name)
+        {
+            this.Parent = parent;
+            this.Name = name;
+
+            ScrollRect = UIUtility.CreateScrollView(name, parent);
+            ScrollRect.gameObject.AddComponent<Mask>();
+            ScrollRect.content.gameObject.AddComponent<VerticalLayoutGroup>();
+            ScrollRect.content.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            ScrollRect.verticalScrollbar.GetComponent<RectTransform>().offsetMin = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
+            ScrollRect.viewport.offsetMax = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
+            ScrollRect.movementType = ScrollRect.MovementType.Clamped;
+            ScrollRect.verticalScrollbar.GetComponent<Image>().color = new Color(1, 1, 1, 0.6f);
+
+            ToggleGroup = ScrollRect.content.gameObject.AddComponent<ToggleGroup>();
+            ToggleGroup.allowSwitchOff = true;
+        }
+
+        internal void AddEntry(string name, Action<bool> onValueChanged)
+        {
+            var contentList = UIUtility.CreatePanel($"{this.Name}Entry", ScrollRect.content.transform);
+            contentList.gameObject.AddComponent<LayoutElement>().preferredHeight = MaterialEditorUI.PanelHeight;
+            contentList.gameObject.AddComponent<Mask>();
+            contentList.color = MaterialEditorUI.RowColor;
+
+            var itemPanel = UIUtility.CreatePanel($"{this.Name}EntryPanel", contentList.transform);
+            itemPanel.gameObject.AddComponent<CanvasGroup>();
+            itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = MaterialEditorUI.Padding;
+            itemPanel.color = MaterialEditorUI.ItemColor;
+
+            Toggle toggle = UIUtility.CreateToggle($"{this.Name}Toggle", itemPanel.transform, name);
+            var toggleLE = toggle.gameObject.AddComponent<LayoutElement>();
+            toggleLE.preferredWidth = 12;
+            toggleLE.flexibleWidth = 0;
+            toggle.isOn = false;
+            toggle.group = ToggleGroup;
+            toggle.onValueChanged.AddListener(value => onValueChanged(value));
+
+            itemPanel.gameObject.AddComponent<Button>().onClick.AddListener(() => toggle.isOn = !toggle.isOn);
+        }
+
+        internal void ClearList()
+        {
+            foreach (Transform child in ScrollRect.content.transform)
+            {
+                UnityEngine.Object.Destroy(child.gameObject);
+            }
+        }
+    }
+}

--- a/src/MaterialEditor.Base/UI/UI.SelectListPanel.cs
+++ b/src/MaterialEditor.Base/UI/UI.SelectListPanel.cs
@@ -9,7 +9,6 @@ namespace MaterialEditorAPI
     internal class SelectListPanel
     {
         public Image Panel { get; }
-        private ToggleGroup toggleGroup;
         private string name;
         private Transform parent;
         private ScrollRect scrollRect;
@@ -44,9 +43,6 @@ namespace MaterialEditorAPI
             scrollRect.viewport.offsetMax = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
             scrollRect.movementType = ScrollRect.MovementType.Clamped;
             scrollRect.verticalScrollbar.GetComponent<Image>().color = new Color(1, 1, 1, 0.6f);
-
-            toggleGroup = scrollRect.content.gameObject.AddComponent<ToggleGroup>();
-            toggleGroup.allowSwitchOff = true;
         }
 
         public void AddEntry(string name, Action<bool> onValueChanged)
@@ -68,7 +64,6 @@ namespace MaterialEditorAPI
             var toggleLE = toggle.gameObject.AddComponent<LayoutElement>();
             toggle.gameObject.GetComponentInChildren<CanvasRenderer>(true).transform.SetRect(0f, 1f, 0f, 1f, 1f, -18f, 18f, -1f);
             toggle.isOn = false;
-            toggle.group = toggleGroup;
             toggle.onValueChanged.AddListener(value => onValueChanged(value));
 
             itemPanel.gameObject.AddComponent<Button>().onClick.AddListener(() => toggle.isOn = !toggle.isOn);
@@ -87,11 +82,6 @@ namespace MaterialEditorAPI
         public void ToggleVisibility(bool visible)
         {
             Panel.gameObject.SetActive(visible);
-        }
-
-        public bool AnyTogglesOn()
-        {
-            return toggleGroup.AnyTogglesOn();
         }
 
         private void FilterList(string filter)

--- a/src/MaterialEditor.Base/UI/UI.SelectListPanel.cs
+++ b/src/MaterialEditor.Base/UI/UI.SelectListPanel.cs
@@ -1,28 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
 using UILib;
-using UniRx.Triggers;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace MaterialEditorAPI
 {
-    internal class SelectListEntryTemplate
+    internal class SelectListPanel
     {
-        public string Name { get; }
-        public Transform Parent { get; }
-        public ToggleGroup ToggleGroup { get; }
-        public ScrollRect ScrollRect { get; }
         public Image Panel { get; }
+        private ToggleGroup toggleGroup;
+        private string name;
+        private Transform parent;
+        private ScrollRect scrollRect;
 
         private InputField filterInputField;
         private Dictionary<string, Image> listItems;
 
-        internal SelectListEntryTemplate(Transform parent, string name, string title)
+        public SelectListPanel(Transform parent, string name, string title)
         {
             listItems = new Dictionary<string, Image>();
-            this.Parent = parent;
-            this.Name = name;
+            this.parent = parent;
+            this.name = name;
 
             Panel = UIUtility.CreatePanel($"{name}Panel", parent);
             Panel.color = new Color(0.42f, 0.42f, 0.42f);
@@ -36,40 +35,40 @@ namespace MaterialEditorAPI
             filterInputField.transform.SetRect(0.4f, 1f, 1f, 1f, 2f, -MaterialEditorUI.HeaderSize, -2f, -2f);
             filterInputField.onValueChanged.AddListener(FilterList);
 
-            ScrollRect = UIUtility.CreateScrollView(name, Panel.transform);
-            ScrollRect.transform.SetRect(0f, 0f, 1f, 1f, 2f, 2f, -2f, -MaterialEditorUI.HeaderSize);
-            ScrollRect.gameObject.AddComponent<Mask>();
-            ScrollRect.content.gameObject.AddComponent<VerticalLayoutGroup>();
-            ScrollRect.content.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-            ScrollRect.verticalScrollbar.GetComponent<RectTransform>().offsetMin = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
-            ScrollRect.viewport.offsetMax = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
-            ScrollRect.movementType = ScrollRect.MovementType.Clamped;
-            ScrollRect.verticalScrollbar.GetComponent<Image>().color = new Color(1, 1, 1, 0.6f);
+            scrollRect = UIUtility.CreateScrollView(name, Panel.transform);
+            scrollRect.transform.SetRect(0f, 0f, 1f, 1f, 2f, 2f, -2f, -MaterialEditorUI.HeaderSize);
+            scrollRect.gameObject.AddComponent<Mask>();
+            scrollRect.content.gameObject.AddComponent<VerticalLayoutGroup>();
+            scrollRect.content.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            scrollRect.verticalScrollbar.GetComponent<RectTransform>().offsetMin = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
+            scrollRect.viewport.offsetMax = new Vector2(MaterialEditorUI.ScrollOffsetX, 0f);
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            scrollRect.verticalScrollbar.GetComponent<Image>().color = new Color(1, 1, 1, 0.6f);
 
-            ToggleGroup = ScrollRect.content.gameObject.AddComponent<ToggleGroup>();
-            ToggleGroup.allowSwitchOff = true;
+            toggleGroup = scrollRect.content.gameObject.AddComponent<ToggleGroup>();
+            toggleGroup.allowSwitchOff = true;
         }
 
-        internal void AddEntry(string name, Action<bool> onValueChanged)
+        public void AddEntry(string name, Action<bool> onValueChanged)
         {
             if (listItems.ContainsKey(name))
                 return;
 
-            var contentList = UIUtility.CreatePanel($"{this.Name}Entry", ScrollRect.content.transform);
+            var contentList = UIUtility.CreatePanel($"{this.name}Entry", scrollRect.content.transform);
             contentList.gameObject.AddComponent<LayoutElement>().preferredHeight = MaterialEditorUI.PanelHeight;
             contentList.gameObject.AddComponent<Mask>();
             contentList.color = MaterialEditorUI.RowColor;
 
-            var itemPanel = UIUtility.CreatePanel($"{this.Name}EntryPanel", contentList.transform);
+            var itemPanel = UIUtility.CreatePanel($"{this.name}EntryPanel", contentList.transform);
             itemPanel.gameObject.AddComponent<CanvasGroup>();
             itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = MaterialEditorUI.Padding;
             itemPanel.color = MaterialEditorUI.ItemColor;
 
-            Toggle toggle = UIUtility.CreateToggle($"{this.Name}Toggle", itemPanel.transform, name);
+            Toggle toggle = UIUtility.CreateToggle($"{this.name}Toggle", itemPanel.transform, name);
             var toggleLE = toggle.gameObject.AddComponent<LayoutElement>();
             toggle.gameObject.GetComponentInChildren<CanvasRenderer>(true).transform.SetRect(0f, 1f, 0f, 1f, 1f, -18f, 18f, -1f);
             toggle.isOn = false;
-            toggle.group = ToggleGroup;
+            toggle.group = toggleGroup;
             toggle.onValueChanged.AddListener(value => onValueChanged(value));
 
             itemPanel.gameObject.AddComponent<Button>().onClick.AddListener(() => toggle.isOn = !toggle.isOn);
@@ -77,17 +76,22 @@ namespace MaterialEditorAPI
             listItems[name] = contentList;
         }
 
-        internal void ClearList()
+        public void ClearList()
         {
             filterInputField.Set("");
             listItems.Clear();
-            foreach (Transform child in ScrollRect.content.transform)
+            foreach (Transform child in scrollRect.content.transform)
                 UnityEngine.Object.Destroy(child.gameObject);
         }
 
-        internal void ToggleVisibility(bool visible)
+        public void ToggleVisibility(bool visible)
         {
             Panel.gameObject.SetActive(visible);
+        }
+
+        public bool AnyTogglesOn()
+        {
+            return toggleGroup.AnyTogglesOn();
         }
 
         private void FilterList(string filter)

--- a/src/MaterialEditor.Base/UI/UI.SelectListPanel.cs
+++ b/src/MaterialEditor.Base/UI/UI.SelectListPanel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UILib;
 using UnityEngine;
 using UnityEngine.UI;
+using static MaterialEditorAPI.MaterialEditorPluginBase;
 
 namespace MaterialEditorAPI
 {
@@ -69,11 +70,13 @@ namespace MaterialEditorAPI
             itemPanel.gameObject.AddComponent<Button>().onClick.AddListener(() => toggle.isOn = !toggle.isOn);
 
             listItems[name] = contentList;
+            FilterList(filterInputField.text);
         }
 
         public void ClearList()
         {
-            filterInputField.Set("");
+            if (!PersistFilter.Value)
+                filterInputField.Set("");
             listItems.Clear();
             foreach (Transform child in scrollRect.content.transform)
                 UnityEngine.Object.Destroy(child.gameObject);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -163,10 +163,10 @@ namespace MaterialEditorAPI
             VirtualList.Initialize();
 
             MaterialEditorRendererList = new SelectListPanel(MaterialEditorMainPanel.transform, "RendererList", "Renderers");
-            MaterialEditorRendererList.Panel.transform.SetRect(1f, 0.5f, 1f, 1f, MarginSize, MarginSize / 2f, MarginSize + 180f);
+            MaterialEditorRendererList.Panel.transform.SetRect(1f, 0.5f, 1f, 1f, MarginSize, MarginSize / 2f, MarginSize + UIListWidth.Value);
             MaterialEditorRendererList.ToggleVisibility(false);
             MaterialEditorMaterialList = new SelectListPanel(MaterialEditorMainPanel.transform, "MaterialList", "Materials");
-            MaterialEditorMaterialList.Panel.transform.SetRect(1f, 0f, 1f, 0.5f, MarginSize, 0f, MarginSize + 180f, -MarginSize);
+            MaterialEditorMaterialList.Panel.transform.SetRect(1f, 0f, 1f, 0.5f, MarginSize, 0f, MarginSize + UIListWidth.Value, -MarginSize);
             MaterialEditorMaterialList.ToggleVisibility(false);
         }
 
@@ -213,6 +213,10 @@ namespace MaterialEditorAPI
                 MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);
             if (MaterialEditorMainPanel != null)
                 SetMainRectWithMemory(0.05f, 0.05f, UIWidth.Value * UIScale.Value, UIHeight.Value * UIScale.Value);
+            if (MaterialEditorRendererList != null)
+                MaterialEditorRendererList.Panel.transform.SetRect(1f, 0.5f, 1f, 1f, MarginSize, MarginSize / 2f, MarginSize + UIListWidth.Value);
+            if (MaterialEditorMaterialList != null)
+                MaterialEditorMaterialList.Panel.transform.SetRect(1f, 0f, 1f, 0.5f, MarginSize, 0f, MarginSize + UIListWidth.Value, -MarginSize);
         }
 
         /// <summary>

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -305,7 +305,7 @@ namespace MaterialEditorAPI
             List<ItemInfo> items = new List<ItemInfo>();
             Dictionary<string, Material> matList = new Dictionary<string, Material>();
 
-            PopulateRenderedList(go, data, rendListFull);
+            PopulateRendererList(go, data, rendListFull);
 
             CurrentGameObject = go;
             CurrentData = data;

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -232,7 +232,7 @@ namespace MaterialEditorAPI
         /// <param name="go">GameObject for which to read the renderers</param>
         /// <param name="data">Object that will be passed through to the get/set/reset events</param>
         /// <param name="rendListFull">List of all renderers to display</param>
-        private void PopulateRenderedList(GameObject go, object data, IEnumerable<Renderer> rendListFull)
+        private void PopulateRendererList(GameObject go, object data, IEnumerable<Renderer> rendListFull)
         {
             if (go != CurrentGameObject)
             {

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -35,9 +35,9 @@ namespace MaterialEditorAPI
         private static ScrollRect MaterialEditorScrollableUI;
         private static InputField FilterInputField;
 
-        private static SelectListEntryTemplate MaterialEditorRendererList;
+        private static SelectListPanel MaterialEditorRendererList;
         private static Renderer SelectedRenderer;
-        private static SelectListEntryTemplate MaterialEditorMaterialList;
+        private static SelectListPanel MaterialEditorMaterialList;
         private static Material SelectedMaterial;
         private static bool ListsVisible = false;
 
@@ -162,10 +162,10 @@ namespace MaterialEditorAPI
             VirtualList.EntryTemplate = template;
             VirtualList.Initialize();
 
-            MaterialEditorRendererList = new SelectListEntryTemplate(MaterialEditorMainPanel.transform, "RendererList", "Renderers");
+            MaterialEditorRendererList = new SelectListPanel(MaterialEditorMainPanel.transform, "RendererList", "Renderers");
             MaterialEditorRendererList.Panel.transform.SetRect(1f, 0.5f, 1f, 1f, MarginSize, MarginSize / 2f, MarginSize + 180f);
             MaterialEditorRendererList.ToggleVisibility(false);
-            MaterialEditorMaterialList = new SelectListEntryTemplate(MaterialEditorMainPanel.transform, "MaterialList", "Materials");
+            MaterialEditorMaterialList = new SelectListPanel(MaterialEditorMainPanel.transform, "MaterialList", "Materials");
             MaterialEditorMaterialList.Panel.transform.SetRect(1f, 0f, 1f, 0.5f, MarginSize, 0f, MarginSize + 180f, -MarginSize);
             MaterialEditorMaterialList.ToggleVisibility(false);
         }
@@ -226,6 +226,12 @@ namespace MaterialEditorAPI
             return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase);
         }
 
+        /// <summary>
+        /// Populate the renderer list
+        /// </summary>
+        /// <param name="go">GameObject for which to read the renderers</param>
+        /// <param name="data">Object that will be passed through to the get/set/reset events</param>
+        /// <param name="rendListFull">List of all renderers to display</param>
         private void PopulateRenderedList(GameObject go, object data, IEnumerable<Renderer> rendListFull)
         {
             if (go != CurrentGameObject)
@@ -236,7 +242,7 @@ namespace MaterialEditorAPI
                 foreach (var rend in rendListFull)
                     MaterialEditorRendererList.AddEntry(rend.NameFormatted(), value =>
                     {
-                        if (!MaterialEditorRendererList.ToggleGroup.AnyTogglesOn())
+                        if (!MaterialEditorRendererList.AnyTogglesOn())
                             SelectedRenderer = null;
                         else if (value)
                             SelectedRenderer = rend;
@@ -247,16 +253,23 @@ namespace MaterialEditorAPI
             }
         }
 
-        private void PopulateMaterialList(GameObject go, object data, IEnumerable<Renderer> rendListFull)
+
+        /// <summary>
+        /// Populate the materials list
+        /// </summary>
+        /// <param name="go">GameObject for which to read the renderers</param>
+        /// <param name="data">Object that will be passed through to the get/set/reset events</param>
+        /// <param name="materials">List of all materials to display</param>
+        private void PopulateMaterialList(GameObject go, object data, IEnumerable<Renderer> materials)
         {
             SelectedMaterial = null;
             MaterialEditorMaterialList.ClearList();
 
-            foreach (var rend in rendListFull.Where(rend => SelectedRenderer == null || rend == SelectedRenderer))
+            foreach (var rend in materials.Where(rend => SelectedRenderer == null || rend == SelectedRenderer))
                 foreach (var mat in GetMaterials(go, rend))
                     MaterialEditorMaterialList.AddEntry(mat.NameFormatted(), value =>
                     {
-                        if (!MaterialEditorMaterialList.ToggleGroup.AnyTogglesOn())
+                        if (!MaterialEditorMaterialList.AnyTogglesOn())
                             SelectedMaterial = null;
                         else if (value)
                             SelectedMaterial = mat;

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -39,6 +39,7 @@ namespace MaterialEditorAPI
         private static Renderer SelectedRenderer;
         private static SelectListEntryTemplate MaterialEditorMaterialList;
         private static Material SelectedMaterial;
+        private static bool ListsVisible = false;
 
 
         internal static FileSystemWatcher TexChangeWatcher;
@@ -118,7 +119,7 @@ namespace MaterialEditorAPI
             persistSearchText.transform.SetRect(0f, 0.15f, 1f, 0.85f, 120f, 0f, 0, 0f);
 
             var close = UIUtility.CreateButton("CloseButton", DragPanel.transform, "");
-            close.transform.SetRect(1f, 0f, 1f, 1f, -20f, 1f, -1f, -1f);
+            close.transform.SetRect(1f, 0f, 1f, 1f, -40f, 1f, -21f, -1f);
             close.onClick.AddListener(() => Visible = false);
 
             //X button
@@ -130,6 +131,19 @@ namespace MaterialEditorAPI
             x2.transform.SetRect(0f, 0f, 1f, 1f, 8f, 0f, -8f);
             x2.rectTransform.eulerAngles = new Vector3(0f, 0f, -45f);
             x2.color = Color.black;
+
+            var listButton = UIUtility.CreateButton("ViewListButton", DragPanel.transform, "<");
+            listButton.transform.SetRect(1f, 0f, 1f, 1f, -20f, 1f, -1f, -1f);
+            listButton.onClick.AddListener(() => MaterialEditorRendererList.ToggleVisibility(!ListsVisible));
+            listButton.onClick.AddListener(() => MaterialEditorMaterialList.ToggleVisibility(!ListsVisible));
+            listButton.onClick.AddListener(() => {
+                var text = listButton.GetComponentInChildren<Text>(true);
+                ListsVisible = !ListsVisible;
+                if (ListsVisible)
+                    text.text = "<";
+                else
+                    text.text = ">";
+            });
 
             MaterialEditorScrollableUI = UIUtility.CreateScrollView("MaterialEditorWindow", MaterialEditorMainPanel.transform);
             MaterialEditorScrollableUI.transform.SetRect(0f, 0f, 1f, 1f, MarginSize, MarginSize, -MarginSize, -HeaderSize - MarginSize / 2f);
@@ -148,10 +162,10 @@ namespace MaterialEditorAPI
             VirtualList.EntryTemplate = template;
             VirtualList.Initialize();
 
-            MaterialEditorRendererList = new SelectListEntryTemplate(MaterialEditorMainPanel.transform, "RendererList");
-            MaterialEditorRendererList.ScrollRect.transform.SetRect(1f, 0.5f, 1.4f, 1f, MarginSize, MarginSize / 2f, -MarginSize, -HeaderSize - MarginSize / 2f);
-            MaterialEditorMaterialList = new SelectListEntryTemplate(MaterialEditorMainPanel.transform, "MaterialList");
-            MaterialEditorMaterialList.ScrollRect.transform.SetRect(1f, 0f, 1.4f, 0.5f, MarginSize, MarginSize, -MarginSize, -HeaderSize - MarginSize / 2f);
+            MaterialEditorRendererList = new SelectListEntryTemplate(MaterialEditorMainPanel.transform, "RendererList", "Renderers");
+            MaterialEditorRendererList.Panel.transform.SetRect(1f, 0.5f, 1f, 1f, MarginSize, MarginSize / 2f, MarginSize + 180f);
+            MaterialEditorMaterialList = new SelectListEntryTemplate(MaterialEditorMainPanel.transform, "MaterialList", "Materials");
+            MaterialEditorMaterialList.Panel.transform.SetRect(1f, 0f, 1f, 0.5f, MarginSize, 0f, MarginSize + 180f, -MarginSize);
         }
 
         /// <summary>
@@ -204,7 +218,7 @@ namespace MaterialEditorAPI
         /// </summary>
         /// <param name="text">Text to search in</param>
         /// <param name="filter">Filter with which to search the text</param>
-        private bool WildCardSearch(string text, string filter)
+        internal static bool WildCardSearch(string text, string filter)
         {
             string regex = "^.*" + Regex.Escape(filter).Replace("\\?", ".").Replace("\\*", ".*") + ".*$";
             return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase);

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -78,7 +78,7 @@ namespace KK_Plugins.MaterialEditor
             InitUI();
 
             ItemTypeDropDown = UIUtility.CreateDropdown("ItemType", DragPanel.transform);
-            ItemTypeDropDown.transform.SetRect(1f, 0f, 1f, 1f, -200f, 1f, -19f, -1f);
+            ItemTypeDropDown.transform.SetRect(1f, 0f, 1f, 1f, -220f, 1f, -39f, -1f);
             ItemTypeDropDown.captionText.transform.SetRect(0.05f, 0f, 1f, 1f, 5f, 2f, -15f, -2f);
             ItemTypeDropDown.captionText.alignment = TextAnchor.MiddleLeft;
             ItemTypeDropDown.gameObject.SetActive(false);


### PR DESCRIPTION
Adds two collapsible lists to the side of the main window where you can easily filter the main window to the selected renderer/material.
If you select a renderer, the material list will update to only show materials connected to that renderer

If a material/renderer is selected, the main window filter will only filter on those that are selected in the lists

![image](https://github.com/IllusionMods/KK_Plugins/assets/141709004/8235e8fd-1667-4f80-bd20-9ff2df70de61)
