### PR TITLE
[ME] Projector support

### DIFF
--- a/src/MaterialEditor.Base/CopyContainer.cs
+++ b/src/MaterialEditor.Base/CopyContainer.cs
@@ -28,6 +28,10 @@ namespace MaterialEditorAPI
         /// List of shader edits
         /// </summary>
         public List<MaterialShader> MaterialShaderList = new List<MaterialShader>();
+        /// <summary>
+        /// List of projector edits
+        /// </summary>
+        public List<ProjectorProperty> ProjectorPropertyList = new List<ProjectorProperty>();
 
         /// <summary>
         /// Whether there are any copied edits
@@ -36,7 +40,7 @@ namespace MaterialEditorAPI
         {
             get
             {
-                if (MaterialFloatPropertyList.Count == 0 && MaterialKeywordPropertyList.Count == 0 && MaterialColorPropertyList.Count == 0 && MaterialTexturePropertyList.Count == 0 && MaterialShaderList.Count == 0)
+                if (MaterialFloatPropertyList.Count == 0 && MaterialKeywordPropertyList.Count == 0 && MaterialColorPropertyList.Count == 0 && MaterialTexturePropertyList.Count == 0 && MaterialShaderList.Count == 0 && ProjectorPropertyList.Count == 0)
                     return true;
                 return false;
             }
@@ -52,6 +56,7 @@ namespace MaterialEditorAPI
             MaterialColorPropertyList = new List<MaterialColorProperty>();
             MaterialTexturePropertyList = new List<MaterialTextureProperty>();
             MaterialShaderList = new List<MaterialShader>();
+            ProjectorPropertyList = new List<ProjectorProperty>();
         }
 
         /// <summary>
@@ -216,6 +221,32 @@ namespace MaterialEditorAPI
             /// </summary>
             /// <returns></returns>
             public bool NullCheck() => ShaderName.IsNullOrEmpty() && RenderQueue == null;
+        }
+
+        /// <summary>
+        /// Data storage class for projector properties
+        /// </summary>
+        public class ProjectorProperty
+        {
+            /// <summary>
+            /// Name of the property
+            /// </summary>
+            public MaterialAPI.ProjectorProperties Property;
+            /// <summary>
+            /// Value
+            /// </summary>
+            public float Value;
+
+            /// <summary>
+            /// Data storage class for projector properties
+            /// </summary>
+            /// <param name="property">Name of the property</param>
+            /// <param name="value">Value</param>
+            public ProjectorProperty(MaterialAPI.ProjectorProperties property, float value)
+            {
+                Property = property;
+                Value = value;
+            }
         }
     }
 }

--- a/src/MaterialEditor.Base/Extensions.cs
+++ b/src/MaterialEditor.Base/Extensions.cs
@@ -23,6 +23,7 @@ namespace MaterialEditorAPI
         public static string NameFormatted(this GameObject go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Material go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Renderer go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
+        public static string NameFormatted(this Projector go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Shader go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Mesh go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         /// <summary>

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -460,17 +460,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorEnabled(GameObject gameObject, string projectorName, bool value)
         {
-            bool didSet = false;
-
             foreach (var projector in GetProjectorList(gameObject))
             {
                 if (projector.NameFormatted() == projectorName)
                 {
                     projector.enabled = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>
@@ -482,17 +480,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorFarClipPlane(GameObject gameObject, string projectorName, float value)
         {
-            bool didSet = false;
-
             foreach(var projector in GetProjectorList(gameObject))
             {
                 if(projector.NameFormatted() == projectorName)
                 {
                     projector.farClipPlane = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>
@@ -504,17 +500,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorNearClipPlane(GameObject gameObject, string projectorName, float value)
         {
-            bool didSet = false;
-
             foreach (var projector in GetProjectorList(gameObject))
             {
                 if (projector.NameFormatted() == projectorName)
                 {
                     projector.nearClipPlane = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>
@@ -526,17 +520,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorFieldOfView(GameObject gameObject, string projectorName, float value)
         {
-            bool didSet = false;
-
             foreach (var projector in GetProjectorList(gameObject))
             {
                 if (projector.NameFormatted() == projectorName)
                 {
                     projector.fieldOfView = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>
@@ -548,17 +540,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorAspectRatio(GameObject gameObject, string projectorName, float value)
         {
-            bool didSet = false;
-
             foreach (var projector in GetProjectorList(gameObject))
             {
                 if (projector.NameFormatted() == projectorName)
                 {
                     projector.aspectRatio = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>
@@ -570,17 +560,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorOrthographic(GameObject gameObject, string projectorName, bool value)
         {
-            bool didSet = false;
-
             foreach (var projector in GetProjectorList(gameObject))
             {
                 if (projector.NameFormatted() == projectorName)
                 {
                     projector.orthographic = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>
@@ -592,17 +580,15 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorOrthographicSize(GameObject gameObject, string projectorName, float value)
         {
-            bool didSet = false;
-
             foreach (var projector in GetProjectorList(gameObject))
             {
                 if (projector.NameFormatted() == projectorName)
                 {
                     projector.orthographicSize = value;
-                    didSet = true;
+                    return true;
                 }
             }
-            return didSet;
+            return false;
         }
 
         /// <summary>

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -10,6 +10,8 @@ namespace MaterialEditorAPI
     /// </summary>
     public static class MaterialAPI
     {
+        internal static readonly Dictionary<Projector, Material> ProjectorMaterialInstances = new Dictionary<Projector, Material>();
+
         /// <summary>
         /// Postfix added to the name of a material when copied
         /// </summary>
@@ -31,7 +33,14 @@ namespace MaterialEditorAPI
             if (gameObject == null)
                 return new List<Projector>();
 
-            return gameObject.GetComponentsInChildren<Projector>(true);
+            var projectors = gameObject.GetComponentsInChildren<Projector>(true);
+            foreach (var projector in projectors)
+                if (!ProjectorMaterialInstances.ContainsKey(projector))
+                {
+                    projector.material = new Material(projector.material);
+                    ProjectorMaterialInstances[projector] = projector.material;
+                }
+            return projectors;
         }
 
         /// <summary>

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -416,19 +416,36 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorProperty(GameObject gameObject, string projectorName, ProjectorProperties propertyName, float value)
         {
-            if (propertyName == ProjectorProperties.FarClipPlane)
+            if (propertyName == ProjectorProperties.Enabled)
+                return SetProjectorEnabled(gameObject, projectorName, System.Convert.ToBoolean(value));
+            else if (propertyName == ProjectorProperties.FarClipPlane)
                 return SetProjectorFarClipPlane(gameObject, projectorName, value);
-            if (propertyName == ProjectorProperties.NearClipPlane)
+            else if (propertyName == ProjectorProperties.NearClipPlane)
                 return SetProjectorNearClipPlane(gameObject, projectorName, value);
-            if (propertyName == ProjectorProperties.FieldOfView)
+            else if (propertyName == ProjectorProperties.FieldOfView)
                 return SetProjectorFieldOfView(gameObject, projectorName, value);
-            if (propertyName == ProjectorProperties.AspectRatio)
+            else if (propertyName == ProjectorProperties.AspectRatio)
                 return SetProjectorAspectRatio(gameObject, projectorName, value);
-            if (propertyName == ProjectorProperties.Orthographic)
+            else if (propertyName == ProjectorProperties.Orthographic)
                 return SetProjectorOrthographic(gameObject, projectorName, System.Convert.ToBoolean(value));
-            if (propertyName == ProjectorProperties.OrthographicSize)
+            else if (propertyName == ProjectorProperties.OrthographicSize)
                 return SetProjectorOrthographicSize(gameObject, projectorName, value);
             return false;
+        }
+
+        public static bool SetProjectorEnabled(GameObject gameObject, string projectorName, bool value)
+        {
+            bool didSet = false;
+
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    projector.enabled = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
         }
 
         public static bool SetProjectorFarClipPlane(GameObject gameObject, string projectorName, float value)
@@ -752,6 +769,10 @@ namespace MaterialEditorAPI
         }
         public enum ProjectorProperties
         {
+            /// <summary>
+            /// Whether the projector is enabled
+            /// </summary>
+            Enabled,
             /// <summary>
             /// Near clip plane to start projecting
             /// </summary>

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -451,6 +451,10 @@ namespace MaterialEditorAPI
                 return SetProjectorOrthographic(gameObject, projectorName, System.Convert.ToBoolean(value));
             else if (propertyName == ProjectorProperties.OrthographicSize)
                 return SetProjectorOrthographicSize(gameObject, projectorName, value);
+            else if (propertyName == ProjectorProperties.IgnoreCharaLayer)
+                return SetProjectorIgnoreLayers(gameObject, projectorName, System.Convert.ToBoolean(value), 10);
+            else if (propertyName == ProjectorProperties.IgnoreMapLayer)
+                return SetProjectorIgnoreLayers(gameObject, projectorName, System.Convert.ToBoolean(value), 11);
             return false;
         }
 
@@ -589,6 +593,33 @@ namespace MaterialEditorAPI
                 {
                     projector.orthographicSize = value;
                     return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Add or remove the given layer to/from the ignored layers property.
+        /// Ensures it's not removed/added that was already the case
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
+        /// <param name="ignore">If the given layer should be ignored or not</param>
+        /// <param name="layer">The index of the layer to be added/removed</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
+        public static bool SetProjectorIgnoreLayers(GameObject gameObject, string projectorName, bool ignore, int layer)
+        {
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    bool inMask = projector.ignoreLayers == (projector.ignoreLayers | (1 << layer));
+                    //Remove layer from mask
+                    if (inMask && !ignore)
+                        projector.ignoreLayers &= ~(1 << layer);
+                    //Add layer to mask
+                    else if(!inMask && ignore)
+                        projector.ignoreLayers |= (1 << layer);
                 }
             }
             return false;
@@ -855,7 +886,15 @@ namespace MaterialEditorAPI
             /// <summary>
             /// The size of the orthographic projection
             /// </summary>
-            OrthographicSize
+            OrthographicSize,
+            /// <summary>
+            /// If the projector should ignore objects on the chara layer
+            /// </summary>
+            IgnoreCharaLayer,
+            /// <summary>
+            /// If the projector should ignore objects on the map layer
+            /// </summary>
+            IgnoreMapLayer
         }
     }
 }

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -86,6 +86,7 @@ namespace MaterialEditorAPI
                 foreach (var material in GetMaterials(gameObject, renderer))
                     if (material.NameFormatted() == materialName)
                         materials.Add(material);
+
             foreach (var projector in GetProjectorList(gameObject))
                 materials.Add(projector.material);
 

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -481,8 +481,8 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Set the farclipPlane property of a projector
         /// </summary>
-        /// <param name="gameObject">GameObject to search for the renderer</param>
-        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
         /// <param name="value">Value to be set</param>
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorFarClipPlane(GameObject gameObject, string projectorName, float value)
@@ -501,8 +501,8 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Set the nearClipPlane property of a projector
         /// </summary>
-        /// <param name="gameObject">GameObject to search for the renderer</param>
-        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
         /// <param name="value">Value to be set</param>
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorNearClipPlane(GameObject gameObject, string projectorName, float value)
@@ -521,8 +521,8 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Set the fieldOfView property of a projector
         /// </summary>
-        /// <param name="gameObject">GameObject to search for the renderer</param>
-        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
         /// <param name="value">Value to be set</param>
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorFieldOfView(GameObject gameObject, string projectorName, float value)
@@ -541,8 +541,8 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Set the aspectRatio property of a projector
         /// </summary>
-        /// <param name="gameObject">GameObject to search for the renderer</param>
-        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
         /// <param name="value">Value to be set</param>
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorAspectRatio(GameObject gameObject, string projectorName, float value)
@@ -561,8 +561,8 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Set the orthographic property of a projector
         /// </summary>
-        /// <param name="gameObject">GameObject to search for the renderer</param>
-        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
         /// <param name="value">Value to be set</param>
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorOrthographic(GameObject gameObject, string projectorName, bool value)
@@ -581,8 +581,8 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Set the orthoGraphicSize property of a projector
         /// </summary>
-        /// <param name="gameObject">GameObject to search for the renderer</param>
-        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
         /// <param name="value">Value to be set</param>
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorOrthographicSize(GameObject gameObject, string projectorName, float value)

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -26,6 +26,14 @@ namespace MaterialEditorAPI
             return gameObject.GetComponentsInChildren<Renderer>(true);
         }
 
+        public static IEnumerable<Projector> GetProjectorList(GameObject gameObject)
+        {
+            if (gameObject == null)
+                return new List<Projector>();
+
+            return gameObject.GetComponentsInChildren<Projector>(true);
+        }
+
         /// <summary>
         /// Get a list of materials for the renderer
         /// </summary>
@@ -57,6 +65,8 @@ namespace MaterialEditorAPI
                 foreach (var material in GetMaterials(gameObject, renderer))
                     if (material.NameFormatted() == materialName)
                         materials.Add(material);
+            foreach (var projector in GetProjectorList(gameObject))
+                materials.Add(projector.material);
 
             return materials;
         }

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
 
 namespace MaterialEditorAPI
@@ -35,12 +34,16 @@ namespace MaterialEditorAPI
         /// <summary>
         /// Get a list of all the projectors of a GameObject
         /// </summary>
-        public static IEnumerable<Projector> GetProjectorList(GameObject gameObject)
+        public static IEnumerable<Projector> GetProjectorList(GameObject gameObject, bool inChildren = false)
         {
             if (gameObject == null)
                 return new List<Projector>();
 
-            var projectors = gameObject.GetComponentsInChildren<Projector>(true);
+            IEnumerable<Projector> projectors;
+            if(inChildren)
+                projectors = gameObject.GetComponentsInChildren<Projector>(true);
+            else
+                projectors = gameObject.GetComponents<Projector>();
 
             //Assign a unique copy of the material if the projector didn't have one already
             foreach (var projector in projectors)

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -407,6 +407,121 @@ namespace MaterialEditorAPI
         }
 
         /// <summary>
+        /// Set the value of the specified projector property
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the projector</param>
+        /// <param name="projectorName">Name of the projector being modified</param>
+        /// <param name="propertyName">Property of the projector being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
+        public static bool SetProjectorProperty(GameObject gameObject, string projectorName, ProjectorProperties propertyName, float value)
+        {
+            if (propertyName == ProjectorProperties.FarClipPlane)
+                return SetProjectorFarClipPlane(gameObject, projectorName, value);
+            if (propertyName == ProjectorProperties.NearClipPlane)
+                return SetProjectorNearClipPlane(gameObject, projectorName, value);
+            if (propertyName == ProjectorProperties.FieldOfView)
+                return SetProjectorFieldOfView(gameObject, projectorName, value);
+            if (propertyName == ProjectorProperties.AspectRatio)
+                return SetProjectorAspectRatio(gameObject, projectorName, value);
+            if (propertyName == ProjectorProperties.Orthographic)
+                return SetProjectorOrthographic(gameObject, projectorName, System.Convert.ToBoolean(value));
+            if (propertyName == ProjectorProperties.OrthographicSize)
+                return SetProjectorOrthographicSize(gameObject, projectorName, value);
+            return false;
+        }
+
+        public static bool SetProjectorFarClipPlane(GameObject gameObject, string projectorName, float value)
+        {
+            bool didSet = false;
+
+            foreach(var projector in GetProjectorList(gameObject))
+            {
+                if(projector.NameFormatted() == projectorName)
+                {
+                    projector.farClipPlane = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        public static bool SetProjectorNearClipPlane(GameObject gameObject, string projectorName, float value)
+        {
+            bool didSet = false;
+
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    projector.nearClipPlane = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        public static bool SetProjectorFieldOfView(GameObject gameObject, string projectorName, float value)
+        {
+            bool didSet = false;
+
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    projector.fieldOfView = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        public static bool SetProjectorAspectRatio(GameObject gameObject, string projectorName, float value)
+        {
+            bool didSet = false;
+
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    projector.aspectRatio = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        public static bool SetProjectorOrthographic(GameObject gameObject, string projectorName, bool value)
+        {
+            bool didSet = false;
+
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    projector.orthographic = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        public static bool SetProjectorOrthographicSize(GameObject gameObject, string projectorName, float value)
+        {
+            bool didSet = false;
+
+            foreach (var projector in GetProjectorList(gameObject))
+            {
+                if (projector.NameFormatted() == projectorName)
+                {
+                    projector.orthographicSize = value;
+                    didSet = true;
+                }
+            }
+            return didSet;
+        }
+
+        /// <summary>
         /// Set the texture property of a material
         /// </summary>
         /// <param name="gameObject">GameObject to search for the renderer</param>
@@ -634,6 +749,33 @@ namespace MaterialEditorAPI
             /// Whether the renderer updates while off-screen
             /// </summary>
             UpdateWhenOffscreen
+        }
+        public enum ProjectorProperties
+        {
+            /// <summary>
+            /// Near clip plane to start projecting
+            /// </summary>
+            NearClipPlane,
+            /// <summary>
+            /// Far clip plane to stop projecting
+            /// </summary>
+            FarClipPlane,
+            /// <summary>
+            /// Field of View of projection
+            /// </summary>
+            FieldOfView,
+            /// <summary>
+            /// Aspect ratio of the projection
+            /// </summary>
+            AspectRatio,
+            /// <summary>
+            /// Whether the projector should project in orthographic mode
+            /// </summary>
+            Orthographic,
+            /// <summary>
+            /// The size of the orthographic projection
+            /// </summary>
+            OrthographicSize
         }
     }
 }

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -10,6 +10,10 @@ namespace MaterialEditorAPI
     /// </summary>
     public static class MaterialAPI
     {
+        /// <summary>
+        /// Projector materials share an instance by default, unlike renderers which get a unique one by default.
+        /// This list keeps track of every projector and it's new unique material instance
+        /// </summary>
         internal static readonly Dictionary<Projector, Material> ProjectorMaterialInstances = new Dictionary<Projector, Material>();
 
         /// <summary>
@@ -28,12 +32,17 @@ namespace MaterialEditorAPI
             return gameObject.GetComponentsInChildren<Renderer>(true);
         }
 
+        /// <summary>
+        /// Get a list of all the projectors of a GameObject
+        /// </summary>
         public static IEnumerable<Projector> GetProjectorList(GameObject gameObject)
         {
             if (gameObject == null)
                 return new List<Projector>();
 
             var projectors = gameObject.GetComponentsInChildren<Projector>(true);
+
+            //Assign a unique copy of the material if the projector didn't have one already
             foreach (var projector in projectors)
                 if (!ProjectorMaterialInstances.ContainsKey(projector))
                 {
@@ -442,6 +451,13 @@ namespace MaterialEditorAPI
             return false;
         }
 
+        /// <summary>
+        /// Set the enabled property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorEnabled(GameObject gameObject, string projectorName, bool value)
         {
             bool didSet = false;
@@ -457,6 +473,13 @@ namespace MaterialEditorAPI
             return didSet;
         }
 
+        /// <summary>
+        /// Set the farclipPlane property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorFarClipPlane(GameObject gameObject, string projectorName, float value)
         {
             bool didSet = false;
@@ -472,6 +495,13 @@ namespace MaterialEditorAPI
             return didSet;
         }
 
+        /// <summary>
+        /// Set the nearClipPlane property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorNearClipPlane(GameObject gameObject, string projectorName, float value)
         {
             bool didSet = false;
@@ -487,6 +517,13 @@ namespace MaterialEditorAPI
             return didSet;
         }
 
+        /// <summary>
+        /// Set the fieldOfView property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorFieldOfView(GameObject gameObject, string projectorName, float value)
         {
             bool didSet = false;
@@ -502,6 +539,13 @@ namespace MaterialEditorAPI
             return didSet;
         }
 
+        /// <summary>
+        /// Set the aspectRatio property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorAspectRatio(GameObject gameObject, string projectorName, float value)
         {
             bool didSet = false;
@@ -517,6 +561,13 @@ namespace MaterialEditorAPI
             return didSet;
         }
 
+        /// <summary>
+        /// Set the orthographic property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorOrthographic(GameObject gameObject, string projectorName, bool value)
         {
             bool didSet = false;
@@ -532,6 +583,13 @@ namespace MaterialEditorAPI
             return didSet;
         }
 
+        /// <summary>
+        /// Set the orthoGraphicSize property of a projector
+        /// </summary>
+        /// <param name="gameObject">GameObject to search for the renderer</param>
+        /// <param name="projectorName">Name of the renderer being modified</param>
+        /// <param name="value">Value to be set</param>
+        /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetProjectorOrthographicSize(GameObject gameObject, string projectorName, float value)
         {
             bool didSet = false;
@@ -776,6 +834,9 @@ namespace MaterialEditorAPI
             /// </summary>
             UpdateWhenOffscreen
         }
+        /// <summary>
+        /// Properties of a projector that can be set
+        /// </summary>
         public enum ProjectorProperties
         {
             /// <summary>

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -74,8 +74,14 @@ namespace MaterialEditorAPI
             PersistFilter = Config.Bind("Config", "Persist Filter", false, "Persist search filter across editor windows");
             ShowTimelineButtons = Config.Bind("Config", "Show Timeline Buttons", false, "Show buttons in the UI (in studio only) to add interpolables to the timeline. Requires game restart to take effect");
 
+            //Everything in these games is 10x the size of KK/KKS
+#if AI || HS2 || PH
+            ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 5 }));
+            ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 1000f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 4 }));
+#else
             ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 10f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 5 }));
             ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 4 }));
+#endif
             ProjectorFieldOfViewMax = Config.Bind("Projector", "Max Field Of View", 180f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 180f), new ConfigurationManagerAttributes { Order = 3 }));
             ProjectorAspectRatioMax = Config.Bind("Projector", "Max Aspect Ratio", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 2 }));
             ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 1 }));

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -78,7 +78,7 @@ namespace MaterialEditorAPI
 #if AI || HS2 || PH
             ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 5 }));
             ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 1000f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 4 }));
