### PR TITLE
[ME][KK/KKS] Remove coordinate properties when that coordinate is removed

### DIFF
--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -61,6 +61,9 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="currentGameMode"></param>
         protected override void OnCardBeingSaved(GameMode currentGameMode)
         {
+#if KK || KKS
+            PurgeUnusedCoordinates();
+#endif
             PurgeUnusedTextures();
 
             if (RendererPropertyList.Count == 0 && MaterialFloatPropertyList.Count == 0 && MaterialKeywordPropertyList.Count == 0 && MaterialColorPropertyList.Count == 0 && MaterialTexturePropertyList.Count == 0 && MaterialShaderList.Count == 0 && MaterialCopyList.Count == 0)
@@ -2375,6 +2378,20 @@ namespace KK_Plugins.MaterialEditor
                 TextureDictionary.Remove(texID);
             }
         }
+
+#if KK || KKS
+        internal void PurgeUnusedCoordinates()
+        {
+            RendererPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            ProjectorPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialFloatPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialColorPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialKeywordPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialTexturePropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialShaderList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialCopyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+        }
+#endif
 
         /// <summary>
         /// Type of object, used for saving MaterialEditor data.

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -2380,6 +2380,10 @@ namespace KK_Plugins.MaterialEditor
         }
 
 #if KK || KKS
+
+        /// <summary>
+        /// Purge coordinate properties that reference a coordinate that no longer exists
+        /// </summary>
         internal void PurgeUnusedCoordinates()
         {
             RendererPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -62,6 +62,7 @@ namespace KK_Plugins.MaterialEditor
         protected override void OnCardBeingSaved(GameMode currentGameMode)
         {
 #if KK || KKS
+            //Always run on save to also purge them for cards made before this purging was implemented
             PurgeUnusedCoordinates();
 #endif
             PurgeUnusedTextures();

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -592,6 +592,7 @@ namespace KK_Plugins.MaterialEditor
             chaControl.StartCoroutine(MaterialEditorPlugin.GetCharaController(chaControl).LoadData(false, false, false));
         }
 
+#if KK || KKS
         internal static void RemoveCoordinateSlotHook()
         {
             if (MakerAPI.InsideAndLoaded)
@@ -600,5 +601,6 @@ namespace KK_Plugins.MaterialEditor
                 controller.PurgeUnusedCoordinates();
             }
         }
+#endif
     }
 }

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -591,5 +591,14 @@ namespace KK_Plugins.MaterialEditor
         {
             chaControl.StartCoroutine(MaterialEditorPlugin.GetCharaController(chaControl).LoadData(false, false, false));
         }
+
+        internal static void RemoveCoordinateSlotHook()
+        {
+            if (MakerAPI.InsideAndLoaded)
+            {
+                var controller = MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl());
+                controller.PurgeUnusedCoordinates();
+            }
+        }
     }
 }

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -218,6 +218,7 @@ namespace KK_Plugins.MaterialEditor
                     harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHookStudio), AccessTools.all)));
             }
 
+#if KK || KKS
             //Hook to delete properties of an outfit that gets removed
             var moreOutfitsType = Type.GetType($"KK_Plugins.MoreOutfits.Plugin, {Constants.Prefix}_MoreOutfits");
             if(moreOutfitsType != null)
@@ -226,6 +227,7 @@ namespace KK_Plugins.MaterialEditor
                 if (method != null)
                     harmony.Patch(method, postfix: new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.RemoveCoordinateSlotHook), AccessTools.all)));
             }
+#endif
 
             StartCoroutine(LoadXML());
             StartCoroutine(GetUncensorSelectorParts());

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -37,6 +37,7 @@ namespace KK_Plugins.MaterialEditor
     /// <summary>
     /// MaterialEditor plugin base
     /// </summary>
