### PR TITLE
[AI/HS2] Reapply the body alpha mask texture after loading new body

### DIFF
--- a/src/UncensorSelector.Core/Core.UncensorSelector.Controller.cs
+++ b/src/UncensorSelector.Core/Core.UncensorSelector.Controller.cs
@@ -397,6 +397,8 @@ namespace KK_Plugins
 
 #if KK || EC || KKS
                     ChaControl.customMatBody.SetTexture(ChaShader._AlphaMask, ChaControl.texBodyAlphaMask);
+#elif AI || HS2
+                    ChaControl.customMatBody.SetTexture(ChaShader.AlphaMask, ChaControl.texBodyAlphaMask);
 #endif
                     ChaControl.updateAlphaMask = true;
                 }


### PR DESCRIPTION
This change addresses an issue specific to AI and HS2 in which loading an uncensor led to the body alpha mask texture getting lost in the process; the change simply reapplies the texture in question before the updateAlphaMask flag is set to true. This was already in place for KK, EC and KKS.
`ChaShader.AlphaMask` in AI and HS2 is the equivalent to `ChaShader._AlphaMask` in KK, EC and KKS.