### PR TITLE
[ME] Add accessory names to the ItemTypeDropDown

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -178,7 +178,11 @@ namespace KK_Plugins.MaterialEditor
             var accessories = chaControl.GetAccessoryObjects();
             for (var i = 0; i < accessories.Length; i++)
                 if (accessories[i] != null)
+#if !PH
+                    ItemTypeDropDown.options.Add(new Dropdown.OptionData($"Accessory {AccessoryIndexToString(i)} {chaControl.infoAccessory[i].Name}"));
+#else
                     ItemTypeDropDown.options.Add(new Dropdown.OptionData($"Accessory {AccessoryIndexToString(i)}"));
+#endif
         }
 
         private void ChangeItemType(int selectedItem, ChaControl chaControl)

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -81,6 +81,7 @@ namespace KK_Plugins.MaterialEditor
             ItemTypeDropDown.captionText.transform.SetRect(0.05f, 0f, 1f, 1f, 5f, 2f, -15f, -2f);
             ItemTypeDropDown.captionText.alignment = TextAnchor.MiddleLeft;
             ItemTypeDropDown.gameObject.SetActive(false);
+            AutoScrollToSelectionWithDropdown.Setup(ItemTypeDropDown);
 
 #if PH
             RectTransform original = GameObject.Find("StudioScene").transform.Find("Canvas Object List/Image Bar/Button Folder").GetComponent<RectTransform>();


### PR DESCRIPTION
Adds accessory names to the ItemTypeDropdown in studio and makes it autoscroll to the current position. It now looks like this and makes finding the accessory you want to edit a lot easier

![image](https://github.com/IllusionMods/KK_Plugins/assets/141709004/1964ca03-f901-4541-bd57-5a5317e28a5a)

I can't find where the accessory name is stored in PH however