+    [BepInDependency("com.deathweasel.bepinex.moreoutfits", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(KoikatuAPI.GUID, KoikatuAPI.VersionConst)]
     [BepInDependency(XUnity.ResourceRedirector.Constants.PluginData.Identifier, XUnity.ResourceRedirector.Constants.PluginData.Version)]
     [BepInDependency(ExtendedSave.GUID, ExtendedSave.Version)]
@@ -198,7 +199,7 @@ namespace KK_Plugins.MaterialEditor
             {
                 var method = uncensorSelectorType.GetMethod("BodyDropdownChanged", AccessTools.all);
                 if (method != null)
-                    harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHook), AccessTools.all)));
+                    harmony.Patch(method, postfix: new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHook), AccessTools.all)));
                 method = uncensorSelectorType.GetMethod("PenisDropdownChanged", AccessTools.all);
                 if (method != null)
                     harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHook), AccessTools.all)));
@@ -215,6 +216,14 @@ namespace KK_Plugins.MaterialEditor
                 method = uncensorSelectorType.GetMethod("BallsDropdownChangedStudio", AccessTools.all);
                 if (method != null)
                     harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHookStudio), AccessTools.all)));
+            }
+
+            var moreOutfitsType = Type.GetType($"KK_Plugins.MoreOutfits.Plugin, {Constants.Prefix}_MoreOutfits");
+            if(moreOutfitsType != null)
+            {
+                var method = moreOutfitsType.GetMethod("RemoveCoordinateSlot", AccessTools.all);
+                if (method != null)
+                    harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.RemoveCoordinateSlotHook), AccessTools.all)));
             }
 
             StartCoroutine(LoadXML());

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -218,6 +218,7 @@ namespace KK_Plugins.MaterialEditor
                     harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHookStudio), AccessTools.all)));
             }
 
+            //Hook to delete properties of an outfit that gets removed
             var moreOutfitsType = Type.GetType($"KK_Plugins.MoreOutfits.Plugin, {Constants.Prefix}_MoreOutfits");
             if(moreOutfitsType != null)
             {

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -199,7 +199,7 @@ namespace KK_Plugins.MaterialEditor
             {
                 var method = uncensorSelectorType.GetMethod("BodyDropdownChanged", AccessTools.all);
                 if (method != null)
-                    harmony.Patch(method, postfix: new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHook), AccessTools.all)));
+                    harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHook), AccessTools.all)));
                 method = uncensorSelectorType.GetMethod("PenisDropdownChanged", AccessTools.all);
                 if (method != null)
                     harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.UncensorSelectorHook), AccessTools.all)));
@@ -223,7 +223,7 @@ namespace KK_Plugins.MaterialEditor
             {
                 var method = moreOutfitsType.GetMethod("RemoveCoordinateSlot", AccessTools.all);
                 if (method != null)
-                    harmony.Patch(method, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.RemoveCoordinateSlotHook), AccessTools.all)));
+                    harmony.Patch(method, postfix: new HarmonyMethod(typeof(Hooks).GetMethod(nameof(Hooks.RemoveCoordinateSlotHook), AccessTools.all)));
             }
 
             StartCoroutine(LoadXML());

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -37,12 +37,13 @@ namespace KK_Plugins.MaterialEditor
     /// <summary>
     /// MaterialEditor plugin base
     /// </summary>
-    [BepInDependency("com.deathweasel.bepinex.moreoutfits", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(KoikatuAPI.GUID, KoikatuAPI.VersionConst)]
     [BepInDependency(XUnity.ResourceRedirector.Constants.PluginData.Identifier, XUnity.ResourceRedirector.Constants.PluginData.Version)]
     [BepInDependency(ExtendedSave.GUID, ExtendedSave.Version)]
 #if !PH
     [BepInDependency(Sideloader.Sideloader.GUID, Sideloader.Sideloader.Version)]
+#elif KK || KKS
+    [BepInDependency("com.deathweasel.bepinex.moreoutfits", BepInDependency.DependencyFlags.SoftDependency)]
 #endif
     [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
     public partial class MaterialEditorPlugin : MaterialEditorAPI.MaterialEditorPluginBase


### PR DESCRIPTION
When a coordinate was removed, the associated properties were never purged. This could cause some very bad card bloating, primarily when textures were involved.

This now purges those properties. It will also purge them on save, in case a card made before this purging has properties from slots that no longer exist. If these slots still exist however, it _could_ still contain dead properties (e.g. you removed a slot and then added it back). 