-            ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 20f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 1 }));
+            ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 20f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 1 }));
 #else
             ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 10f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 5 }));
             ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 4 }));

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -78,13 +78,14 @@ namespace MaterialEditorAPI
 #if AI || HS2 || PH
             ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 5 }));
             ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 1000f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 1000f), new ConfigurationManagerAttributes { Order = 4 }));
+            ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 20f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 1 }));
 #else
             ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 10f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 5 }));
             ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 4 }));
+            ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 1 }));
 #endif
             ProjectorFieldOfViewMax = Config.Bind("Projector", "Max Field Of View", 180f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 180f), new ConfigurationManagerAttributes { Order = 3 }));
             ProjectorAspectRatioMax = Config.Bind("Projector", "Max Aspect Ratio", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 2 }));
-            ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 1 }));
 
             UIScale.SettingChanged += MaterialEditorUI.UISettingChanged;
             UIWidth.SettingChanged += MaterialEditorUI.UISettingChanged;

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -50,6 +50,11 @@ namespace MaterialEditorAPI
         internal static ConfigEntry<string> ConfigExportPath { get; private set; }
         public static ConfigEntry<bool> PersistFilter { get; set; }
         public static ConfigEntry<bool> ShowTimelineButtons { get; set; }
+        public static ConfigEntry<float> ProjectorNearClipPlaneMax { get; set; }
+        public static ConfigEntry<float> ProjectorFarClipPlaneMax { get; set; }
+        public static ConfigEntry<float> ProjectorFieldOfViewMax { get; set; }
+        public static ConfigEntry<float> ProjectorAspectRatioMax { get; set; }
+        public static ConfigEntry<float> ProjectorOrthographicSizeMax { get; set; }
 
         public virtual void Awake()
         {
@@ -68,6 +73,12 @@ namespace MaterialEditorAPI
             ConfigExportPath = Config.Bind("Config", "Export Path Override", "", new ConfigDescription($"Textures and models will be exported to this folder. If empty, exports to {ExportPathDefault}", null, new ConfigurationManagerAttributes { Order = 1 }));
             PersistFilter = Config.Bind("Config", "Persist Filter", false, "Persist search filter across editor windows");
             ShowTimelineButtons = Config.Bind("Config", "Show Timeline Buttons", false, "Show buttons in the UI (in studio only) to add interpolables to the timeline. Requires game restart to take effect");
+
+            ProjectorNearClipPlaneMax = Config.Bind("Projector", "Max Near Clip Plane", 10f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 5 }));
+            ProjectorFarClipPlaneMax = Config.Bind("Projector", "Max Far Clip Plane", 100f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 4 }));
+            ProjectorFieldOfViewMax = Config.Bind("Projector", "Max Field Of View", 180f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 180f), new ConfigurationManagerAttributes { Order = 3 }));
+            ProjectorAspectRatioMax = Config.Bind("Projector", "Max Aspect Ratio", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 2 }));
+            ProjectorOrthographicSizeMax = Config.Bind("Projector", "Max Orthographic Size", 2f, new ConfigDescription("Controls the max value of the slider for this projector property", new AcceptableValueRange<float>(0.01f, 100f), new ConfigurationManagerAttributes { Order = 1 }));
 
             UIScale.SettingChanged += MaterialEditorUI.UISettingChanged;
             UIWidth.SettingChanged += MaterialEditorUI.UISettingChanged;

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -259,8 +259,13 @@ namespace MaterialEditorAPI
                             Text text = MaterialCopyRemove.GetComponentInChildren<Text>();
                             text.text = "Copy Material";
                         }
