### PR TITLE
[ME] Shortcut to remove orphaned properties on the current outfit

### DIFF
--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -2420,8 +2420,10 @@ namespace KK_Plugins.MaterialEditor
                 var renderers = GetRendererList(go);
                 if (renderers == null) return;
 
-                var rendererNames = renderers.Select(x => x.NameFormatted());
                 var materialNames = renderers.SelectMany(x => x.materials).Select(x => x.NameFormatted()).ToList();
+                var projectors = GetProjectorList(objectType, go);
+                materialNames.AddRange(projectors.Select(x => x.material.NameFormatted()));
+
                 var materialPropertiesDict = renderers
                     .SelectMany(x => x.materials)
                     .GroupBy(x => x.NameFormatted())
@@ -2431,11 +2433,17 @@ namespace KK_Plugins.MaterialEditor
                         x => XMLShaderProperties[XMLShaderProperties.ContainsKey(x.shader.NameFormatted()) ? x.shader.NameFormatted() : "default"].Select(i => i.Key)
                 );
 
+                removedCount += ProjectorPropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && !projectors.Select(projector => projector.NameFormatted()).Contains(x.ProjectorName)
+                );
                 removedCount += RendererPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
                     && x.ObjectType == objectType
-                    && !rendererNames.Contains(x.RendererName)
+                    && !renderers.Select(rend => rend.NameFormatted()).Contains(x.RendererName)
                 );
                 removedCount += MaterialFloatPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -164,6 +164,8 @@ namespace KK_Plugins.MaterialEditor
                 GameObjectToSet = null;
             }
             base.Update();
+            if (MaterialEditorPlugin.PurgeOrphanedPropertiesHotkey.Value.IsDown())
+                PurgeOrphanedProperties();
         }
 
         /// <summary>
@@ -2358,10 +2360,10 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// Purge unused textures from TextureDictionary
         /// </summary>
-        protected void PurgeUnusedTextures()
+        protected int PurgeUnusedTextures()
         {
             if (TextureDictionary.Count <= 0)
-                return;
+                return 0;
 
             HashSet<int> unuseds = new HashSet<int>(TextureDictionary.Keys);
 
@@ -2378,6 +2380,7 @@ namespace KK_Plugins.MaterialEditor
                 TextureDictionary[texID].Dispose();
                 TextureDictionary.Remove(texID);
             }
+            return unuseds.Count;
         }
 
 #if KK || KKS
@@ -2397,6 +2400,113 @@ namespace KK_Plugins.MaterialEditor
             MaterialCopyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
         }
 #endif
