### PR TITLE
[Colliders] Reduce FindObjects

### DIFF
--- a/src/Colliders.Core/Core.Colliders.Controller.cs
+++ b/src/Colliders.Core/Core.Colliders.Controller.cs
@@ -33,10 +33,24 @@ namespace KK_Plugins
 
             private bool didSetStates;
 
+            private static HashSet<ColliderController> allControllers = new HashSet<ColliderController>();
+
             private float BreastSize => ChaControl.chaFile.custom.body.shapeValueBody[(int)BodyShapeIdx.BustSize];
             public bool BreastCollidersEnabled { get; set; }
             public bool SkirtCollidersEnabled { get; set; }
             public bool FloorColliderEnabled { get; set; }
+
+            protected override void Awake()
+            {
+                base.Awake();
+                allControllers.Add(this);
+            }
+
+            protected override void OnDestroy()
+            {
+                allControllers.Remove(this);
+                base.OnDestroy();
+            }
 
             internal void Main()
             {
@@ -263,12 +277,13 @@ namespace KK_Plugins
             }
             private void UpdateArmCollidersBreastDBAll()
             {
-                var controllers = FindObjectsOfType<ColliderController>();
                 var dynamicBones = GetComponentsInChildren<DynamicBone_Ver02>(true);
 
-                for (var i = 0; i < controllers.Length; i++)
-                    for (var j = 0; j < dynamicBones.Length; j++)
-                        UpdateArmCollidersBreastDB(dynamicBones[j], controllers[i].ArmColliders);
+                foreach ( var controller in GetAllColliderControllers() )
+                {
+                    for (var i = 0; i < dynamicBones.Length; i++)
+                        UpdateArmCollidersBreastDB(dynamicBones[i], controller.ArmColliders);
+                }   
             }
 
             /// <summary>
@@ -380,6 +395,16 @@ namespace KK_Plugins
                 }
             }
 #endif
+
+            /// <summary>
+            /// Get all active controllers
+            /// </summary>
+            static public IEnumerable<ColliderController> GetAllColliderControllers()
+            {
+                foreach (var controller in allControllers)
+                    if (controller && controller.enabled)
+                        yield return controller;
+            }
         }
     }
 }

--- a/src/Colliders.Core/Core.Colliders.Controller.cs
+++ b/src/Colliders.Core/Core.Colliders.Controller.cs
@@ -399,7 +399,7 @@ namespace KK_Plugins
             /// <summary>
             /// Get all active controllers
             /// </summary>
-            static public IEnumerable<ColliderController> GetAllColliderControllers()
+            public static IEnumerable<ColliderController> GetAllColliderControllers()
             {
                 foreach (var controller in allControllers)
                     if (controller && controller.gameObject.activeInHierarchy)

--- a/src/Colliders.Core/Core.Colliders.Controller.cs
+++ b/src/Colliders.Core/Core.Colliders.Controller.cs
@@ -402,7 +402,7 @@ namespace KK_Plugins
             static public IEnumerable<ColliderController> GetAllColliderControllers()
             {
                 foreach (var controller in allControllers)
-                    if (controller && controller.enabled)
+                    if (controller && controller.gameObject.activeInHierarchy)
                         yield return controller;
             }
         }

--- a/src/Colliders.Core/Core.Colliders.cs
+++ b/src/Colliders.Core/Core.Colliders.cs
@@ -180,9 +180,8 @@ namespace KK_Plugins
             protected override void OnSceneSave() { }
             protected override void OnSceneLoad(SceneOperationKind operation, ReadOnlyDictionary<int, ObjectCtrlInfo> loadedItems)
             {
-                var controllers = FindObjectsOfType<ColliderController>();
-                for (var i = 0; i < controllers.Length; i++)
-                    controllers[i].ApplyColliders();
+                foreach( var controller in ColliderController.GetAllColliderControllers())
+                    controller.ApplyColliders();
             }
         }
     }


### PR DESCRIPTION
I reduced the number of calls to FindObjects.
I don't think that all FindObjects should be deleted. However, I fixed the FindObjects for Collider because the number of calls during scene loading was a little high.
Please review and merge.

Changes in loading time for huge scenes:

Before average 34.5
```
Scene loading completed: 34.4[s]
Scene loading completed: 34.8[s]
Scene loading completed: 34.3[s]
Scene loading completed: 34.6[s]
Scene loading completed: 34.4[s]
```

After average 33.62 -0.88
```
Scene loading completed: 33.8[s]
Scene loading completed: 33.9[s]
Scene loading completed: 33.5[s]
Scene loading completed: 33.6[s]
Scene loading completed: 33.3[s]
```