-                        MaterialCopyRemove.onClick.RemoveAllListeners();
-                        MaterialCopyRemove.onClick.AddListener(delegate { item.MaterialOnCopyRemove.Invoke(); });
+                        if (item.MaterialOnCopyRemove != null)
+                        {
+                            MaterialCopyRemove.onClick.RemoveAllListeners();
+                            MaterialCopyRemove.onClick.AddListener(delegate { item.MaterialOnCopyRemove.Invoke(); });
+                        }
+                        else
+                            MaterialCopyRemove.gameObject.SetActive(false);
 
                         break;
                     case ItemInfo.RowItemType.Shader:

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -1,5 +1,4 @@
 ﻿using BepInEx;
-using MessagePack.Decoders;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -636,7 +635,7 @@ namespace MaterialEditorAPI
                                 propertyName: propertyName,
                                 onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ItemInfo.RowItemType.FloatProperty, materialName, propertyName),
                                 changeValue: value => SetMaterialFloatProperty(data, mat, propertyName, value, go),
-                                resetValue: value => RemoveMaterialFloatProperty(data, mat, propertyName, go),
+                                resetValue: () => RemoveMaterialFloatProperty(data, mat, propertyName, go),
                                 valueFloatOriginal: valueFloatOriginal,
                                 minValue: property.Value.MinValue,
                                 maxValue: property.Value.MaxValue
@@ -667,15 +666,75 @@ namespace MaterialEditorAPI
 
             void PopulateProjectorSettings(Projector projector)
             {
-                AddFloatslider(projector.nearClipPlane, "Near Clip Plane", null, value => projector.nearClipPlane = value, value => projector.nearClipPlane = value, 0.1f, 0.01f, 10f);
-                AddFloatslider(projector.farClipPlane, "Far Clip Plane", null, value => projector.farClipPlane = value, value => projector.farClipPlane = value, 20f, 0.01f, 100f);
-                AddFloatslider(projector.fieldOfView, "Field Of View", null, value => projector.fieldOfView = value, value => projector.fieldOfView = value, 60f, 0.01f, 180f);
-                AddFloatslider(projector.aspectRatio, "Aspect ratio", null, value => projector.aspectRatio = value, value => projector.aspectRatio = value, 1f, 0.01f, 20f);
-                AddFloatslider(Convert.ToSingle(projector.orthographic), "Orthographic", null, value => projector.orthographic = Convert.ToBoolean(value), value => projector.orthographic = Convert.ToBoolean(value), 0f, 0f, 1f);
-                AddFloatslider(projector.orthographicSize, "Orthographic Size", null, value => projector.orthographicSize = value, value => projector.orthographicSize = value, 10f, 0.01f, 20f);
+                AddFloatslider
+                (
+                    valueFloat: projector.nearClipPlane,
+                    propertyName: "Near Clip Plane",
+                    onInteroperableClick: null,
+                    changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, value, projector.gameObject),
+                    resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, projector.gameObject),
+                    valueFloatOriginal: 0.1f,
+                    minValue: 0.01f,
+                    maxValue: 10f
+                );
+                AddFloatslider
+                (
+                    valueFloat: projector.farClipPlane,
+                    propertyName: "Far Clip Plane",
+                    onInteroperableClick: null,
+                    changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, value, projector.gameObject),
+                    resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, projector.gameObject),
+                    valueFloatOriginal: 20f,
+                    minValue: 0.01f,
+                    maxValue: 100f
+                );
+                AddFloatslider
+                (
+                    valueFloat: projector.fieldOfView,
+                    propertyName: "Field Of View",
+                    onInteroperableClick: null,
+                    changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.FieldOfView, value, projector.gameObject),
+                    resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FieldOfView, projector.gameObject),
+                    valueFloatOriginal: 60f,
+                    minValue: 0.01f,
+                    maxValue: 180f
+                );
+                AddFloatslider
+                (
+                    valueFloat: projector.aspectRatio,
+                    propertyName: "Aspect ratio",
+                    onInteroperableClick: null,
+                    changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.AspectRatio, value, projector.gameObject),
+                    resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.AspectRatio, projector.gameObject),
+                    valueFloatOriginal: 1f,
+                    minValue: 0.01f,
+                    maxValue: 20f
+                );
+                AddFloatslider
+                (
+                    valueFloat: Convert.ToSingle(projector.orthographic),
+                    propertyName: "Orthographic",
+                    onInteroperableClick: null,
+                    changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.Orthographic, value, projector.gameObject),
+                    resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.Orthographic, projector.gameObject),
+                    valueFloatOriginal: 0f,
+                    minValue: 0f,
+                    maxValue: 1f
+                );
+                AddFloatslider
+                (
+                    valueFloat: projector.orthographicSize,
+                    propertyName: "Orthographic Size",
+                    onInteroperableClick: null,
+                    changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, value, projector.gameObject),
+                    resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, projector.gameObject),
+                    valueFloatOriginal: 10f,
+                    minValue: 0f,
+                    maxValue: 20f
+                );
             }
 
-            void AddFloatslider(float valueFloat, string propertyName, Action onInteroperableClick, Action<float> changeValue, Action<float> resetValue, float valueFloatOriginal, float? minValue = null, float? maxValue = null)
+            void AddFloatslider(float valueFloat, string propertyName, Action onInteroperableClick, Action<float> changeValue, Action resetValue, float valueFloatOriginal, float? minValue = null, float? maxValue = null)
             {
                 var contentItem = new ItemInfo(ItemInfo.RowItemType.FloatProperty, propertyName)
                 {
@@ -688,7 +747,7 @@ namespace MaterialEditorAPI
                 if (maxValue != null)
                     contentItem.FloatValueSliderMax = (float)maxValue;
                 contentItem.FloatValueOnChange = value => changeValue(value);
-                contentItem.FloatValueOnReset = () => resetValue(valueFloatOriginal);
+                contentItem.FloatValueOnReset = () => resetValue();
                 items.Add(contentItem);
             }
         }
@@ -741,6 +800,11 @@ namespace MaterialEditorAPI
         public abstract string GetRendererPropertyValue(object data, Renderer renderer, RendererProperties property, GameObject gameObject);
         public abstract void SetRendererProperty(object data, Renderer renderer, RendererProperties property, string value, GameObject gameObject);
         public abstract void RemoveRendererProperty(object data, Renderer renderer, RendererProperties property, GameObject gameObject);
+
+        public abstract float? GetProjectorPropertyValueOriginal(object data, Projector renderer, ProjectorProperties property, GameObject gameObject);
+        public abstract float? GetProjectorPropertyValue(object data, Projector renderer, ProjectorProperties property, GameObject gameObject);
+        public abstract void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject gameObject);
+        public abstract void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject);
 
         public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject);
         public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -723,7 +723,7 @@ namespace MaterialEditorAPI
                         (
                             valueFloat: valueFloat,
                             propertyName: name,
-                            onInteroperableClick: () => SelectInterpolableButtonOnClick(go, property, projector.NameFormatted()),
+                            onInteroperableClick: () => SelectProjectorInterpolableButtonOnClick(go, property, projector.NameFormatted()),
                             changeValue: value => SetProjectorProperty(data, projector, property, value, projector.gameObject),
                             resetValue: () => RemoveProjectorProperty(data, projector, property, projector.gameObject),
                             valueFloatOriginal: originalValueTemp != null ? (float)originalValueTemp : valueFloat,
@@ -886,7 +886,7 @@ namespace MaterialEditorAPI
 #endif
         }
 
-        private void SelectInterpolableButtonOnClick(GameObject go, ProjectorProperties property, string projectorName)
+        private void SelectProjectorInterpolableButtonOnClick(GameObject go, ProjectorProperties property, string projectorName)
         {
             selectedProjectorInterpolable = new SelectedProjectorInterpolable(go, property, projectorName);
             MaterialEditorPluginBase.Logger.LogMessage($"Activated interpolable(s), {selectedProjectorInterpolable}");

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using static MaterialEditorAPI.MaterialAPI;
 using static MaterialEditorAPI.MaterialEditorPluginBase;
+using static RootMotion.FinalIK.GrounderQuadruped;
 
 namespace MaterialEditorAPI
 {
@@ -677,78 +678,60 @@ namespace MaterialEditorAPI
 
             void PopulateProjectorSettings(Projector projector)
             {
-                if(filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Near Clip Plane", filterWord)))
-                    AddFloatslider
-                    (
-                        valueFloat: projector.nearClipPlane,
-                        propertyName: "Near Clip Plane",
-                        onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.NearClipPlane, projector.NameFormatted()),
-                        changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, value, projector.gameObject),
-                        resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, projector.gameObject),
-                        valueFloatOriginal: 0.1f,
-                        minValue: 0.01f,
-                        maxValue: ProjectorNearClipPlaneMax.Value
-                    );
-                if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Far Clip Plane", filterWord)))
-                    AddFloatslider
-                    (
-                        valueFloat: projector.farClipPlane,
-                        propertyName: "Far Clip Plane",
-                        onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.FarClipPlane, projector.NameFormatted()),
-                        changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, value, projector.gameObject),
-                        resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, projector.gameObject),
-                        valueFloatOriginal: 20f,
-                        minValue: 0.01f,
-                        maxValue: ProjectorFarClipPlaneMax.Value
-                    );
-                if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Field Of View", filterWord)))
-                    AddFloatslider
-                    (
-                        valueFloat: projector.fieldOfView,
-                        propertyName: "Field Of View",
-                        onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.FieldOfView, projector.NameFormatted()),
-                        changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.FieldOfView, value, projector.gameObject),
-                        resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FieldOfView, projector.gameObject),
-                        valueFloatOriginal: 60f,
-                        minValue: 0.01f,
-                        maxValue: ProjectorFieldOfViewMax.Value
-                    );
-                if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Aspect ratio", filterWord)))
-                    AddFloatslider
-                    (
-                        valueFloat: projector.aspectRatio,
-                        propertyName: "Aspect ratio",
-                        onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.AspectRatio, projector.NameFormatted()),
-                        changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.AspectRatio, value, projector.gameObject),
-                        resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.AspectRatio, projector.gameObject),
-                        valueFloatOriginal: 1f,
-                        minValue: 0.01f,
-                        maxValue: ProjectorAspectRatioMax.Value
-                    );
-                if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Orthographic", filterWord)))
-                    AddFloatslider
-                    (
-                        valueFloat: Convert.ToSingle(projector.orthographic),
-                        propertyName: "Orthographic",
-                        onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.Orthographic, projector.NameFormatted()),
-                        changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.Orthographic, value, projector.gameObject),
-                        resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.Orthographic, projector.gameObject),
-                        valueFloatOriginal: 0f,
-                        minValue: 0f,
-                        maxValue: 1f
-                    );
-                if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Orthographic Size", filterWord)))
-                    AddFloatslider
-                    (
-                        valueFloat: projector.orthographicSize,
-                        propertyName: "Orthographic Size",
-                        onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.OrthographicSize, projector.NameFormatted()),
-                        changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, value, projector.gameObject),
-                        resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, projector.gameObject),
-                        valueFloatOriginal: 10f,
-                        minValue: 0f,
-                        maxValue: ProjectorOrthographicSizeMax.Value
-                    );
+                foreach (var property in Enum.GetValues(typeof(ProjectorProperties)).Cast<ProjectorProperties>().Where(prop => prop != ProjectorProperties.Enabled))
+                {
+                    float maxValue = 100f;
+                    string name = "";
+                    float valueFloat = 0f;
+                    float? originalValueTemp = GetProjectorPropertyValueOriginal(data, projector, property, go);
+
+                    switch (property)
+                    {
+                        case ProjectorProperties.NearClipPlane:
+                            name = "Near Clip Plane";
+                            valueFloat = projector.nearClipPlane;
+                            maxValue = ProjectorNearClipPlaneMax.Value;
+                            break;
+                        case ProjectorProperties.FarClipPlane:
+                            name = "Far Clip Plane";
+                            valueFloat = projector.farClipPlane;
+                            maxValue = ProjectorFarClipPlaneMax.Value;
+                            break;
+                        case ProjectorProperties.FieldOfView:
+                            name = "Field Of View";
+                            valueFloat = projector.fieldOfView;
+                            maxValue = ProjectorFieldOfViewMax.Value;
+                            break;
+                        case ProjectorProperties.AspectRatio:
+                            name = "Aspect Ratio";
+                            valueFloat = projector.aspectRatio;
+                            maxValue = ProjectorAspectRatioMax.Value;
+                            break;
+                        case ProjectorProperties.Orthographic:
+                            name = "Orthographic";
+                            valueFloat = Convert.ToSingle(projector.orthographic);
+                            maxValue = 1f;
+                            break;
+                        case ProjectorProperties.OrthographicSize:
+                            name = "Orthographic Size";
+                            valueFloat = projector.orthographicSize;
+                            maxValue = ProjectorOrthographicSizeMax.Value;
+                            break;
+                    }
+
+                    if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch(name, filterWord)))
+                        AddFloatslider
+                        (
+                            valueFloat: valueFloat,
+                            propertyName: name,
+                            onInteroperableClick: () => SelectInterpolableButtonOnClick(go, property, projector.NameFormatted()),
+                            changeValue: value => SetProjectorProperty(data, projector, property, value, projector.gameObject),
+                            resetValue: () => RemoveProjectorProperty(data, projector, property, projector.gameObject),
+                            valueFloatOriginal: originalValueTemp != null ? (float)originalValueTemp : valueFloat,
+                            minValue: 0f,
+                            maxValue: maxValue
+                        );
+                }
             }
 
             void AddFloatslider(float valueFloat, string propertyName, Action onInteroperableClick, Action<float> changeValue, Action resetValue, float valueFloatOriginal, float? minValue = null, float? maxValue = null)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -74,6 +74,7 @@ namespace MaterialEditorAPI
         private Renderer ObjRenderer;
 
         internal static SelectedInterpolable selectedInterpolable;
