### PR TITLE
[ME] Drag labels to change float attached float values

### DIFF
--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -43,6 +43,7 @@ namespace MaterialEditorAPI
         public static ConfigEntry<float> UIWidth { get; set; }
         public static ConfigEntry<float> UIHeight { get; set; }
         public static ConfigEntry<float> UIListWidth { get; set; }
+        public static ConfigEntry<float> DragSensitivity { get; set; }
         public static ConfigEntry<bool> WatchTexChanges { get; set; }
         public static ConfigEntry<bool> ShaderOptimization { get; set; }
         public static ConfigEntry<bool> ExportBakedMesh { get; set; }
@@ -62,10 +63,11 @@ namespace MaterialEditorAPI
             Logger = base.Logger;
             Directory.CreateDirectory(ExportPath);
 
-            UIScale = Config.Bind("Config", "UI Scale", 1.75f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(1f, 3f), new ConfigurationManagerAttributes { Order = 5 }));
-            UIWidth = Config.Bind("Config", "UI Width", 0.3f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { Order = 4, ShowRangeAsPercent = false }));
-            UIHeight = Config.Bind("Config", "UI Height", 0.3f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { Order = 3, ShowRangeAsPercent = false }));
-            UIListWidth = Config.Bind("Config", "UI List Width", 180f, new ConfigDescription("Controls width of the renderer/materials lists to the side of the window", new AcceptableValueRange<float>(100f, 500f), new ConfigurationManagerAttributes { Order = 2, ShowRangeAsPercent = false }));
+            UIScale = Config.Bind("Config", "UI Scale", 1.75f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(1f, 3f), new ConfigurationManagerAttributes { Order = 7 }));
+            UIWidth = Config.Bind("Config", "UI Width", 0.3f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { Order = 6, ShowRangeAsPercent = false }));
+            UIHeight = Config.Bind("Config", "UI Height", 0.3f, new ConfigDescription("Controls the size of the window.", new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { Order = 5, ShowRangeAsPercent = false }));
+            UIListWidth = Config.Bind("Config", "UI List Width", 180f, new ConfigDescription("Controls width of the renderer/materials lists to the side of the window", new AcceptableValueRange<float>(100f, 500f), new ConfigurationManagerAttributes { Order = 4, ShowRangeAsPercent = false }));
+            DragSensitivity = Config.Bind("Config", "Drag Sensitivity", 30f, new ConfigDescription("Controls the sensitivity of dragging labels to edit float values", new AcceptableValueRange<float>(1f, 100f), new ConfigurationManagerAttributes { Order = 3, ShowRangeAsPercent = false }));
             WatchTexChanges = Config.Bind("Config", "Watch File Changes", true, new ConfigDescription("Watch for file changes and reload textures on change. Can be toggled in the UI.", null, new ConfigurationManagerAttributes { Order = 2 }));
             ShaderOptimization = Config.Bind("Config", "Shader Optimization", true, new ConfigDescription("Replaces every loaded shader with the MaterialEditor copy of the shader. Reduces the number of copies of shaders loaded which reduces RAM usage and improves performance.", null, new ConfigurationManagerAttributes { Order = 1 }));
             ExportBakedMesh = Config.Bind("Config", "Export Baked Mesh", false, new ConfigDescription("When enabled, skinned meshes will be exported in their current state with all customization applied as well as in the current pose.", null, new ConfigurationManagerAttributes { Order = 1 }));

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -871,7 +871,7 @@ namespace MaterialEditorAPI
             dragText.OnDragAsObservable().Subscribe(drag =>
             {
                 float multiplier = 0f;
-                float delta = drag.delta.x * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) / 10000;
+                float delta = drag.delta.x / Screen.dpi * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) * (MaterialEditorPluginBase.DragSensitivity.Value / 100f);
                 if (float.TryParse(inputField.text, out float input))
                 {
                     multiplier = delta / input + 1;

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -655,6 +655,8 @@ namespace MaterialEditorAPI
                         FloatSlider.value = item.FloatValue;
                         FloatInputField.text = item.FloatValue.ToString();
 
+                        SubscribeToOnDragUpdateInput(FloatLabel, FloatInputField);
+
                         FloatSlider.onValueChanged.AddListener(value =>
                         {
                             FloatInputField.text = value.ToString();
@@ -669,6 +671,7 @@ namespace MaterialEditorAPI
                                 return;
                             }
                             item.FloatValue = input;
+                            FloatInputField.text = item.FloatValue.ToString();
 
                             FloatSlider.Set(item.FloatValue, sendCallback: false);
 
@@ -856,13 +859,13 @@ namespace MaterialEditorAPI
             return component;
         }
 
-        /// <summary>
-        /// Subscribes to the on onDrag event on the given Text object, and updates the given input field(s) according to the drag
-        /// </summary>
-        /// <param name="dragText">The text that should be draggable</param>
-        /// <param name="inputField">The InputField that should be updated upon dragging</param>
-        /// <param name="pairedInputFields">This InputField will also be updated if alt is held while dragging (e.g. pairing X and Y fields)</param>
-        public void SubscribeToOnDragUpdateInput(Text dragText, InputField inputField, InputField[] pairedInputFields = null)
+    /// <summary>
+    /// Subscribes to the on onDrag event on the given Text object, and updates the given input field(s) according to the drag
+    /// </summary>
+    /// <param name="dragText">The text that should be draggable</param>
+    /// <param name="inputField">The InputField that should be updated upon dragging</param>
+    /// <param name="pairedInputFields">This InputField will also be updated if alt is held while dragging (e.g. pairing X and Y fields)</param>
+    public void SubscribeToOnDragUpdateInput(Text dragText, InputField inputField, InputField[] pairedInputFields = null)
         {
 #if !API
             dragText.OnDragAsObservable().Subscribe(drag =>
@@ -870,10 +873,7 @@ namespace MaterialEditorAPI
                 float multiplier = 0f;
                 float delta = drag.delta.x * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) / 1000;
                 if (float.TryParse(inputField.text, out float input))
-                {
-                    multiplier = delta / input + 1;
                     inputField.onEndEdit.Invoke((input + delta).ToString());
-                }
                 if (pairedInputFields?.Length > 0 && Input.GetKey(KeyCode.LeftAlt))
                     foreach (var pairedInputField in pairedInputFields)
                         if (float.TryParse(pairedInputField.text, out float pairedInput))

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -873,7 +873,10 @@ namespace MaterialEditorAPI
                 float multiplier = 0f;
                 float delta = drag.delta.x * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) / 1000;
                 if (float.TryParse(inputField.text, out float input))
+                {
+                    multiplier = delta / input + 1;
                     inputField.onEndEdit.Invoke((input + delta).ToString());
+                }
                 if (pairedInputFields?.Length > 0 && Input.GetKey(KeyCode.LeftAlt))
                     foreach (var pairedInputField in pairedInputFields)
                         if (float.TryParse(pairedInputField.text, out float pairedInput))

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -393,10 +393,10 @@ namespace MaterialEditorAPI
                         ScaleXInput.text = item.Scale.x.ToString();
                         ScaleYInput.text = item.Scale.y.ToString();
 
-                        SubscribeToOnDragUpdateInput(OffsetXText, OffsetXInput, OffsetYInput);
-                        SubscribeToOnDragUpdateInput(OffsetYText, OffsetYInput, OffsetXInput);
-                        SubscribeToOnDragUpdateInput(ScaleXText, ScaleXInput, ScaleYInput);
-                        SubscribeToOnDragUpdateInput(ScaleYText, ScaleYInput, ScaleXInput);
+                        SubscribeToOnDragUpdateInput(OffsetXText, OffsetXInput, new[] { OffsetYInput });
+                        SubscribeToOnDragUpdateInput(OffsetYText, OffsetYInput, new[] { OffsetXInput });
+                        SubscribeToOnDragUpdateInput(ScaleXText, ScaleXInput, new[] { ScaleYInput });
+                        SubscribeToOnDragUpdateInput(ScaleYText, ScaleYInput, new[] { ScaleXInput });
 
                         OffsetXInput.onEndEdit.AddListener(value =>
                         {
@@ -505,9 +505,9 @@ namespace MaterialEditorAPI
                         ColorBInput.text = item.ColorValue.b.ToString();
                         ColorAInput.text = item.ColorValue.a.ToString();
 
-                        SubscribeToOnDragUpdateInput(ColorRText, ColorRInput);
-                        SubscribeToOnDragUpdateInput(ColorGText, ColorGInput);
-                        SubscribeToOnDragUpdateInput(ColorBText, ColorBInput);
+                        SubscribeToOnDragUpdateInput(ColorRText, ColorRInput, new[] { ColorGInput, ColorBInput });
+                        SubscribeToOnDragUpdateInput(ColorGText, ColorGInput, new[] { ColorRInput, ColorBInput });
+                        SubscribeToOnDragUpdateInput(ColorBText, ColorBInput, new[] { ColorRInput, ColorGInput });
                         SubscribeToOnDragUpdateInput(ColorAText, ColorAInput);
 
                         ColorEditButton.image.color = item.ColorValue;
@@ -861,8 +861,8 @@ namespace MaterialEditorAPI
         /// </summary>
         /// <param name="dragText">The text that should be draggable</param>
         /// <param name="inputField">The InputField that should be updated upon dragging</param>
-        /// <param name="pairedInputField">This InputField will also be updated if alt is held while dragging (e.g. pairing X and Y fields)</param>
-        public void SubscribeToOnDragUpdateInput(Text dragText, InputField inputField, InputField pairedInputField = null)
+        /// <param name="pairedInputFields">This InputField will also be updated if alt is held while dragging (e.g. pairing X and Y fields)</param>
+        public void SubscribeToOnDragUpdateInput(Text dragText, InputField inputField, InputField[] pairedInputFields = null)
         {
 #if !API
             dragText.OnDragAsObservable().Subscribe(drag =>
@@ -872,8 +872,10 @@ namespace MaterialEditorAPI
                 {
                     inputField.onEndEdit.Invoke((input + delta).ToString());
                 }
-                if (pairedInputField != null && Input.GetKey(KeyCode.LeftAlt) && float.TryParse(pairedInputField.text, out float pairedInput))
-                    pairedInputField.onEndEdit.Invoke((pairedInput + delta).ToString());
+                if (pairedInputFields?.Length > 0 && Input.GetKey(KeyCode.LeftAlt))
+                    foreach(var pairedInputField in pairedInputFields)
+                        if(float.TryParse(pairedInputField.text, out float pairedInput))
+                            pairedInputField.onEndEdit.Invoke((pairedInput + delta).ToString());
             });
 #endif
         }

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -867,15 +867,23 @@ namespace MaterialEditorAPI
 #if !API
             dragText.OnDragAsObservable().Subscribe(drag =>
             {
+                float multiplier = 0f;
                 float delta = drag.delta.x * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) / 1000;
                 if (float.TryParse(inputField.text, out float input))
                 {
+                    multiplier = delta / input + 1;
                     inputField.onEndEdit.Invoke((input + delta).ToString());
                 }
                 if (pairedInputFields?.Length > 0 && Input.GetKey(KeyCode.LeftAlt))
-                    foreach(var pairedInputField in pairedInputFields)
-                        if(float.TryParse(pairedInputField.text, out float pairedInput))
-                            pairedInputField.onEndEdit.Invoke((pairedInput + delta).ToString());
+                    foreach (var pairedInputField in pairedInputFields)
+                        if (float.TryParse(pairedInputField.text, out float pairedInput))
+                        {
+                            if (Input.GetKey(KeyCode.Mouse1) && !float.IsInfinity(multiplier) && !float.IsNaN(multiplier))
+                                pairedInputField.onEndEdit.Invoke((pairedInput * multiplier).ToString());
+                            else
+                                pairedInputField.onEndEdit.Invoke((pairedInput + delta).ToString());
+                        }
+
             });
 #endif
         }

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -871,7 +871,7 @@ namespace MaterialEditorAPI
             dragText.OnDragAsObservable().Subscribe(drag =>
             {
                 float multiplier = 0f;
-                float delta = drag.delta.x * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) / 1000;
+                float delta = drag.delta.x * (Input.GetKey(KeyCode.LeftShift) ? 10f : 1f) / (Input.GetKey(KeyCode.LeftControl) ? 10f : 1f) / 10000;
                 if (float.TryParse(inputField.text, out float input))
                 {
                     multiplier = delta / input + 1;


### PR DESCRIPTION
Allows for dragging on the labels to change values, just like it works in the transform panel in studio, or the accessory transform panel in maker.

It accepts a few modifiers to change thebehaviour:
- `shift`: Speed up movement by a factor of 10
- `ctrl`: Slow down movement by a factor of 10
- `alt`: Also change a connected field an even amount (e.g. also change X when changing Y)
- `right click`: When used in combination with `alt`, keeps the current ratio between the values intact

This works for all the different float values ME shows
- Texture offset (Combines X and Y for `alt`)
- Texture scale (Combines X and Y for `alt`)
- RGBA values (Combines RGB for `alt`)
- Float sliders (Dragging the label ignores the slider min/max)

https://github.com/IllusionMods/KK_Plugins/assets/141709004/84cbb990-0223-42c7-9668-24fa77ac7afc