### PR TITLE
[ME] Fix mipmap calculation in WebP

### DIFF
--- a/src/Shared.TextureContainer/Shared.ImageHelper.cs
+++ b/src/Shared.TextureContainer/Shared.ImageHelper.cs
@@ -60,6 +60,23 @@ namespace KK_Plugins
             return tex;
         }
 
+        internal static int CalculateTextureBytes(int width, int height, bool mipmap)
+        {
+            int bytes = width * height * 4;
+
+            if (!mipmap)
+                return bytes;
+
+            while (width > 1 || height > 1)
+            {
+                width = (width + 1) >> 1;
+                height = (height + 1) >> 1;
+                bytes += width * height * 4;
+            }
+
+            return bytes;
+        }
+
         /// <summary>
         /// Load all needed dependencies for loading all the supported file formats.
         /// Needs to be to be run before any classes using these dependencies are loaded!

--- a/src/Shared.TextureContainer/Shared.ImageHelper.cs
+++ b/src/Shared.TextureContainer/Shared.ImageHelper.cs
@@ -60,23 +60,6 @@ namespace KK_Plugins
             return tex;
         }
 
-        internal static int CalculateTextureBytes(int width, int height, bool mipmap)
-        {
-            int bytes = width * height * 4;
-
-            if (!mipmap)
-                return bytes;
-
-            while (width > 1 || height > 1)
-            {
-                width = (width + 1) >> 1;
-                height = (height + 1) >> 1;
-                bytes += width * height * 4;
-            }
-
-            return bytes;
-        }
-
         /// <summary>
         /// Load all needed dependencies for loading all the supported file formats.
         /// Needs to be to be run before any classes using these dependencies are loaded!

--- a/src/Shared.TextureContainer/WebP/Texture2DExt.cs
+++ b/src/Shared.TextureContainer/WebP/Texture2DExt.cs
@@ -1,12 +1,11 @@
 ﻿//https://github.com/octo-code/webp-unity3d
 using System;
-using System.Text;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 using UnityEngine;
 
 using WebP.Extern;
+using KK_Plugins;
 
 namespace WebP
 {
@@ -112,13 +111,8 @@ namespace WebP
 				{
 					scalingFunction(ref lWidth, ref lHeight);
 				}
-				
-				// If mipmaps are requested we need to create 1/3 more memory for the mipmaps to be generated in.
-				int numBytesRequired = lWidth * lHeight * 4;
-				if (lMipmaps)
-				{
-					numBytesRequired = Mathf.CeilToInt((numBytesRequired * 4.0f) / 3.0f);
-				}
+
+				int numBytesRequired = ImageHelper.CalculateTextureBytes(lWidth, lHeight, lMipmaps);
 				
 				lRawData = new byte[numBytesRequired];
 				fixed (byte* lRawDataPtr = lRawData)

--- a/src/Shared.TextureContainer/WebP/Texture2DExt.cs
+++ b/src/Shared.TextureContainer/WebP/Texture2DExt.cs
@@ -112,7 +112,7 @@ namespace WebP
 					scalingFunction(ref lWidth, ref lHeight);
 				}
 
-				int numBytesRequired = ImageHelper.CalculateTextureBytes(lWidth, lHeight, lMipmaps);
+				int numBytesRequired = CalculateTextureBytes(lWidth, lHeight, lMipmaps);
 				
 				lRawData = new byte[numBytesRequired];
 				fixed (byte* lRawDataPtr = lRawData)
@@ -269,6 +269,23 @@ namespace WebP
             }
 
             return lOutputBuffer;
+        }
+
+        internal static int CalculateTextureBytes(int width, int height, bool mipmap)
+        {
+            int bytes = width * height * 4;
+
+            if (!mipmap)
+                return bytes;
+
+            while (width > 1 || height > 1)
+            {
+                width = (width + 1) >> 1;
+                height = (height + 1) >> 1;
+                bytes += width * height * 4;
+            }
+
+            return bytes;
         }
     }
 }

--- a/src/Shared.TextureContainer/WebP/Texture2DExt.cs
+++ b/src/Shared.TextureContainer/WebP/Texture2DExt.cs
@@ -1,11 +1,8 @@
 ﻿//https://github.com/octo-code/webp-unity3d
 using System;
 using System.Runtime.InteropServices;
-
 using UnityEngine;
-
 using WebP.Extern;
-using KK_Plugins;
 
 namespace WebP
 {


### PR DESCRIPTION
When mipmaps are generated, more bytes need to be allocated for the texture that is going to be generated. The original calculation had a chance to allocate too few bytes when using a non-square texture.
The new calcaution fixes that. Thanks to @takahiro0327 for the formula.