+        internal static SelectedProjectorInterpolable selectedProjectorInterpolable;
 
         /// <summary>
         /// Initialize the MaterialEditor UI
@@ -670,7 +671,7 @@ namespace MaterialEditorAPI
                 (
                     valueFloat: projector.nearClipPlane,
                     propertyName: "Near Clip Plane",
-                    onInteroperableClick: null,
+                    onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.NearClipPlane, projector.NameFormatted()),
                     changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, value, projector.gameObject),
                     resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, projector.gameObject),
                     valueFloatOriginal: 0.1f,
@@ -681,7 +682,7 @@ namespace MaterialEditorAPI
                 (
                     valueFloat: projector.farClipPlane,
                     propertyName: "Far Clip Plane",
-                    onInteroperableClick: null,
+                    onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.FarClipPlane, projector.NameFormatted()),
                     changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, value, projector.gameObject),
                     resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, projector.gameObject),
                     valueFloatOriginal: 20f,
@@ -692,7 +693,7 @@ namespace MaterialEditorAPI
                 (
                     valueFloat: projector.fieldOfView,
                     propertyName: "Field Of View",
-                    onInteroperableClick: null,
+                    onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.FieldOfView, projector.NameFormatted()),
                     changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.FieldOfView, value, projector.gameObject),
                     resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FieldOfView, projector.gameObject),
                     valueFloatOriginal: 60f,
@@ -703,7 +704,7 @@ namespace MaterialEditorAPI
                 (
                     valueFloat: projector.aspectRatio,
                     propertyName: "Aspect ratio",
-                    onInteroperableClick: null,
+                    onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.AspectRatio, projector.NameFormatted()),
                     changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.AspectRatio, value, projector.gameObject),
                     resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.AspectRatio, projector.gameObject),
                     valueFloatOriginal: 1f,
@@ -714,7 +715,7 @@ namespace MaterialEditorAPI
                 (
                     valueFloat: Convert.ToSingle(projector.orthographic),
                     propertyName: "Orthographic",
-                    onInteroperableClick: null,
+                    onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.Orthographic, projector.NameFormatted()),
                     changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.Orthographic, value, projector.gameObject),
                     resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.Orthographic, projector.gameObject),
                     valueFloatOriginal: 0f,
@@ -725,7 +726,7 @@ namespace MaterialEditorAPI
                 (
                     valueFloat: projector.orthographicSize,
                     propertyName: "Orthographic Size",
-                    onInteroperableClick: null,
+                    onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ProjectorProperties.OrthographicSize, projector.NameFormatted()),
                     changeValue: value => SetProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, value, projector.gameObject),
                     resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, projector.gameObject),
                     valueFloatOriginal: 10f,
@@ -886,6 +887,15 @@ namespace MaterialEditorAPI
 #endif
         }
 
+        private void SelectInterpolableButtonOnClick(GameObject go, ProjectorProperties property, string projectorName)
+        {
+            selectedProjectorInterpolable = new SelectedProjectorInterpolable(go, property, projectorName);
+            MaterialEditorPluginBase.Logger.LogMessage($"Activated interpolable(s), {selectedProjectorInterpolable}");
+#if !API && !EC
+            TimelineCompatibilityHelper.RefreshInterpolablesList();
+#endif
+        }
+
         internal class SelectedInterpolable
         {
             public string MaterialName;
@@ -906,6 +916,25 @@ namespace MaterialEditorAPI
             public override string ToString()
             {
                 return $"{RowType}: {string.Join(" - ", new string[] { PropertyName, MaterialName, RendererName,  }.Where(x => !x.IsNullOrEmpty()).ToArray())}";
+            }
+        }
+
+        internal class SelectedProjectorInterpolable
+        {
+            public string ProjectorName;
+            public ProjectorProperties Property;
+            public GameObject GameObject;
+
+            public SelectedProjectorInterpolable(GameObject go, ProjectorProperties property, string projectorName)
+            {
+                GameObject = go;
+                Property = property;
+                ProjectorName = projectorName;
+            }
+
+            public override string ToString()
+            {
+                return $"Projector: {string.Join(" - ", new string[] { Property.ToString(), ProjectorName, }.Where(x => !x.IsNullOrEmpty()).ToArray())}";
             }
         }
     }

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -677,7 +677,7 @@ namespace MaterialEditorAPI
 
             void PopulateProjectorSettings(Projector projector)
             {
-                foreach (var property in Enum.GetValues(typeof(ProjectorProperties)).Cast<ProjectorProperties>().Where(prop => prop != ProjectorProperties.Enabled))
+                foreach (var property in Enum.GetValues(typeof(ProjectorProperties)).Cast<ProjectorProperties>())
                 {
                     float maxValue = 100f;
                     string name = "";
@@ -686,6 +686,11 @@ namespace MaterialEditorAPI
 
                     switch (property)
                     {
+                        case ProjectorProperties.Enabled:
+                            name = "Enabled";
+                            valueFloat = Convert.ToSingle(projector.enabled);
+                            maxValue = 1f;
+                            break;
                         case ProjectorProperties.NearClipPlane:
                             name = "Near Clip Plane";
                             valueFloat = projector.nearClipPlane;

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -460,14 +460,14 @@ namespace MaterialEditorAPI
                 var materialItem = new ItemInfo(ItemInfo.RowItemType.Material, "Material")
                 {
                     MaterialName = materialName,
-                    MaterialOnCopy = () => MaterialCopyEdits(data, mat, go, projector),
+                    MaterialOnCopy = () => MaterialCopyEdits(data, mat, go),
                     MaterialOnPaste = () =>
                     {
-                        MaterialPasteEdits(data, mat, go, projector);
+                        MaterialPasteEdits(data, mat, go);
                         PopulateList(go, data, filter);
                     }
                 };
-                //Projectors only support 1 material. Copy button is hidden the function is null
+                //Projectors only support 1 material. Copy button is hidden if the function is null
                 if (projector == null)
                     materialItem.MaterialOnCopyRemove = () =>
                     {
@@ -809,8 +809,8 @@ namespace MaterialEditorAPI
         public abstract void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject gameObject);
         public abstract void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject);
 
-        public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject, Projector projector = null);
-        public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject, Projector projector = null);
+        public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject);
+        public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject);
         public abstract void MaterialCopyRemove(object data, Material material, GameObject gameObject);
 
         public abstract string GetMaterialShaderNameOriginal(object data, Material material, GameObject gameObject);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -687,7 +687,7 @@ namespace MaterialEditorAPI
                         resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.NearClipPlane, projector.gameObject),
                         valueFloatOriginal: 0.1f,
                         minValue: 0.01f,
-                        maxValue: 10f
+                        maxValue: ProjectorNearClipPlaneMax.Value
                     );
                 if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Far Clip Plane", filterWord)))
                     AddFloatslider
@@ -699,7 +699,7 @@ namespace MaterialEditorAPI
                         resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FarClipPlane, projector.gameObject),
                         valueFloatOriginal: 20f,
                         minValue: 0.01f,
-                        maxValue: 100f
+                        maxValue: ProjectorFarClipPlaneMax.Value
                     );
                 if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Field Of View", filterWord)))
                     AddFloatslider
@@ -711,7 +711,7 @@ namespace MaterialEditorAPI
                         resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.FieldOfView, projector.gameObject),
                         valueFloatOriginal: 60f,
                         minValue: 0.01f,
-                        maxValue: 180f
+                        maxValue: ProjectorFieldOfViewMax.Value
                     );
                 if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Aspect ratio", filterWord)))
                     AddFloatslider
@@ -723,7 +723,7 @@ namespace MaterialEditorAPI
                         resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.AspectRatio, projector.gameObject),
                         valueFloatOriginal: 1f,
                         minValue: 0.01f,
-                        maxValue: 20f
+                        maxValue: ProjectorAspectRatioMax.Value
                     );
                 if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch("Orthographic", filterWord)))
                     AddFloatslider
@@ -747,7 +747,7 @@ namespace MaterialEditorAPI
                         resetValue: () => RemoveProjectorProperty(data, projector, ProjectorProperties.OrthographicSize, projector.gameObject),
                         valueFloatOriginal: 10f,
                         minValue: 0f,
-                        maxValue: 20f
+                        maxValue: ProjectorOrthographicSizeMax.Value
                     );
             }
 

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -305,10 +305,8 @@ namespace MaterialEditorAPI
 
             List<Renderer> rendList = new List<Renderer>();
             IEnumerable<Renderer> rendListFull = GetRendererList(go);
-            MaterialEditorPluginBase.Logger.LogInfo($"rendlistFul count: {rendListFull.Count()}");
             List<Projector> projectorList = new List<Projector>();
             IEnumerable<Projector> projectorListFull = GetProjectorList(go);
-            MaterialEditorPluginBase.Logger.LogInfo($"projectorList count: {projectorListFull.Count()}");
             List<string> filterList = new List<string>();
             List<string> filterListProperties = new List<string>();
             List<ItemInfo> items = new List<ItemInfo>();
@@ -355,17 +353,13 @@ namespace MaterialEditorAPI
                             projectorList.Add(projector);
             }
 
-            MaterialEditorPluginBase.Logger.LogInfo($"rendList count: {rendList.Count()}");
             for (var i = 0; i < rendList.Count; i++)
             {
                 var rend = rendList[i];
-                MaterialEditorPluginBase.Logger.LogInfo($"rendList count: {rend.NameFormatted()}");
                 //Get materials if materials list wasn't previously built by the filter    
                 if (filterList.Count == 0)
-                {
                     foreach (var mat in SelectedMaterials.Count == 0 ? GetMaterials(go, rend) : GetMaterials(go, rend).Where(mat => SelectedMaterials.Contains(mat)))
                         matList[mat.NameFormatted()] = mat;
-                }
 
                 var rendererItem = new ItemInfo(ItemInfo.RowItemType.Renderer, "Renderer")
                 {

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -721,6 +721,16 @@ namespace MaterialEditorAPI
                             valueFloat = projector.orthographicSize;
                             maxValue = ProjectorOrthographicSizeMax.Value;
                             break;
+                        case ProjectorProperties.IgnoreMapLayer:
+                            name = "Ignore Map layer";
+                            valueFloat = Convert.ToSingle(projector.ignoreLayers == (projector.ignoreLayers | (1 << 11)));
+                            maxValue = 1f;
+                            break;
+                        case ProjectorProperties.IgnoreCharaLayer:
+                            name = "Ignore Chara Layer";
+                            valueFloat = Convert.ToSingle(projector.ignoreLayers == (projector.ignoreLayers | (1 << 10)));
+                            maxValue = 1f;
+                            break;
                     }
 
                     if (filterListProperties.Count == 0 || filterListProperties.Any(filterWord => WildCardSearch(name, filterWord)))

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -467,12 +467,14 @@ namespace MaterialEditorAPI
                         PopulateList(go, data, filter);
                     }
                 };
-                materialItem.MaterialOnCopyRemove = () =>
-                {
-                    MaterialCopyRemove(data, mat, go);
-                    PopulateList(go, data, filter);
-                    PopulateMaterialList(go, data, rendListFull);
-                };
+                //Projectors only support 1 material. Copy button is hidden the function is null
+                if (projector == null)
+                    materialItem.MaterialOnCopyRemove = () =>
+                    {
+                        MaterialCopyRemove(data, mat, go);
+                        PopulateList(go, data, filter);
+                        PopulateMaterialList(go, data, rendListFull);
+                    };
                 items.Add(materialItem);
 
                 //Shader

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -10,7 +10,6 @@ using UnityEngine;
 using UnityEngine.UI;
 using static MaterialEditorAPI.MaterialAPI;
 using static MaterialEditorAPI.MaterialEditorPluginBase;
