### PR TITLE
[ME] Fix loading of broken texture properties

### DIFF
--- a/src/MaterialEditor.Base/NormalMapManager.cs
+++ b/src/MaterialEditor.Base/NormalMapManager.cs
@@ -39,50 +39,57 @@ namespace MaterialEditorAPI
         /// <returns>True if the texture was converted</returns>
         public bool ConvertNormalMap(ref Texture tex, string propertyName)
         {
-            if (!NormalMapProperties.Any(x => propertyName.Contains(x)))
-                return false;
-
-            if (tex == null || IsBrokenTexture(tex))
-                return false;
-
-            Texture normalTex;
-
-            if ( _convertedNormalMap.TryGetValue(tex, out var normalMapRef) )
+            try
             {
-                //It was a texture that had been converted in the past.
-                if (normalMapRef != null)
-                {
-                    normalTex = (Texture)normalMapRef.Target;
+                if (!NormalMapProperties.Any(x => propertyName.Contains(x)))
+                    return false;
 
-                    if(normalTex != null)
+                if (tex == null || IsBrokenTexture(tex))
+                    return false;
+
+                Texture normalTex;
+
+                if (_convertedNormalMap.TryGetValue(tex, out var normalMapRef))
+                {
+                    //It was a texture that had been converted in the past.
+                    if (normalMapRef != null)
                     {
-                        tex = normalTex;
-                        return true;
+                        normalTex = (Texture)normalMapRef.Target;
+
+                        if (normalTex != null)
+                        {
+                            tex = normalTex;
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        // Unsupported textures
+                        return false;
                     }
                 }
-                else
+
+                //Never converted or had been converted but was deleted.
+                normalTex = ConvertNormalMap(tex);
+
+                if (normalTex == null)
                 {
                     // Unsupported textures
+                    _convertedNormalMap[tex] = null;
                     return false;
                 }
+
+                var weakref = new WeakReference(normalTex);
+                _convertedNormalMap[tex] = weakref;         //If the same conversion comes in, return this texture.
+                _convertedNormalMap[normalTex] = weakref;   //If a converted texture comes in, return this texture.
+
+                tex = normalTex;
+                return true;
             }
-
-            //Never converted or had been converted but was deleted.
-            normalTex = ConvertNormalMap(tex);
-
-            if (normalTex == null )
+            catch
             {
-                // Unsupported textures
-                _convertedNormalMap[tex] = null;
                 return false;
             }
-
-            var weakref = new WeakReference(normalTex);
-            _convertedNormalMap[tex] = weakref;         //If the same conversion comes in, return this texture.
-            _convertedNormalMap[normalTex] = weakref;   //If a converted texture comes in, return this texture.
-
-            tex = normalTex;
-            return true;
         }
 
         /// <summary>

--- a/src/MaterialEditor.Base/NormalMapManager.cs
+++ b/src/MaterialEditor.Base/NormalMapManager.cs
@@ -86,8 +86,9 @@ namespace MaterialEditorAPI
                 tex = normalTex;
                 return true;
             }
-            catch
+            catch(Exception ex)
             {
+                Logger.LogError(ex);
                 return false;
             }
         }

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -1259,7 +1259,7 @@ namespace KK_Plugins.MaterialEditor
         /// <returns>True if the value was set, false if it could not be set</returns>
         private bool SetTextureWithProperty(GameObject go, MaterialTextureProperty textureProperty)
         {
-            if (!textureProperty.TexID.HasValue)
+            if (!textureProperty.TexID.HasValue || !textureProperty.NullCheck())
                 return false;
 
             int texID = textureProperty.TexID.Value;

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -582,7 +582,7 @@ namespace KK_Plugins.MaterialEditor
                     for (var i = 0; i < properties.Count; i++)
                     {
                         var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
+                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType) && !loadedProperty.NullCheck())
                         {
                             int? texID = null;
                             if (loadedProperty.TexID != null && importDictionary.TryGetValue((int)loadedProperty.TexID, out var importTextID))
@@ -1345,7 +1345,7 @@ namespace KK_Plugins.MaterialEditor
         /// <returns>True if the value was set, false if it could not be set</returns>
         private bool SetTextureWithProperty(GameObject go, MaterialTextureProperty textureProperty)
         {
-            if (!textureProperty.TexID.HasValue)
+            if (!textureProperty.TexID.HasValue || !textureProperty.NullCheck())
                 return false;
 
             int texID = textureProperty.TexID.Value;
@@ -3127,7 +3127,7 @@ namespace KK_Plugins.MaterialEditor
             /// Check if the TexID, Offset, and Scale are all null. Safe to remove this data if true.
             /// </summary>
             /// <returns></returns>
-            public bool NullCheck() => TexID == null && Offset == null && Scale == null;
+            public bool NullCheck() => (TexID == null && Offset == null && Scale == null) || Property == null || MaterialName == null;
         }
 
         /// <summary>

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -3124,10 +3124,18 @@ namespace KK_Plugins.MaterialEditor
             }
 
             /// <summary>
-            /// Check if the TexID, Offset, and Scale are all null. Safe to remove this data if true.
+            /// Check if any of a subset of properties is null. Which either make it safe to remove or a broken property.
+            /// Both cases make the TextureProperty safe for removal
             /// </summary>
             /// <returns></returns>
-            public bool NullCheck() => (TexID == null && Offset == null && Scale == null) || Property == null || MaterialName == null;
+            public bool NullCheck() 
+            {
+                // These become null when an animated texture is removed
+                var safeToRemove = TexID == null && Offset == null && Scale == null;
+                // These should never be null, and the property will never work if they are (and can cause issues)
+                var brokenProperty = Property == null || MaterialName == null;
+                return safeToRemove || brokenProperty;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
It is apparently possible that ME saves a property with certain values as `null` that should never be `null`. I don't know how this would happen, but when this happens to a texture property, loading will fail when it hits this property.
The cause for the instance I was checking was because the method that converts normalmaps checks if the property is a normalmap property, but this fails if the property name is `null`.

`null` Values don't seem to be a problem for any other property types because they're just passed around until it hits the actual Unity method, which doesn't care about `null` values itself.

So to fix this I added some `null` checks to the texture property to prevent this.