+
+        internal void PurgeOrphanedProperties()
+        {
+            int removedCount = 0;
+            MaterialEditorPluginBase.Logger.LogInfo(100);
+            for (var i = 0; i < ChaControl.objClothes.Length; i++)
+                removeProperties(ObjectType.Clothing, i, ChaControl.objClothes[i]);
+            MaterialEditorPluginBase.Logger.LogInfo(200);
+            for (var i = 0; i < ChaControl.objAccessory.Length; i++)
+                removeProperties(ObjectType.Accessory, i, ChaControl.objAccessory[i]);
+            MaterialEditorPluginBase.Logger.LogInfo(300);
+            for (var i = 0; i < ChaControl.objHair.Length; i++)
+                removeProperties(ObjectType.Hair, i, ChaControl.objHair[i]);
+            //The same is not done for the body because some properties are exposed, while technically still there and used
+            //An example would be the face alpha mask not being exposed in koikatsu's v+ shaders, while still being applied if set in a shader that does expose it
+
+            void removeProperties(ObjectType objectType, int slot, GameObject go)
+            {
+                if (go == null) return;
+                MaterialEditorPluginBase.Logger.LogInfo(1);
+                var renderers = GetRendererList(go);
+                if (renderers == null) return;
+
+                MaterialEditorPluginBase.Logger.LogInfo(2);
+                var rendererNames = renderers.Select(x => x.NameFormatted());
+                MaterialEditorPluginBase.Logger.LogInfo(3);
+                var materialNames = renderers.SelectMany(x => x.materials).Select(x => x.NameFormatted()).ToList();
+                MaterialEditorPluginBase.Logger.LogInfo(4);
+                var materialPropertiesDict = renderers
+                    .SelectMany(x => x.materials)
+                    .GroupBy(x => x.NameFormatted())
+                    .Select(x => x.First())
+                    .ToDictionary(
+                        x => x.NameFormatted(),
+                        x => XMLShaderProperties[XMLShaderProperties.ContainsKey(x.shader.NameFormatted()) ? x.shader.NameFormatted() : "default"].Select(i => i.Key)
+                );
+
+                MaterialEditorPluginBase.Logger.LogInfo(5);
+                removedCount += RendererPropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && !rendererNames.Contains(x.RendererName)
+                );
+                MaterialEditorPluginBase.Logger.LogInfo(6);
+                removedCount += MaterialFloatPropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && (
+                        !materialNames.Contains(x.MaterialName)
+                        || !materialPropertiesDict.ContainsKey(x.MaterialName)
+                        || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
+                    )
+                );
+                MaterialEditorPluginBase.Logger.LogInfo(7);
+                removedCount += MaterialColorPropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && (
+                        !materialNames.Contains(x.MaterialName)
+                        || !materialPropertiesDict.ContainsKey(x.MaterialName)
+                        || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
+                    )
+                );
+                MaterialEditorPluginBase.Logger.LogInfo(8);
+                removedCount += MaterialKeywordPropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && (
+                        !materialNames.Contains(x.MaterialName)
+                        || !materialPropertiesDict.ContainsKey(x.MaterialName)
+                        || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
+                    )
+                );
+                MaterialEditorPluginBase.Logger.LogInfo(9);
+                removedCount += MaterialTexturePropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && (
+                        !materialNames.Contains(x.MaterialName)
+                        || !materialPropertiesDict.ContainsKey(x.MaterialName)
+                        || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
+                    )
+                );
+                MaterialEditorPluginBase.Logger.LogInfo(10);
+                removedCount += MaterialShaderList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && !materialNames.Contains(x.MaterialName)
+                );
+                MaterialEditorPluginBase.Logger.LogInfo(11);
+                removedCount += MaterialCopyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && !materialNames.Contains(x.MaterialName)
+                );
+            }
+            MaterialEditorPluginBase.Logger.LogMessage($"Removed {removedCount} orphaned propertie(s)");
+            var purgedTextures = PurgeUnusedTextures();
+            MaterialEditorPluginBase.Logger.LogMessage($"Removed {purgedTextures} orphaned texture(s)");
+        }
 
         /// <summary>
         /// Type of object, used for saving MaterialEditor data.
@@ -2555,7 +2665,7 @@ namespace KK_Plugins.MaterialEditor
                 ValueOriginal = valueOriginal;
             }
         }