-using static RootMotion.FinalIK.GrounderQuadruped;
 
 namespace MaterialEditorAPI
 {
@@ -307,7 +306,7 @@ namespace MaterialEditorAPI
             List<Renderer> rendList = new List<Renderer>();
             IEnumerable<Renderer> rendListFull = GetRendererList(go);
             List<Projector> projectorList = new List<Projector>();
-            IEnumerable<Projector> projectorListFull = GetProjectorList(go);
+            IEnumerable<Projector> projectorListFull = GetProjectorList(data, go);
             List<string> filterList = new List<string>();
             List<string> filterListProperties = new List<string>();
             List<ItemInfo> items = new List<ItemInfo>();
@@ -805,6 +804,7 @@ namespace MaterialEditorAPI
         public abstract float? GetProjectorPropertyValue(object data, Projector renderer, ProjectorProperties property, GameObject gameObject);
         public abstract void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject gameObject);
         public abstract void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject);
+        public abstract IEnumerable<Projector> GetProjectorList(object data, GameObject gameObject);
 
         public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject);
         public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -459,10 +459,10 @@ namespace MaterialEditorAPI
                 var materialItem = new ItemInfo(ItemInfo.RowItemType.Material, "Material")
                 {
                     MaterialName = materialName,
-                    MaterialOnCopy = () => MaterialCopyEdits(data, mat, go),
+                    MaterialOnCopy = () => MaterialCopyEdits(data, mat, go, projector),
                     MaterialOnPaste = () =>
                     {
-                        MaterialPasteEdits(data, mat, go);
+                        MaterialPasteEdits(data, mat, go, projector);
                         PopulateList(go, data, filter);
                     }
                 };
@@ -806,8 +806,8 @@ namespace MaterialEditorAPI
         public abstract void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject gameObject);
         public abstract void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject);
 
-        public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject);
-        public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject);
+        public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject, Projector projector = null);
+        public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject, Projector projector = null);
         public abstract void MaterialCopyRemove(object data, Material material, GameObject gameObject);
 
         public abstract string GetMaterialShaderNameOriginal(object data, Material material, GameObject gameObject);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -625,24 +625,22 @@ namespace MaterialEditorAPI
                     {
                         if (mat.HasProperty($"_{propertyName}"))
                         {
-                            float valueFloat = mat.GetFloat($"_{propertyName}");
-                            float valueFloatOriginal = valueFloat;
+                            float valueFloatOriginal = mat.GetFloat($"_{propertyName}");
                             float? valueFloatOriginalTemp = GetMaterialFloatPropertyValueOriginal(data, mat, propertyName, go);
                             if (valueFloatOriginalTemp != null)
                                 valueFloatOriginal = (float)valueFloatOriginalTemp;
-                            var contentItem = new ItemInfo(ItemInfo.RowItemType.FloatProperty, propertyName)
-                            {
-                                FloatValue = valueFloat,
-                                FloatValueOriginal = valueFloatOriginal,
-                                SelectInterpolableButtonFloatOnClick = () => SelectInterpolableButtonOnClick(go, ItemInfo.RowItemType.FloatProperty, materialName, propertyName)
-                            };
-                            if (property.Value.MinValue != null)
-                                contentItem.FloatValueSliderMin = (float)property.Value.MinValue;
-                            if (property.Value.MaxValue != null)
-                                contentItem.FloatValueSliderMax = (float)property.Value.MaxValue;
-                            contentItem.FloatValueOnChange = value => SetMaterialFloatProperty(data, mat, propertyName, value, go);
-                            contentItem.FloatValueOnReset = () => RemoveMaterialFloatProperty(data, mat, propertyName, go);
-                            items.Add(contentItem);
+
+                            AddFloatslider
+                            (
+                                valueFloat: mat.GetFloat($"_{propertyName}"),
+                                propertyName: propertyName,
+                                onInteroperableClick: () => SelectInterpolableButtonOnClick(go, ItemInfo.RowItemType.FloatProperty, materialName, propertyName),
+                                changeValue: value => SetMaterialFloatProperty(data, mat, propertyName, value, go),
+                                resetValue: value => RemoveMaterialFloatProperty(data, mat, propertyName, go),
+                                valueFloatOriginal: valueFloatOriginal,
+                                minValue: property.Value.MinValue,
+                                maxValue: property.Value.MaxValue
+                            );
                         }
                     }
                     else if (property.Value.Type == ShaderPropertyType.Keyword)
@@ -669,11 +667,12 @@ namespace MaterialEditorAPI
 
             void PopulateProjectorSettings(Projector projector)
             {
-                AddFloatslider(projector.nearClipPlane, "Near Clip Plane", null, value => projector.nearClipPlane = value, value => projector.nearClipPlane = value, 0.1f, 0.01f, 100f);
+                AddFloatslider(projector.nearClipPlane, "Near Clip Plane", null, value => projector.nearClipPlane = value, value => projector.nearClipPlane = value, 0.1f, 0.01f, 10f);
                 AddFloatslider(projector.farClipPlane, "Far Clip Plane", null, value => projector.farClipPlane = value, value => projector.farClipPlane = value, 20f, 0.01f, 100f);
                 AddFloatslider(projector.fieldOfView, "Field Of View", null, value => projector.fieldOfView = value, value => projector.fieldOfView = value, 60f, 0.01f, 180f);
-                AddFloatslider(projector.aspectRatio, "Aspect ratio", null, value => projector.aspectRatio = value, value => projector.aspectRatio = value, 1f, 0.01f, 100f);
-                AddFloatslider(projector.orthographicSize, "Orthographic Size", null, value => projector.orthographicSize = value, value => projector.orthographicSize = value, 10f, 0.01f, 100f);
+                AddFloatslider(projector.aspectRatio, "Aspect ratio", null, value => projector.aspectRatio = value, value => projector.aspectRatio = value, 1f, 0.01f, 20f);
+                AddFloatslider(Convert.ToSingle(projector.orthographic), "Orthographic", null, value => projector.orthographic = Convert.ToBoolean(value), value => projector.orthographic = Convert.ToBoolean(value), 0f, 0f, 1f);
+                AddFloatslider(projector.orthographicSize, "Orthographic Size", null, value => projector.orthographicSize = value, value => projector.orthographicSize = value, 10f, 0.01f, 20f);
             }
 
             void AddFloatslider(float valueFloat, string propertyName, Action onInteroperableClick, Action<float> changeValue, Action<float> resetValue, float valueFloatOriginal, float? minValue = null, float? maxValue = null)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -485,6 +485,9 @@ namespace MaterialEditorAPI
                     };
                 items.Add(materialItem);
 
+                if (projector != null)
+                    PopulateProjectorSettings(projector);
+
                 //Shader
                 string shaderNameOriginal = shaderName;
                 var temp = GetMaterialShaderNameOriginal(data, mat, go);
@@ -520,9 +523,6 @@ namespace MaterialEditorAPI
                     ShaderRenderQueueOnReset = () => RemoveMaterialShaderRenderQueue(data, mat, go)
                 };
                 items.Add(shaderRenderQueueItem);
-
-                if (projector != null)
-                    PopulateProjectorSettings(projector);
 
                 foreach (var property in XMLShaderProperties[XMLShaderProperties.ContainsKey(shaderName) ? shaderName : "default"].OrderBy(x => x.Value.Type).ThenBy(x => x.Key))
                 {

--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -4,6 +4,7 @@ using KKAPI;
 using KKAPI.Maker;
 using KKAPI.Maker.UI;
 using MaterialEditorAPI;
+using System;
 using System.Collections;
 using UnityEngine;
 using static MaterialEditorAPI.MaterialAPI;
@@ -317,6 +318,26 @@ namespace KK_Plugins.MaterialEditor
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).RemoveRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, go);
+        }
+
+        public override float? GetProjectorPropertyValueOriginal(object data, Projector renderer, ProjectorProperties property, GameObject gameObject)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override float? GetProjectorPropertyValue(object data, Projector renderer, ProjectorProperties property, GameObject gameObject)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject gameObject)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
+        {
+            throw new NotImplementedException();
         }
 
         public override void MaterialCopyEdits(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -320,24 +320,28 @@ namespace KK_Plugins.MaterialEditor
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).RemoveRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, go);
         }
 
-        public override float? GetProjectorPropertyValueOriginal(object data, Projector renderer, ProjectorProperties property, GameObject gameObject)
+        public override float? GetProjectorPropertyValueOriginal(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
         {
-            throw new NotImplementedException();
+            ObjectData objectData = (ObjectData)data;
+            return MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).GetProjectorPropertyValueOriginal(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
         }
 
-        public override float? GetProjectorPropertyValue(object data, Projector renderer, ProjectorProperties property, GameObject gameObject)
+        public override float? GetProjectorPropertyValue(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
         {
-            throw new NotImplementedException();
+            ObjectData objectData = (ObjectData)data;
+            return MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).GetProjectorPropertyValue(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
         }
 
         public override void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject gameObject)
         {
-            throw new NotImplementedException();
+            ObjectData objectData = (ObjectData)data;
+            MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).SetProjectorProperty(objectData.Slot, objectData.ObjectType, projector, property, value, gameObject);
         }
 
         public override void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
         {
-            throw new NotImplementedException();
+            ObjectData objectData = (ObjectData)data;
+            MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).RemoveProjectorProperty(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
         }
 
         public override void MaterialCopyEdits(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -4,8 +4,8 @@ using KKAPI;
 using KKAPI.Maker;
 using KKAPI.Maker.UI;
 using MaterialEditorAPI;
-using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using static MaterialEditorAPI.MaterialAPI;
 #if AI || HS2
@@ -342,6 +342,11 @@ namespace KK_Plugins.MaterialEditor
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).RemoveProjectorProperty(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
+        }
+        public override IEnumerable<Projector> GetProjectorList(object data, GameObject gameObject)
+        {
+            ObjectData objectData = (ObjectData)data;
+            return MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).GetProjectorList(objectData.ObjectType, gameObject);
         }
 
         public override void MaterialCopyEdits(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -340,12 +340,12 @@ namespace KK_Plugins.MaterialEditor
             throw new NotImplementedException();
         }
 
-        public override void MaterialCopyEdits(object data, Material material, GameObject go, Projector projector = null)
+        public override void MaterialCopyEdits(object data, Material material, GameObject go)
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).MaterialCopyEdits(objectData.Slot, objectData.ObjectType, material, go);
         }
-        public override void MaterialPasteEdits(object data, Material material, GameObject go, Projector projector = null)
+        public override void MaterialPasteEdits(object data, Material material, GameObject go)
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).MaterialPasteEdits(objectData.Slot, objectData.ObjectType, material, go);

--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -340,12 +340,12 @@ namespace KK_Plugins.MaterialEditor
             throw new NotImplementedException();
         }
 
-        public override void MaterialCopyEdits(object data, Material material, GameObject go)
+        public override void MaterialCopyEdits(object data, Material material, GameObject go, Projector projector = null)
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).MaterialCopyEdits(objectData.Slot, objectData.ObjectType, material, go);
         }
-        public override void MaterialPasteEdits(object data, Material material, GameObject go)
+        public override void MaterialPasteEdits(object data, Material material, GameObject go, Projector projector = null)
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).MaterialPasteEdits(objectData.Slot, objectData.ObjectType, material, go);

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -283,6 +283,12 @@ namespace KK_Plugins.MaterialEditor
                     }
                 }
             }
+
+            //Turn projectors off if the item (or one of its parents) is toggled off
+            foreach (var objectCtrlInfo in loadedItems.Values)
+                if (objectCtrlInfo is OCIItem item)
+                    foreach (var projector in item.objectItem.GetComponentsInChildren<Projector>())
+                        projector.enabled = item.visible;
         }
 
         /// <summary>
@@ -629,6 +635,10 @@ namespace KK_Plugins.MaterialEditor
                         MaterialAPI.SetRendererProperty(GetObjectByID(id), property.RendererName, property.Property, property.Value);
                         // potential recalc of normals, have to test...
                     }
+
+                //Turn projector off if the item (or one of its parents) is toggled off
+                foreach (var projector in item.objectItem.GetComponentsInChildren<Projector>())
+                    projector.enabled = item.visible;
             }
 
 

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -620,18 +620,15 @@ namespace KK_Plugins.MaterialEditor
 
         protected override void OnObjectVisibilityToggled(ObjectCtrlInfo objectCtrlInfo, bool visible)
         {
-            if (objectCtrlInfo is OCIItem item)
+            if (visible && objectCtrlInfo is OCIItem item)
             {
                 var id = item.GetSceneId();
-                if(visible)
-                    foreach (var property in RendererPropertyList.Where(x => x.ID == id && x.Property == RendererProperties.Enabled))
-                    {
-                        MaterialAPI.SetRendererProperty(GetObjectByID(id), property.RendererName, property.Property, property.Value);
-                        // potential recalc of normals, have to test...
-                    }
+                foreach (var property in RendererPropertyList.Where(x => x.ID == id && x.Property == RendererProperties.Enabled))
+                {
+                    MaterialAPI.SetRendererProperty(GetObjectByID(id), property.RendererName, property.Property, property.Value);
+                    // potential recalc of normals, have to test...
+                }
             }
-
-
             base.OnObjectVisibilityToggled(objectCtrlInfo, visible);
         }
 

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -591,6 +591,8 @@ namespace KK_Plugins.MaterialEditor
                             MaterialPasteEdits(ociItem.objectInfo.dicKey, mat);
                         }
                     }
