### PR TITLE
[Shared] Optimized sequence equal

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -672,7 +672,7 @@ namespace KK_Plugins.MaterialEditor
         {
             int highestID = 0;
             foreach (var tex in TextureDictionary)
-                if (tex.Value.Data.SequenceEqual(textureBytes))
+                if (Utility.FastSequenceEqual(tex.Value.Data,textureBytes))
                     return tex.Key;
                 else if (tex.Key > highestID)
                     highestID = tex.Key;

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -672,7 +672,7 @@ namespace KK_Plugins.MaterialEditor
         {
             int highestID = 0;
             foreach (var tex in TextureDictionary)
-                if (Utility.FastSequenceEqual(tex.Value.Data,textureBytes))
+                if (Utility.SequenceEqualFast(tex.Value.Data,textureBytes))
                     return tex.Key;
                 else if (tex.Key > highestID)
                     highestID = tex.Key;

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -855,7 +855,7 @@ namespace KK_Plugins.MaterialEditor
         {
             int highestID = 0;
             foreach (var tex in TextureDictionary)
-                if (Utility.FastSequenceEqual(tex.Value.Data,textureBytes))
+                if (Utility.SequenceEqualFast(tex.Value.Data,textureBytes))
                     return tex.Key;
                 else if (tex.Key > highestID)
                     highestID = tex.Key;

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -855,7 +855,7 @@ namespace KK_Plugins.MaterialEditor
         {
             int highestID = 0;
             foreach (var tex in TextureDictionary)
-                if (tex.Value.Data.SequenceEqual(textureBytes))
+                if (Utility.FastSequenceEqual(tex.Value.Data,textureBytes))
                     return tex.Key;
                 else if (tex.Key > highestID)
                     highestID = tex.Key;

--- a/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
@@ -58,7 +58,7 @@ namespace KK_Plugins
             /// <param name="a">The first byte array to compare.</param>
             /// <param name="b">The second byte array to compare.</param>
             /// <returns>True if the byte arrays are equal, false otherwise.</returns>
-            static private bool SequenceEqual( byte[] a, byte[] b )
+            static private bool SequenceEqual(byte[] a, byte[] b)
             {
                 // Check if both references are the same, if so, return true.
                 if (System.Object.ReferenceEquals(a, b))
@@ -75,43 +75,43 @@ namespace KK_Plugins
                 unsafe
                 {
                     // Fix the memory locations of the arrays to prevent the garbage collector from moving them.
-                    fixed (byte* s = &a[0])
-                    fixed (byte* t = &b[0])
+                    fixed (byte* pA = &a[0])
+                    fixed (byte* pB = &b[0])
                     {
                         int offset = 0;
 
                         // If both pointers are 8-byte aligned, use 64-bit comparison.
-                        if (((int)s & 7) == 0 && ((int)t & 7) == 0)
+                        if (((int)pA & 7) == 0 && ((int)pB & 7) == 0)
                         {
-                            ulong* x = (ulong*)s;
-                            ulong* y = (ulong*)t;
-                            offset = bytes & ~7;        // Round down to the nearest multiple of 8.
-                            int len = offset >> 3;      // Divide by 8 to get the number of 64-bit blocks.
+                            ulong* ulongA = (ulong*)pA;
+                            ulong* ulongB = (ulong*)pB;
+                            offset = bytes & ~7;       // Round down to the nearest multiple of 8.
+                            int count = offset >> 3;    // Divide by 8 to get the number of 64-bit blocks.
 
-                            for ( int i = 0; i < len; ++i )
+                            for (int i = 0; i < count; ++i)
                             {
-                                if (x[i] != y[i])
+                                if (ulongA[i] != ulongB[i])
                                     goto NotEquals;
                             }
                         }
                         // If both pointers are 4-byte aligned, use 32-bit comparison.
-                        else if (((int)s & 3) == 0 && ((int)t & 3) == 0)
+                        else if (((int)pA & 3) == 0 && ((int)pB & 3) == 0)
                         {
-                            uint* x = (uint*)s;
-                            uint* y = (uint*)t;
-                            offset = bytes & ~3;        // Round down to the nearest multiple of 4.
-                            int len = offset >> 2;      // Divide by 4 to get the number of 32-bit blocks.
+                            uint* uintA = (uint*)pA;
+                            uint* uintB = (uint*)pB;
+                            offset = bytes & ~3;       // Round down to the nearest multiple of 4.
+                            int count = offset >> 2;    // Divide by 4 to get the number of 32-bit blocks.
 
-                            for (int i = 0; i < len; ++i)
+                            for (int i = 0; i < count; ++i)
                             {
-                                if (x[i] != y[i])
+                                if (uintA[i] != uintB[i])
                                     goto NotEquals;
                             }
                         }
 
                         // Compare remaining bytes one by one.
                         for (int i = offset; i < bytes; ++i)
-                            if (s[i] != t[i])
+                            if (pA[i] != pB[i])
                                 goto NotEquals;
                     }
                 }

--- a/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
@@ -46,83 +46,12 @@ namespace KK_Plugins
                     return other.hash == hash &&
                         other.format == format &&
                         other.mipmaps == mipmaps &&
-                        SequenceEqual(other.data, data);
+                        Utility.FastSequenceEqual(other.data, data);
                 }
 
                 return false;
             }
 
-            /// <summary>
-            /// Compares two byte arrays for equality in a high-performance manner using unsafe code.
-            /// </summary>
-            /// <param name="a">The first byte array to compare.</param>
-            /// <param name="b">The second byte array to compare.</param>
-            /// <returns>True if the byte arrays are equal, false otherwise.</returns>
-            static private bool SequenceEqual(byte[] a, byte[] b)
-            {
-                // Check if both references are the same, if so, return true.
-                if (System.Object.ReferenceEquals(a, b))
-                    return true;
-
-                int bytes = a.Length;
-
-                if (bytes != b.Length)
-                    return false;
-
-                if (bytes <= 0)
-                    return true;
-
-                unsafe
-                {
-                    // Fix the memory locations of the arrays to prevent the garbage collector from moving them.
-                    fixed (byte* pA = &a[0])
-                    fixed (byte* pB = &b[0])
-                    {
-                        int offset = 0;
-
-                        // If both pointers are 8-byte aligned, use 64-bit comparison.
-                        if (((int)pA & 7) == 0 && ((int)pB & 7) == 0)
-                        {
-                            ulong* ulongA = (ulong*)pA;
-                            ulong* ulongB = (ulong*)pB;
-                            offset = bytes & ~7;       // Round down to the nearest multiple of 8.
-                            int count = offset >> 3;    // Divide by 8 to get the number of 64-bit blocks.
-
-                            for (int i = 0; i < count; ++i)
-                            {
-                                if (ulongA[i] != ulongB[i])
-                                    goto NotEquals;
-                            }
-                        }
-                        // If both pointers are 4-byte aligned, use 32-bit comparison.
-                        else if (((int)pA & 3) == 0 && ((int)pB & 3) == 0)
-                        {
-                            uint* uintA = (uint*)pA;
-                            uint* uintB = (uint*)pB;
-                            offset = bytes & ~3;       // Round down to the nearest multiple of 4.
-                            int count = offset >> 2;    // Divide by 4 to get the number of 32-bit blocks.
-
-                            for (int i = 0; i < count; ++i)
-                            {
-                                if (uintA[i] != uintB[i])
-                                    goto NotEquals;
-                            }
-                        }
-
-                        // Compare remaining bytes one by one.
-                        for (int i = offset; i < bytes; ++i)
-                            if (pA[i] != pB[i])
-                                goto NotEquals;
-                    }
-                }
-
-                return true;
-
-NotEquals:
-                // Return false indicating arrays are not equal.
-                // Note: Using a return statement in the loop can potentially degrade performance due to the generated binary code, 
-                return false;
-            }
 
             public override int GetHashCode()
             {

--- a/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
+++ b/src/Shared.TextureContainer/Shared.TextureContainerManager.cs
@@ -46,7 +46,7 @@ namespace KK_Plugins
                     return other.hash == hash &&
                         other.format == format &&
                         other.mipmaps == mipmaps &&
-                        Utility.FastSequenceEqual(other.data, data);
+                        Utility.SequenceEqualFast(other.data, data);
                 }
 
                 return false;

--- a/src/Shared/Shared.Utility.cs
+++ b/src/Shared/Shared.Utility.cs
@@ -13,7 +13,7 @@ namespace KK_Plugins
         /// <param name="a">The first byte array to compare.</param>
         /// <param name="b">The second byte array to compare.</param>
         /// <returns>True if the byte arrays are equal, false otherwise.</returns>
-        static public bool FastSequenceEqual(byte[] a, byte[] b)
+        static public bool SequenceEqualFast(byte[] a, byte[] b)
         {
             // Check if both references are the same, if so, return true.
             if (System.Object.ReferenceEquals(a, b))

--- a/src/Shared/Shared.Utility.cs
+++ b/src/Shared/Shared.Utility.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KK_Plugins
+{
+    internal class Utility
+    {
+
+        /// <summary>
+        /// Compares two byte arrays for equality in a high-performance manner using unsafe code.
+        /// </summary>
+        /// <param name="a">The first byte array to compare.</param>
+        /// <param name="b">The second byte array to compare.</param>
+        /// <returns>True if the byte arrays are equal, false otherwise.</returns>
+        static public bool FastSequenceEqual(byte[] a, byte[] b)
+        {
+            // Check if both references are the same, if so, return true.
+            if (System.Object.ReferenceEquals(a, b))
+                return true;
+
+            if (a == null || b == null)
+                return false;
+
+            int bytes = a.Length;
+
+            if (bytes != b.Length)
+                return false;
+
+            if (bytes <= 0)
+                return true;
+
+            unsafe
+            {
+                // Fix the memory locations of the arrays to prevent the garbage collector from moving them.
+                fixed (byte* pA = &a[0])
+                fixed (byte* pB = &b[0])
+                {
+                    int offset = 0;
+
+                    // If both pointers are 8-byte aligned, use 64-bit comparison.
+                    if (((int)pA & 7) == 0 && ((int)pB & 7) == 0 && bytes >= 32)
+                    {
+                        offset = bytes & ~31;       // Round down to the nearest multiple of 32.
+
+                        byte* pA_ = pA;
+                        byte* pB_ = pB;
+                        byte* pALast = pA + offset;
+
+                        do
+                        {
+                            if (*(ulong*)pA_ != *(ulong*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 8;
+                            pB_ += 8;
+
+                            if (*(ulong*)pA_ != *(ulong*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 8;
+                            pB_ += 8;
+
+                            if (*(ulong*)pA_ != *(ulong*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 8;
+                            pB_ += 8;
+
+                            if (*(ulong*)pA_ != *(ulong*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 8;
+                            pB_ += 8;
+                        }
+                        while (pA_ != pALast);
+                    }
+                    // If both pointers are 4-byte aligned, use 32-bit comparison.
+                    else if (((int)pA & 3) == 0 && ((int)pB & 3) == 0 && bytes >= 16)
+                    {
+                        offset = bytes & ~15;       // Round down to the nearest multiple of 16.
+
+                        byte* pA_ = pA;
+                        byte* pB_ = pB;
+                        byte* pALast = pA + offset;
+
+                        do
+                        {
+                            if (*(uint*)pA_ != *(uint*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 4;
+                            pB_ += 4;
+
+                            if (*(uint*)pA_ != *(uint*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 4;
+                            pB_ += 4;
+
+                            if (*(uint*)pA_ != *(uint*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 4;
+                            pB_ += 4;
+
+                            if (*(uint*)pA_ != *(uint*)pB_)
+                                goto NotEquals;
+
+                            pA_ += 4;
+                            pB_ += 4;
+                        }
+                        while (pA_ != pALast);
+                    }
+
+                    // Compare remaining bytes one by one.
+                    for (int i = offset; i < bytes; ++i)
+                        if (pA[i] != pB[i])
+                            goto NotEquals;
+                }
+            }
+
+            return true;
+
+NotEquals:
+            // Return false indicating arrays are not equal.
+            // Note: Using a return statement in the loop can potentially degrade performance due to the generated binary code, 
+            return false;
+        }
+    }
+}

--- a/src/Shared/Shared.projitems
+++ b/src/Shared/Shared.projitems
@@ -15,5 +15,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Shared.Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Shared.Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Shared.TimelineCompatibility.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Shared.Utility.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Optimized SequenceEqual. Please merge if you have no problem.

The loading time for scenes containing large images with the same content is slightly reduced.
This change should also slightly reduce the loading time of apng/gifs.

---
Loading time for one huge scene

Before: average 33.78[s]
```
Scene loading completed: 34.1[s]
Scene loading completed: 33.6[s]
Scene loading completed: 33.5[s]
Scene loading completed: 33.3[s]
Scene loading completed: 34.4[s]
```

After: average 32.04[s] (-1.74)
```
Scene loading completed: 32.2[s]
Scene loading completed: 31.8[s]
Scene loading completed: 32.2[s]
Scene loading completed: 31.8[s]
Scene loading completed: 32.2[s]
```
---

Linq's SequenceEqual was taking 40ms to compare 4MB of data.

https://github.com/mono/mono/blob/c6cdaadb54a1173484f1ada524306ddbf8c2e7d5/mcs/class/referencesource/System.Core/System/Linq/Enumerable.cs#L944
I think the implementation is this SequenceEqual.
I think the overhead of MoveNext() and comparer in the Enumerator is the cause of the slowdown.
The large GCAlloc may also cause boxing by reference to Current.

---
I hadn't looked at the profiler in a while, and there was something at the top. So I looked into it.

![image](https://github.com/IllusionMods/KK_Plugins/assets/4230203/37930560-5eca-45f3-96f2-e15ae7c3280f)
Before Profile:  
[MonoProfilerOutput_2024-06-01_13-41-13.csv](https://github.com/user-attachments/files/15520655/MonoProfilerOutput_2024-06-01_13-41-13.csv)  
After Profile:  
[MonoProfilerOutput_2024-06-01_13-48-02.csv](https://github.com/user-attachments/files/15520656/MonoProfilerOutput_2024-06-01_13-48-02.csv)