-        
+
         /// <summary>
         /// Data storage class for float properties
         /// </summary>

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -2404,13 +2404,11 @@ namespace KK_Plugins.MaterialEditor
         internal void PurgeOrphanedProperties()
         {
             int removedCount = 0;
-            MaterialEditorPluginBase.Logger.LogInfo(100);
+
             for (var i = 0; i < ChaControl.objClothes.Length; i++)
                 removeProperties(ObjectType.Clothing, i, ChaControl.objClothes[i]);
-            MaterialEditorPluginBase.Logger.LogInfo(200);
             for (var i = 0; i < ChaControl.objAccessory.Length; i++)
                 removeProperties(ObjectType.Accessory, i, ChaControl.objAccessory[i]);
-            MaterialEditorPluginBase.Logger.LogInfo(300);
             for (var i = 0; i < ChaControl.objHair.Length; i++)
                 removeProperties(ObjectType.Hair, i, ChaControl.objHair[i]);
             //The same is not done for the body because some properties are exposed, while technically still there and used
@@ -2419,15 +2417,11 @@ namespace KK_Plugins.MaterialEditor
             void removeProperties(ObjectType objectType, int slot, GameObject go)
             {
                 if (go == null) return;
-                MaterialEditorPluginBase.Logger.LogInfo(1);
                 var renderers = GetRendererList(go);
                 if (renderers == null) return;
 
-                MaterialEditorPluginBase.Logger.LogInfo(2);
                 var rendererNames = renderers.Select(x => x.NameFormatted());
-                MaterialEditorPluginBase.Logger.LogInfo(3);
                 var materialNames = renderers.SelectMany(x => x.materials).Select(x => x.NameFormatted()).ToList();
-                MaterialEditorPluginBase.Logger.LogInfo(4);
                 var materialPropertiesDict = renderers
                     .SelectMany(x => x.materials)
                     .GroupBy(x => x.NameFormatted())
@@ -2437,14 +2431,12 @@ namespace KK_Plugins.MaterialEditor
                         x => XMLShaderProperties[XMLShaderProperties.ContainsKey(x.shader.NameFormatted()) ? x.shader.NameFormatted() : "default"].Select(i => i.Key)
                 );
 
-                MaterialEditorPluginBase.Logger.LogInfo(5);
                 removedCount += RendererPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
                     && x.ObjectType == objectType
                     && !rendererNames.Contains(x.RendererName)
                 );
-                MaterialEditorPluginBase.Logger.LogInfo(6);
                 removedCount += MaterialFloatPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
@@ -2455,7 +2447,6 @@ namespace KK_Plugins.MaterialEditor
                         || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
                     )
                 );
-                MaterialEditorPluginBase.Logger.LogInfo(7);
                 removedCount += MaterialColorPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
@@ -2466,7 +2457,6 @@ namespace KK_Plugins.MaterialEditor
                         || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
                     )
                 );
-                MaterialEditorPluginBase.Logger.LogInfo(8);
                 removedCount += MaterialKeywordPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
@@ -2477,7 +2467,6 @@ namespace KK_Plugins.MaterialEditor
                         || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
                     )
                 );
-                MaterialEditorPluginBase.Logger.LogInfo(9);
                 removedCount += MaterialTexturePropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
@@ -2488,14 +2477,12 @@ namespace KK_Plugins.MaterialEditor
                         || !materialPropertiesDict[x.MaterialName].Contains(x.Property)
                     )
                 );
-                MaterialEditorPluginBase.Logger.LogInfo(10);
                 removedCount += MaterialShaderList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
                     && x.ObjectType == objectType
                     && !materialNames.Contains(x.MaterialName)
                 );
-                MaterialEditorPluginBase.Logger.LogInfo(11);
                 removedCount += MaterialCopyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
                     && x.Slot == slot
@@ -2503,9 +2490,11 @@ namespace KK_Plugins.MaterialEditor
                     && !materialNames.Contains(x.MaterialName)
                 );
             }
-            MaterialEditorPluginBase.Logger.LogMessage($"Removed {removedCount} orphaned propertie(s)");
             var purgedTextures = PurgeUnusedTextures();
-            MaterialEditorPluginBase.Logger.LogMessage($"Removed {purgedTextures} orphaned texture(s)");
+            if(purgedTextures == 0)
+                MaterialEditorPluginBase.Logger.LogMessage($"Removed {removedCount} orphaned propertie(s)");
+            else
+                MaterialEditorPluginBase.Logger.LogMessage($"Removed {removedCount} orphaned propertie(s) and {purgedTextures} orphaned texture(s)");
         }
 
         /// <summary>

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -2411,7 +2411,7 @@ namespace KK_Plugins.MaterialEditor
                 removeProperties(ObjectType.Accessory, i, ChaControl.GetAccessoryObjects()[i]);
             for (var i = 0; i < ChaControl.GetHair().Length; i++)
                 removeProperties(ObjectType.Hair, i, ChaControl.GetHair()[i]);