+                    foreach(var projector in GetProjectorList(ociItem.objectItem))
+                        MaterialPasteEdits(ociItem.objectInfo.dicKey, projector.material, projector: projector);
                 }
             foreach (var child in node.child)
                 PasteEditsRecursive(child, ref count);
@@ -684,7 +686,8 @@ namespace KK_Plugins.MaterialEditor
         /// </summary>
         /// <param name="id">Item ID as found in studio's dicObjectCtrl</param>
         /// <param name="material">Material being modified. Also modifies all other materials of the same name.</param>
-        public void MaterialCopyEdits(int id, Material material)
+        /// <param name="projector">Projector being modified</param>
+        public void MaterialCopyEdits(int id, Material material, Projector projector = null)
         {
             CopyData.ClearAll();
 
@@ -723,6 +726,13 @@ namespace KK_Plugins.MaterialEditor
                         CopyData.MaterialTexturePropertyList.Add(new CopyContainer.MaterialTextureProperty(materialTextureProperty.Property, null, materialTextureProperty.Offset, materialTextureProperty.Scale));
                 }
             }
+            if (projector != null)
+                for (var i = 0; i < ProjectorPropertyList.Count; i++)
+                {
+                    var projectorProperty = ProjectorPropertyList[i];
+                    if (projectorProperty.ID == id && projectorProperty.ProjectorName == projector.NameFormatted())
+                        CopyData.ProjectorPropertyList.Add(new CopyContainer.ProjectorProperty(projectorProperty.Property, float.Parse(projectorProperty.Value)));
+                }
         }
         /// <summary>
         /// Paste any edits for the specified object
@@ -730,7 +740,8 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="id">Item ID as found in studio's dicObjectCtrl</param>
         /// <param name="material">Material being modified. Also modifies all other materials of the same name.</param>
         /// <param name="setProperty">Whether to also apply the value to the materials</param>
-        public void MaterialPasteEdits(int id, Material material, bool setProperty = true)
+        /// <param name="projector">Projector being modified</param>
+        public void MaterialPasteEdits(int id, Material material, bool setProperty = true, Projector projector = null)
         {
             for (var i = 0; i < CopyData.MaterialShaderList.Count; i++)
             {
@@ -767,6 +778,12 @@ namespace KK_Plugins.MaterialEditor
                 if (materialTextureProperty.Scale != null)
                     SetMaterialTextureScale(id, material, materialTextureProperty.Property, (Vector2)materialTextureProperty.Scale, setProperty);
             }
+            if(projector != null)
+                for (var i = 0; i < CopyData.ProjectorPropertyList.Count; i++)
+                {
+                    var projectorProperty = CopyData.ProjectorPropertyList[i];
+                    SetProjectorProperty(id, projector, projectorProperty.Property, projectorProperty.Value, setProperty);
+                }
         }
         public void MaterialCopyRemove(int id, Material material, GameObject go, bool setProperty = true)
         {

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -912,6 +912,13 @@ namespace KK_Plugins.MaterialEditor
                 MaterialAPI.SetProjectorProperty(go, projector.NameFormatted(), property, value);
         }
 
+        public IEnumerable<Projector> GetProjectorList(GameObject gameObject)
+        {
+            //Assume the projector component will always be attached to the root object
+            //Otherwise no distinction can be made between projectors and editing them will not work properly
+            return MaterialAPI.GetProjectorList(gameObject, false);
+        }
+
         #region Set, Get, Remove methods
         /// <summary>
         /// Add a renderer property to be saved and loaded with the scene and optionally also update the renderer.

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -283,12 +283,6 @@ namespace KK_Plugins.MaterialEditor
                     }
                 }
             }
-
-            //Turn projectors off if the item (or one of its parents) is toggled off
-            foreach (var objectCtrlInfo in loadedItems.Values)
-                if (objectCtrlInfo is OCIItem item)
-                    foreach (var projector in item.objectItem.GetComponentsInChildren<Projector>())
-                        projector.enabled = item.visible;
         }
 
         /// <summary>
@@ -635,10 +629,6 @@ namespace KK_Plugins.MaterialEditor
                         MaterialAPI.SetRendererProperty(GetObjectByID(id), property.RendererName, property.Property, property.Value);
                         // potential recalc of normals, have to test...
                     }
-
-                //Turn projector off if the item (or one of its parents) is toggled off
-                foreach (var projector in item.objectItem.GetComponentsInChildren<Projector>())
-                    projector.enabled = item.visible;
             }
 
 

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -592,7 +592,7 @@ namespace KK_Plugins.MaterialEditor
                         }
                     }
                     foreach(var projector in GetProjectorList(ociItem.objectItem))
-                        MaterialPasteEdits(ociItem.objectInfo.dicKey, projector.material, projector: projector);
+                        MaterialPasteEdits(ociItem.objectInfo.dicKey, projector.material);
                 }
             foreach (var child in node.child)
                 PasteEditsRecursive(child, ref count);
@@ -681,7 +681,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="id">Item ID as found in studio's dicObjectCtrl</param>
         /// <param name="material">Material being modified. Also modifies all other materials of the same name.</param>
         /// <param name="projector">Projector being modified</param>
-        public void MaterialCopyEdits(int id, Material material, Projector projector = null)
+        public void MaterialCopyEdits(int id, Material material)
         {
             CopyData.ClearAll();
 
@@ -720,11 +720,12 @@ namespace KK_Plugins.MaterialEditor
                         CopyData.MaterialTexturePropertyList.Add(new CopyContainer.MaterialTextureProperty(materialTextureProperty.Property, null, materialTextureProperty.Offset, materialTextureProperty.Scale));
                 }
             }
-            if (projector != null)
+
+            if (GetProjectorList(GetObjectByID(id)).First(x => x.material == material) != null)
                 for (var i = 0; i < ProjectorPropertyList.Count; i++)
                 {
                     var projectorProperty = ProjectorPropertyList[i];
-                    if (projectorProperty.ID == id && projectorProperty.ProjectorName == projector.NameFormatted())
+                    if (projectorProperty.ID == id)
                         CopyData.ProjectorPropertyList.Add(new CopyContainer.ProjectorProperty(projectorProperty.Property, float.Parse(projectorProperty.Value)));
                 }
         }
@@ -735,7 +736,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="material">Material being modified. Also modifies all other materials of the same name.</param>
         /// <param name="setProperty">Whether to also apply the value to the materials</param>
         /// <param name="projector">Projector being modified</param>
-        public void MaterialPasteEdits(int id, Material material, bool setProperty = true, Projector projector = null)
+        public void MaterialPasteEdits(int id, Material material, bool setProperty = true)
         {
             for (var i = 0; i < CopyData.MaterialShaderList.Count; i++)
             {
@@ -772,7 +773,9 @@ namespace KK_Plugins.MaterialEditor
                 if (materialTextureProperty.Scale != null)
                     SetMaterialTextureScale(id, material, materialTextureProperty.Property, (Vector2)materialTextureProperty.Scale, setProperty);
             }
-            if(projector != null)
+
+            var projector = GetProjectorList(GetObjectByID(id)).First(x => x.material == material);
+            if (projector != null)
                 for (var i = 0; i < CopyData.ProjectorPropertyList.Count; i++)
                 {
                     var projectorProperty = CopyData.ProjectorPropertyList[i];

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -629,9 +629,6 @@ namespace KK_Plugins.MaterialEditor
                         MaterialAPI.SetRendererProperty(GetObjectByID(id), property.RendererName, property.Property, property.Value);
                         // potential recalc of normals, have to test...
                     }
-
-                foreach (var property in ProjectorPropertyList.Where(x => x.ID == id && x.Property == ProjectorProperties.Enabled))
-                    MaterialAPI.SetProjectorProperty(GetObjectByID(id), property.ProjectorName, property.Property, Convert.ToSingle(visible));
             }
 
 
@@ -870,15 +867,11 @@ namespace KK_Plugins.MaterialEditor
             GameObject go = GetObjectByID(id);
             if (setProperty)
             {
-                MaterialEditorPluginBase.Logger.LogInfo("Removing property");
                 var original = GetProjectorPropertyValueOriginal(id, projector, property);
-                MaterialEditorPluginBase.Logger.LogInfo($"Original: {original}");
                 if (original != null)
                 {
-                    MaterialEditorPluginBase.Logger.LogInfo($"Original not null");
                     MaterialAPI.SetProjectorProperty(go, projector.NameFormatted(), property, (float)original);
-                } else
-                    MaterialEditorPluginBase.Logger.LogInfo($"Original null");
+                }
             }
 
             ProjectorPropertyList.RemoveAll(x => x.ID == id && x.Property == property && x.ProjectorName == projector.NameFormatted());

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -896,6 +896,10 @@ namespace KK_Plugins.MaterialEditor
                     valueOriginal = Convert.ToSingle(projector.orthographic).ToString(CultureInfo.InvariantCulture);
                 else if (property == ProjectorProperties.OrthographicSize)
                     valueOriginal = projector.orthographicSize.ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.IgnoreCharaLayer)
+                    valueOriginal = Convert.ToSingle(projector.ignoreLayers == (projector.ignoreLayers | (1 << 10))).ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.IgnoreMapLayer)
+                    valueOriginal = Convert.ToSingle(projector.ignoreLayers == (projector.ignoreLayers | (1 << 11))).ToString(CultureInfo.InvariantCulture);
 
                 if (valueOriginal != "")
                     ProjectorPropertyList.Add(new ProjectorProperty(id, projector.NameFormatted(), property, value.ToString(CultureInfo.InvariantCulture), valueOriginal));

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -721,7 +721,7 @@ namespace KK_Plugins.MaterialEditor
                 }
             }
 
-            if (GetProjectorList(GetObjectByID(id)).First(x => x.material == material) != null)
+            if (GetProjectorList(GetObjectByID(id)).FirstOrDefault(x => x.material == material) != null)
                 for (var i = 0; i < ProjectorPropertyList.Count; i++)
                 {
                     var projectorProperty = ProjectorPropertyList[i];
@@ -774,7 +774,7 @@ namespace KK_Plugins.MaterialEditor
                     SetMaterialTextureScale(id, material, materialTextureProperty.Property, (Vector2)materialTextureProperty.Scale, setProperty);
             }
 
