### PR TITLE
[ME] fix normalmap conversion on item copy and timeline texture change

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -378,7 +378,10 @@ namespace KK_Plugins.MaterialEditor
                             MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.TexID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal);
 
                             bool setTex = false;
-                            if (loadedProperty.TexID != null) setTex = SetTexture(ociItem.objectItem, newTextureProperty.MaterialName, newTextureProperty.Property, TextureDictionary[(int)newTextureProperty.TexID].Texture);
+
+                            var tex = TextureDictionary[(int)newTextureProperty.TexID].Texture;
+                            Instance.ConvertNormalMap(ref tex, newTextureProperty.Property);
+                            if (loadedProperty.TexID != null) setTex = SetTexture(ociItem.objectItem, newTextureProperty.MaterialName, newTextureProperty.Property, tex);
 
                             bool setOffset = SetTextureOffset(ociItem.objectItem, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Offset);
                             bool setScale = SetTextureScale(ociItem.objectItem, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Scale);

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.TimelineCompatibilityHelper.cs
@@ -119,7 +119,12 @@ namespace MaterialEditorAPI
                    owner: "MaterialEditor",
                    id: "textureProperty",
                    name: "Texture Property",
-                   interpolateBefore: (oci, parameter, leftValue, rightValue, factor) => SetTexture(parameter.GetGameObject(oci), parameter.materialName, parameter.propertyName, GetTextureByDictionaryID(leftValue)),
+                   interpolateBefore: (oci, parameter, leftValue, rightValue, factor) =>
+                   {
+                       var tex = GetTextureByDictionaryID(leftValue);
+                       MaterialEditorPluginBase.Instance.ConvertNormalMap(ref tex, parameter.propertyName);
+                       SetTexture(parameter.GetGameObject(oci), parameter.materialName, parameter.propertyName, tex);
+                   },
                    interpolateAfter: null,
                    getValue: (oci, parameter) =>
                    {


### PR DESCRIPTION
When copying an item in studio, or changing a texture through timeline, ME would not convert the OpenGL normals to the red ones when applying the texture.

Did a quick pass on all the places `SetTexture` was used to see if the conversion was needed there. Only noticed the timeline texture changing were it would be needed.