-            //The same is not done for the body because some properties are exposed, while technically still there and used
+            //The same is not done for the body because some properties are not exposed, while technically still there and used
             //An example would be the face alpha mask not being exposed in koikatsu's v+ shaders, while still being applied if set in a shader that does expose it
 
             void removeProperties(ObjectType objectType, int slot, GameObject go)

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -2405,12 +2405,12 @@ namespace KK_Plugins.MaterialEditor
         {
             int removedCount = 0;
 
-            for (var i = 0; i < ChaControl.objClothes.Length; i++)
-                removeProperties(ObjectType.Clothing, i, ChaControl.objClothes[i]);
-            for (var i = 0; i < ChaControl.objAccessory.Length; i++)
-                removeProperties(ObjectType.Accessory, i, ChaControl.objAccessory[i]);
-            for (var i = 0; i < ChaControl.objHair.Length; i++)
-                removeProperties(ObjectType.Hair, i, ChaControl.objHair[i]);
+            for (var i = 0; i < ChaControl.GetClothes().Length; i++)
+                removeProperties(ObjectType.Clothing, i, ChaControl.GetClothes()[i]);
+            for (var i = 0; i < ChaControl.GetAccessoryObjects().Length; i++)
+                removeProperties(ObjectType.Accessory, i, ChaControl.GetAccessoryObjects()[i]);
+            for (var i = 0; i < ChaControl.GetHair().Length; i++)
+                removeProperties(ObjectType.Hair, i, ChaControl.GetHair()[i]);
             //The same is not done for the body because some properties are exposed, while technically still there and used
             //An example would be the face alpha mask not being exposed in koikatsu's v+ shaders, while still being applied if set in a shader that does expose it
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.cs
@@ -83,6 +83,7 @@ namespace KK_Plugins.MaterialEditor
         internal static ConfigEntry<KeyboardShortcut> EnableReceiveShadows { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> ResetReceiveShadows { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> PasteEditsHotkey { get; private set; }
+        internal static ConfigEntry<KeyboardShortcut> PurgeOrphanedPropertiesHotkey { get; private set; }
 
         internal static ConfigEntry<bool> RendererCachingEnabled { get; private set; }
 
@@ -152,6 +153,7 @@ namespace KK_Plugins.MaterialEditor
             EnableReceiveShadows = Config.Bind("Keyboard Shortcuts", "Enable ReceiveShadows", new KeyboardShortcut(KeyCode.N, KeyCode.LeftAlt), "Enable ReceiveShadows for all selected items and their child items in Studio");
             ResetReceiveShadows = Config.Bind("Keyboard Shortcuts", "Reset ReceiveShadows", new KeyboardShortcut(KeyCode.N, KeyCode.LeftControl, KeyCode.LeftAlt), "Reset ReceiveShadows for all selected items and their child items in Studio");
             PasteEditsHotkey = Config.Bind("Keyboard Shortcuts", "Paste Edits", new KeyboardShortcut(KeyCode.N), "Paste any copied edits for all selected items and their child items in Studio");
+            PurgeOrphanedPropertiesHotkey = Config.Bind("Keyboard Shortcuts", "Purge Orphaned Properties", new KeyboardShortcut(KeyCode.R, KeyCode.LeftShift, KeyCode.LeftControl), "Remove any properties no longer associated with anything on the current outfit");
 #if PH
             //Disable ShaderOptimization since it doesn't work properly
             ShaderOptimization.Value = false;
@@ -995,7 +997,7 @@ namespace KK_Plugins.MaterialEditor
         }
 #endif
 
-        protected override Texture ConvertNormalMap( Texture tex)
+        protected override Texture ConvertNormalMap(Texture tex)
         {
             var material = NormalMapConvertMaterial;
             if (IsUncompressedNormalMap(tex))


### PR DESCRIPTION
ME still leaves behind some orphaned properties now and then. Especially since before property deletion of deleted outfits. While these properties are mostly not a problem, they can cause major bloat when they keep a reference to a texture alive.
This shortcut looks at all the current outfit game objects and deletes all properties that can't be connected to them.

The body is excluded because it seems to cause a lot of issues with deleting properties that should not be deleted.

I haven't found any errors in removing properties and multiple people have tested it too and they also say everything seems to load back fine.