-            var projector = GetProjectorList(GetObjectByID(id)).First(x => x.material == material);
+            var projector = GetProjectorList(GetObjectByID(id)).FirstOrDefault(x => x.material == material);
             if (projector != null)
                 for (var i = 0; i < CopyData.ProjectorPropertyList.Count; i++)
                 {

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -434,32 +434,28 @@ namespace KK_Plugins.MaterialEditor
         {
             if (data is ObjectData objectData)
             {
-                //var chaControl = go.GetComponentInParent<ChaControl>();
-                //MaterialEditorPlugin.GetCharaController(chaControl).SetRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, value, go);
-                throw new NotImplementedException();
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                return MaterialEditorPlugin.GetCharaController(chaControl).GetProjectorPropertyValueOriginal(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
             }
             else
                 return GetSceneController().GetProjectorPropertyValueOriginal((int)data, projector, property);
         }
-
         public override float? GetProjectorPropertyValue(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
         {
             if (data is ObjectData objectData)
             {
-                //var chaControl = go.GetComponentInParent<ChaControl>();
-                //MaterialEditorPlugin.GetCharaController(chaControl).SetRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, value, go);
-                throw new NotImplementedException();
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                return MaterialEditorPlugin.GetCharaController(chaControl).GetProjectorPropertyValue(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
             }
             else
                 return GetSceneController().GetProjectorPropertyValue((int)data, projector, property);
         }
-
         public override void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject go)
         {
             if (data is ObjectData objectData)
             {
-                //var chaControl = go.GetComponentInParent<ChaControl>();
-                //MaterialEditorPlugin.GetCharaController(chaControl).SetRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, value, go);
+                var chaControl = go.GetComponentInParent<ChaControl>();
+                MaterialEditorPlugin.GetCharaController(chaControl).SetProjectorProperty(objectData.Slot, objectData.ObjectType, projector, property, value, gameObject);
             }
             else
                 GetSceneController().SetProjectorProperty((int)data, projector, property, value);
@@ -468,8 +464,8 @@ namespace KK_Plugins.MaterialEditor
         {
             if (data is ObjectData objectData)
             {
-                //var chaControl = go.GetComponentInParent<ChaControl>();
-                //MaterialEditorPlugin.GetCharaController(chaControl).RemoveRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, go);
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                MaterialEditorPlugin.GetCharaController(chaControl).RemoveProjectorProperty(objectData.Slot, objectData.ObjectType, projector, property, gameObject);
             }
             else
                 GetSceneController().RemoveProjectorProperty((int)data, projector, property);

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -8,14 +8,11 @@ using MaterialEditorAPI;
 using Studio;
 using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using UILib;
-using UniRx;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
-using static Illusion.Utils;
 using static MaterialEditorAPI.MaterialAPI;
 #if AI || HS2
 using AIChara;

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -478,7 +478,7 @@ namespace KK_Plugins.MaterialEditor
                 GetSceneController().RemoveProjectorProperty((int)data, projector, property);
         }
 
-        public override void MaterialCopyEdits(object data, Material material, GameObject go)
+        public override void MaterialCopyEdits(object data, Material material, GameObject go, Projector projector = null)
         {
             if (data is ObjectData objectData)
             {
@@ -486,9 +486,9 @@ namespace KK_Plugins.MaterialEditor
                 MaterialEditorPlugin.GetCharaController(chaControl).MaterialCopyEdits(objectData.Slot, objectData.ObjectType, material, go);
             }
             else
-                GetSceneController().MaterialCopyEdits((int)data, material);
+                GetSceneController().MaterialCopyEdits((int)data, material, projector);
         }
-        public override void MaterialPasteEdits(object data, Material material, GameObject go)
+        public override void MaterialPasteEdits(object data, Material material, GameObject go, Projector projector = null)
         {
             if (data is ObjectData objectData)
             {
@@ -496,7 +496,7 @@ namespace KK_Plugins.MaterialEditor
                 MaterialEditorPlugin.GetCharaController(chaControl).MaterialPasteEdits(objectData.Slot, objectData.ObjectType, material, go);
             }
             else
-                GetSceneController().MaterialPasteEdits((int)data, material);
+                GetSceneController().MaterialPasteEdits((int)data, material, projector: projector);
         }
         public override void MaterialCopyRemove(object data, Material material, GameObject go)
         {

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -475,7 +475,7 @@ namespace KK_Plugins.MaterialEditor
                 GetSceneController().RemoveProjectorProperty((int)data, projector, property);
         }
 
-        public override void MaterialCopyEdits(object data, Material material, GameObject go, Projector projector = null)
+        public override void MaterialCopyEdits(object data, Material material, GameObject go)
         {
             if (data is ObjectData objectData)
             {
@@ -483,9 +483,9 @@ namespace KK_Plugins.MaterialEditor
                 MaterialEditorPlugin.GetCharaController(chaControl).MaterialCopyEdits(objectData.Slot, objectData.ObjectType, material, go);
             }
             else
-                GetSceneController().MaterialCopyEdits((int)data, material, projector);
+                GetSceneController().MaterialCopyEdits((int)data, material);
         }
-        public override void MaterialPasteEdits(object data, Material material, GameObject go, Projector projector = null)
+        public override void MaterialPasteEdits(object data, Material material, GameObject go)
         {
             if (data is ObjectData objectData)
             {
@@ -493,7 +493,7 @@ namespace KK_Plugins.MaterialEditor
                 MaterialEditorPlugin.GetCharaController(chaControl).MaterialPasteEdits(objectData.Slot, objectData.ObjectType, material, go);
             }
             else
-                GetSceneController().MaterialPasteEdits((int)data, material, projector: projector);
+                GetSceneController().MaterialPasteEdits((int)data, material);
         }
         public override void MaterialCopyRemove(object data, Material material, GameObject go)
         {

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -15,6 +15,7 @@ using UniRx;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using static Illusion.Utils;
 using static MaterialEditorAPI.MaterialAPI;
 #if AI || HS2
 using AIChara;
@@ -431,6 +432,50 @@ namespace KK_Plugins.MaterialEditor
             }
             else
                 GetSceneController().RemoveRendererProperty((int)data, renderer, property);
+        }
+        public override float? GetProjectorPropertyValueOriginal(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                //var chaControl = go.GetComponentInParent<ChaControl>();
+                //MaterialEditorPlugin.GetCharaController(chaControl).SetRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, value, go);
+                throw new NotImplementedException();
+            }
+            else
+                return GetSceneController().GetProjectorPropertyValueOriginal((int)data, projector, property);
+        }
+
+        public override float? GetProjectorPropertyValue(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                //var chaControl = go.GetComponentInParent<ChaControl>();
+                //MaterialEditorPlugin.GetCharaController(chaControl).SetRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, value, go);
+                throw new NotImplementedException();
+            }
+            else
+                return GetSceneController().GetProjectorPropertyValue((int)data, projector, property);
+        }
+
+        public override void SetProjectorProperty(object data, Projector projector, ProjectorProperties property, float value, GameObject go)
+        {
+            if (data is ObjectData objectData)
+            {
+                //var chaControl = go.GetComponentInParent<ChaControl>();
+                //MaterialEditorPlugin.GetCharaController(chaControl).SetRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, value, go);
+            }
+            else
+                GetSceneController().SetProjectorProperty((int)data, projector, property, value);
+        }
+        public override void RemoveProjectorProperty(object data, Projector projector, ProjectorProperties property, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                //var chaControl = go.GetComponentInParent<ChaControl>();
+                //MaterialEditorPlugin.GetCharaController(chaControl).RemoveRendererProperty(objectData.Slot, objectData.ObjectType, renderer, property, go);
+            }
+            else
+                GetSceneController().RemoveProjectorProperty((int)data, projector, property);
         }
 
         public override void MaterialCopyEdits(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -7,6 +7,7 @@ using KKAPI.Studio.SaveLoad;
 using MaterialEditorAPI;
 using Studio;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using UILib;
@@ -469,6 +470,16 @@ namespace KK_Plugins.MaterialEditor
             }
             else
                 GetSceneController().RemoveProjectorProperty((int)data, projector, property);
+        }
+        public override IEnumerable<Projector> GetProjectorList(object data, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                return MaterialEditorPlugin.GetCharaController(chaControl).GetProjectorList(objectData.ObjectType, gameObject);
+            }
+            else
+                return GetSceneController().GetProjectorList(gameObject);
         }
 
         public override void MaterialCopyEdits(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
@@ -264,7 +264,7 @@ namespace MaterialEditorAPI
                    writeParameterToXml: WriteProjectorInfoXml,
                    checkIntegrity: (oci, parameter, leftValue, rightValue) => true,
                    getFinalName: (currentName, oci, parameter) => $"{parameter.projectorName}: {parameter.property}",
-                   isCompatibleWithTarget: (oci) => selectedProjectorInterpolable != null
+                   isCompatibleWithTarget: (oci) => IsCompatibleWithProjectorTarget()
                );
         }
 
@@ -323,6 +323,13 @@ namespace MaterialEditorAPI
                     return true;
                 else if ((rowtype == ItemInfo.RowItemType.TextureProperty || rowtype == ItemInfo.RowItemType.ColorProperty || rowtype == ItemInfo.RowItemType.FloatProperty) && !selectedInterpolable.MaterialName.IsNullOrEmpty() && !selectedInterpolable.PropertyName.IsNullOrEmpty())
                     return true;
+            return false;
+        }
+
+        private static bool IsCompatibleWithProjectorTarget()
+        {
+            if (selectedProjectorInterpolable != null && !selectedProjectorInterpolable.ProjectorName.IsNullOrEmpty())
+                return true;
             return false;
         }
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -30,6 +30,7 @@ namespace KK_Plugins.MaterialEditor
     public class MaterialEditorCharaController : CharaCustomFunctionController
     {
         private readonly List<RendererProperty> RendererPropertyList = new List<RendererProperty>();
+        private readonly List<ProjectorProperty> ProjectorPropertyList = new List<ProjectorProperty>();
         private readonly List<MaterialFloatProperty> MaterialFloatPropertyList = new List<MaterialFloatProperty>();
         private readonly List<MaterialColorProperty> MaterialColorPropertyList = new List<MaterialColorProperty>();
         private readonly List<MaterialKeywordProperty> MaterialKeywordPropertyList = new List<MaterialKeywordProperty>();
@@ -79,6 +80,11 @@ namespace KK_Plugins.MaterialEditor
                     data.data.Add(nameof(RendererPropertyList), MessagePackSerializer.Serialize(RendererPropertyList));
                 else
                     data.data.Add(nameof(RendererPropertyList), null);
+
+                if (ProjectorPropertyList.Count > 0)
+                    data.data.Add(nameof(ProjectorPropertyList), MessagePackSerializer.Serialize(ProjectorPropertyList));
+                else
+                    data.data.Add(nameof(ProjectorPropertyList), null);
 
                 if (MaterialFloatPropertyList.Count > 0)
                     data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(MaterialFloatPropertyList));
@@ -164,6 +170,7 @@ namespace KK_Plugins.MaterialEditor
         {
 
             var coordinateRendererPropertyList = RendererPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
+            var coordinateProjectorPropertyList = ProjectorPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
             var coordinateMaterialFloatPropertyList = MaterialFloatPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
 
             var coordinateMaterialKeywordPropertyList = MaterialKeywordPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
@@ -193,6 +200,11 @@ namespace KK_Plugins.MaterialEditor
                     data.data.Add(nameof(RendererPropertyList), MessagePackSerializer.Serialize(coordinateRendererPropertyList));
                 else
                     data.data.Add(nameof(RendererPropertyList), null);
+
+                if (coordinateProjectorPropertyList.Count > 0)
+                    data.data.Add(nameof(ProjectorPropertyList), MessagePackSerializer.Serialize(coordinateProjectorPropertyList));
+                else
+                    data.data.Add(nameof(ProjectorPropertyList), null);
 
                 if (coordinateMaterialFloatPropertyList.Count > 0)
                     data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(coordinateMaterialFloatPropertyList));
@@ -258,6 +270,7 @@ namespace KK_Plugins.MaterialEditor
             if (loadFlags == null)
             {
                 RendererPropertyList.Clear();
+                ProjectorPropertyList.Clear();
                 MaterialFloatPropertyList.Clear();
                 MaterialKeywordPropertyList.Clear();
                 MaterialColorPropertyList.Clear();
@@ -275,6 +288,7 @@ namespace KK_Plugins.MaterialEditor
                 if (loadFlags.Face || loadFlags.Body)
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
+                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
@@ -287,6 +301,7 @@ namespace KK_Plugins.MaterialEditor
                 if (loadFlags.Clothes)
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
+                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
@@ -296,6 +311,7 @@ namespace KK_Plugins.MaterialEditor
                     objectTypesToLoad.Add(ObjectType.Clothing);
 
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
+                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
@@ -307,6 +323,7 @@ namespace KK_Plugins.MaterialEditor
                 if (loadFlags.Hair)
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
+                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
@@ -365,6 +382,18 @@ namespace KK_Plugins.MaterialEditor
                         int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
                         if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
                             RendererPropertyList.Add(new RendererProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+                    }
+                }
+
+                if (data.data.TryGetValue(nameof(ProjectorPropertyList), out var projectorProperties) && projectorProperties != null)
+                {
+                    var properties = MessagePackSerializer.Deserialize<List<ProjectorProperty>>((byte[])projectorProperties);
+                    for (var i = 0; i < properties.Count; i++)
+                    {
+                        var loadedProperty = properties[i];
+                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
+                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
+                            ProjectorPropertyList.Add(new ProjectorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
                     }
                 }
 
@@ -691,6 +720,16 @@ namespace KK_Plugins.MaterialEditor
                 }
                 SetTextureOffset(go, property.MaterialName, property.Property, property.Offset);
                 SetTextureScale(go, property.MaterialName, property.Property, property.Scale);
+            }
+            for (var i = 0; i < ProjectorPropertyList.Count; i++)
+            {
+                var property = ProjectorPropertyList[i];
+                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
+                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
+                if (property.ObjectType == ObjectType.Hair && !hair) continue;
+                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
+
+                MaterialAPI.SetProjectorProperty(FindGameObject(property.ObjectType, property.Slot), property.ProjectorName, property.Property, float.Parse(property.Value));
             }
 
 
@@ -1192,6 +1231,10 @@ namespace KK_Plugins.MaterialEditor
                 else
                     CopyData.MaterialTexturePropertyList.Add(new CopyContainer.MaterialTextureProperty(materialTextureProperty.Property, null, materialTextureProperty.Offset, materialTextureProperty.Scale));
             }
+            if(GetProjectorList(go).FirstOrDefault(x => x.material == material) != null)
+            foreach (var projectorProperty in ProjectorPropertyList.Where(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.ProjectorName == material.NameFormatted()))
+                    CopyData.ProjectorPropertyList.Add(new CopyContainer.ProjectorProperty(projectorProperty.Property, float.Parse(projectorProperty.Value)));
+
         }
         /// <summary>
         /// Paste any edits for the specified object
@@ -1237,6 +1280,14 @@ namespace KK_Plugins.MaterialEditor
                 if (materialTextureProperty.Scale != null)
                     SetMaterialTextureScale(slot, objectType, material, materialTextureProperty.Property, (Vector2)materialTextureProperty.Scale, go, setProperty);
             }
+
+            var projector = GetProjectorList(go).FirstOrDefault(x => x.material == material);
+            if (projector != null)
+                for (var i = 0; i < CopyData.MaterialTexturePropertyList.Count; i++)
+                {
+                    var projectorProperty = CopyData.ProjectorPropertyList[i];
+                    SetProjectorProperty(slot, objectType, projector, projectorProperty.Property, projectorProperty.Value, go, setProperty);
+                }
         }
 
         public void MaterialCopyRemove(int slot, ObjectType objectType, Material material, GameObject go)
@@ -1283,6 +1334,96 @@ namespace KK_Plugins.MaterialEditor
         }
 
         #region Set, Get, Remove methods
+        /// <summary>
+        /// Get the original value of the saved projector property value or null if none is saved
+        /// </summary>
+        /// <param name="slot">Slot of the clothing (0=tops, 1=bottoms, etc.), the hair (0=back, 1=front, etc.), or of the accessory. Ignored for other object types.</param>
+        /// <param name="projector">Projector being modified</param>
+        /// <param name="property">Property of the projector</param>
+        /// <param name="go">GameObject the projector belongs to</param>
+        /// <returns>Saved projector property value</returns>
+        public float? GetProjectorPropertyValueOriginal(int slot, ObjectType objectType, Projector projector, ProjectorProperties property, GameObject go)
+        {
+            var valueOriginal = ProjectorPropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Property == property && x.ProjectorName == projector.NameFormatted())?.ValueOriginal;
+            if (valueOriginal.IsNullOrEmpty())
+                return null;
+            return float.Parse(valueOriginal);
+        }
+        /// <summary>
+        /// Get the value of the saved projector property value or null if none is saved
+        /// </summary>
+        /// <param name="slot">Slot of the clothing (0=tops, 1=bottoms, etc.), the hair (0=back, 1=front, etc.), or of the accessory. Ignored for other object types.</param>
+        /// <param name="projector">Projector being modified</param>
+        /// <param name="property">Property of the projector</param>
+        /// <param name="go">GameObject the projector belongs to</param>
+        /// <returns>Saved projector property value</returns>
+        public float? GetProjectorPropertyValue(int slot, ObjectType objectType, Projector projector, ProjectorProperties property, GameObject go)
+        {
+            var valueOriginal = ProjectorPropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Property == property && x.ProjectorName == projector.NameFormatted())?.Value;
+            if (valueOriginal.IsNullOrEmpty())
+                return null;
+            return float.Parse(valueOriginal);
+        }
+        /// <summary>
+        /// Remove the saved projector property value if one is saved and optionally also update the projector
+        /// </summary>
+        /// <param name="slot">Slot of the clothing (0=tops, 1=bottoms, etc.), the hair (0=back, 1=front, etc.), or of the accessory. Ignored for other object types.</param>
+        /// <param name="projector">Projector being modified</param>
+        /// <param name="property">Property of the projector</param>
+        /// <param name="go">GameObject the projector belongs to</param>
+        /// <param name="setProperty">Whether to also apply the value to the projector</param>
+        public void RemoveProjectorProperty(int slot, ObjectType objectType, Projector projector, ProjectorProperties property, GameObject go, bool setProperty = true)
+        {
+            if (setProperty)
+            {
+                var original = GetProjectorPropertyValueOriginal(slot, objectType, projector, property, go);
+                if (original != null)
+                    MaterialAPI.SetProjectorProperty(go, projector.NameFormatted(), property, (float)original);
+            }
+            ProjectorPropertyList.RemoveAll(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Property == property && x.ProjectorName == projector.NameFormatted());
+        }
+        /// <summary>
+        /// Add a renderer property to be saved and loaded with the card and optionally also update the renderer.
+        /// </summary>
+        /// <param name="slot">Slot of the clothing (0=tops, 1=bottoms, etc.), the hair (0=back, 1=front, etc.), or of the accessory. Ignored for other object types.</param>
+        /// <param name="renderer">Renderer being modified</param>
+        /// <param name="property">Property of the renderer</param>
+        /// <param name="value">Value</param>
+        /// <param name="go">GameObject the renderer belongs to</param>
+        /// <param name="setProperty">Whether to also apply the value to the renderer</param>
+        public void SetProjectorProperty(int slot, ObjectType objectType, Projector projector, ProjectorProperties property, float value, GameObject go, bool setProperty = true)
+        {
+            ProjectorProperty projectorProperty = ProjectorPropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Property == property && x.ProjectorName == projector.NameFormatted());
+            if (projectorProperty == null)
+            {
+                string valueOriginal = "";
+                if (property == ProjectorProperties.FarClipPlane)
+                    valueOriginal = projector.farClipPlane.ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.NearClipPlane)
+                    valueOriginal = projector.nearClipPlane.ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.FieldOfView)
+                    valueOriginal = projector.fieldOfView.ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.AspectRatio)
+                    valueOriginal = projector.aspectRatio.ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.Orthographic)
+                    valueOriginal = Convert.ToSingle(projector.orthographic).ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.OrthographicSize)
+                    valueOriginal = projector.orthographicSize.ToString(CultureInfo.InvariantCulture);
+
+                if (valueOriginal != "")
+                    ProjectorPropertyList.Add(new ProjectorProperty(objectType, GetCoordinateIndex(objectType), slot, projector.NameFormatted(), property, value.ToString(CultureInfo.InvariantCulture), valueOriginal));
+            }
+            else
+            {
+                if (value.ToString(CultureInfo.InvariantCulture) == projectorProperty.ValueOriginal)
+                    RemoveProjectorProperty(slot, objectType, projector, property, go, false);
+                else
+                    projectorProperty.Value = value.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (setProperty)
+                MaterialAPI.SetProjectorProperty(go, projector.NameFormatted(), property, value);
+        }
         /// <summary>
         /// Add a renderer property to be saved and loaded with the card and optionally also update the renderer.
         /// </summary>
@@ -2756,6 +2897,69 @@ namespace KK_Plugins.MaterialEditor
                 Slot = slot;
                 MaterialName = materialName.Replace("(Instance)", "").Trim();
                 MaterialCopyName = materialCopyName;
+            }
+        }
+
+        /// <summary>
+        /// Data storage class for projector properties
+        /// </summary>
+        [Serializable]
+        [MessagePackObject]
+        public class ProjectorProperty
+        {
+            /// <summary>
+            /// Type of the object
+            /// </summary>
+            [Key("ObjectType")]
+            public ObjectType ObjectType;
+            /// <summary>
+            /// Coordinate index, always 0 except in Koikatsu
+            /// </summary>
+            [Key("CoordinateIndex")]
+            public int CoordinateIndex;
+            /// <summary>
+            /// Slot of the accessory, hair, or clothing
+            /// </summary>
+            [Key("Slot")]
+            public int Slot;
+            /// <summary>
+            /// Name of the projector
+            /// </summary>
+            [Key("ProjectorName")]
+            public string ProjectorName;
+            /// <summary>
+            /// Property type
+            /// </summary>
+            [Key("Property")]
+            public ProjectorProperties Property;
+            /// <summary>
+            /// Value
+            /// </summary>
+            [Key("Value")]
+            public string Value;
+            /// <summary>
+            /// Original value
+            /// </summary>
+            [Key("ValueOriginal")]
+            public string ValueOriginal;
+
+            /// <summary>
+            /// Data storage class for projector properties
+            /// </summary>
+            /// <param name="id">ID of the item</param>
+            /// <param name="ProjectorName">Name of the projector</param>
+            /// <param name="property">Property type</param>
+            /// <param name="value">Value</param>
+            /// <param name="valueOriginal">Original</param>
+            public ProjectorProperty(ObjectType objectType, int coordinateIndex, int slot, string projectorName, ProjectorProperties property, string value, string valueOriginal)
+            {
+                ObjectType = objectType;
+                CoordinateIndex = coordinateIndex;
+                Slot = slot;
+                ProjectorName = projectorName.Replace("(Instance)", "").Trim();
+                Property = property;
+                Value = value;
+                ValueOriginal = valueOriginal;
             }
         }
     }

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -1231,8 +1231,8 @@ namespace KK_Plugins.MaterialEditor
                 else
                     CopyData.MaterialTexturePropertyList.Add(new CopyContainer.MaterialTextureProperty(materialTextureProperty.Property, null, materialTextureProperty.Offset, materialTextureProperty.Scale));
             }
-            if(GetProjectorList(go).FirstOrDefault(x => x.material == material) != null)
-            foreach (var projectorProperty in ProjectorPropertyList.Where(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.ProjectorName == material.NameFormatted()))
+            if(GetProjectorList(objectType, go).FirstOrDefault(x => x.material == material) != null)
+                foreach (var projectorProperty in ProjectorPropertyList.Where(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.ProjectorName == material.NameFormatted()))
                     CopyData.ProjectorPropertyList.Add(new CopyContainer.ProjectorProperty(projectorProperty.Property, float.Parse(projectorProperty.Value)));
 
         }
@@ -1281,7 +1281,7 @@ namespace KK_Plugins.MaterialEditor
                     SetMaterialTextureScale(slot, objectType, material, materialTextureProperty.Property, (Vector2)materialTextureProperty.Scale, go, setProperty);
             }
 
-            var projector = GetProjectorList(go).FirstOrDefault(x => x.material == material);
+            var projector = GetProjectorList(objectType, go).FirstOrDefault(x => x.material == material);
             if (projector != null)
                 for (var i = 0; i < CopyData.MaterialTexturePropertyList.Count; i++)
                 {
@@ -1424,6 +1424,15 @@ namespace KK_Plugins.MaterialEditor
             if (setProperty)
                 MaterialAPI.SetProjectorProperty(go, projector.NameFormatted(), property, value);
         }
+        public IEnumerable<Projector> GetProjectorList(ObjectType objectType, GameObject gameObject)
+        {
+            //The body will never have a projector component attached
+            //And returning all components from children will return every projector on a character
+            if (objectType == ObjectType.Character)
+                return new List<Projector>();
+            return MaterialAPI.GetProjectorList(gameObject, true);
+        }
+
         /// <summary>
         /// Add a renderer property to be saved and loaded with the card and optionally also update the renderer.
         /// </summary>

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -1409,6 +1409,10 @@ namespace KK_Plugins.MaterialEditor
                     valueOriginal = Convert.ToSingle(projector.orthographic).ToString(CultureInfo.InvariantCulture);
                 else if (property == ProjectorProperties.OrthographicSize)
                     valueOriginal = projector.orthographicSize.ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.IgnoreCharaLayer)
+                    valueOriginal = Convert.ToSingle(projector.ignoreLayers == (projector.ignoreLayers | (1 << 10))).ToString(CultureInfo.InvariantCulture);
+                else if (property == ProjectorProperties.IgnoreMapLayer)
+                    valueOriginal = Convert.ToSingle(projector.ignoreLayers == (projector.ignoreLayers | (1 << 11))).ToString(CultureInfo.InvariantCulture);
 
                 if (valueOriginal != "")
                     ProjectorPropertyList.Add(new ProjectorProperty(objectType, GetCoordinateIndex(objectType), slot, projector.NameFormatted(), property, value.ToString(CultureInfo.InvariantCulture), valueOriginal));

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -912,6 +912,9 @@ namespace KK_Plugins.MaterialEditor
                         ConvertNormalMaps(material);
                     }
                 }
+                var projectors = go.GetComponentsInChildren<Projector>();
+                foreach (var projector in projectors)
+                    ReplaceShaders(projector.material);
             }
             else if (context.Asset is Material material)
             {

--- a/src/Shared/Shared.Extensions.cs
+++ b/src/Shared/Shared.Extensions.cs
@@ -24,6 +24,7 @@ namespace KK_Plugins
         public static string NameFormatted(this GameObject go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Material go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Renderer go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
+        public static string NameFormatted(this Projector go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Shader go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Mesh go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         /// <summary>


### PR DESCRIPTION
Projector support for ME. Formely you had to use Render Editor to edit them in games that had projectors. Koikatsu doesn't have them yet, but I'm porting those, but then RE doesn't exist on KKS.

All projector properties are treated as material properties in the UI, and thus grouped together with them. I did it like this to make editing them a little easier (grouped together + copy/pasting edits), and since projectors can only ever have one material anyway. Since projectors can only have one material, I also hide the "Copy Material" button now whenever the provided function for that button is `null`.

![image](https://github.com/IllusionMods/KK_Plugins/assets/141709004/66e95b48-28f7-4fae-a9d0-5a789884ca4f)

Fow now I've made all character versions of the projector methods throw a `NotImplementedException`, since projectors don't seem to be used there at all. If the rest of the code is fine I will add those functions for completeness sake though (and in case they do exist there, though I doubt that)
  
There is also the problem of potential conflicts with RE, This is because projectors share their material instance by default, while renderer materials do not. To circumvent this you need to assign a unique copy yourself and keep track if you've already assigned a unique copy or not. RE seems to do this, and might cause conflicts.
In my testing they don't conflict for some reason though, except for the `orthographic` setting, which can't be edited in ME if it's enabled in RE
