### PR TITLE
[ME] Allways show timeline buttons in studio

### DIFF
--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -48,7 +48,6 @@ namespace MaterialEditorAPI
         public static ConfigEntry<bool> ExportBakedWorldPosition { get; set; }
         internal static ConfigEntry<string> ConfigExportPath { get; private set; }
         public static ConfigEntry<bool> PersistFilter { get; set; }
-        public static ConfigEntry<bool> ShowTimelineButtons { get; set; }
         public static ConfigEntry<float> ProjectorNearClipPlaneMax { get; set; }
         public static ConfigEntry<float> ProjectorFarClipPlaneMax { get; set; }
         public static ConfigEntry<float> ProjectorFieldOfViewMax { get; set; }
@@ -72,7 +71,6 @@ namespace MaterialEditorAPI
             ExportBakedWorldPosition = Config.Bind("Config", "Export Baked World Position", false, new ConfigDescription("When enabled, objects will be exported with their position changes intact so that, i.e. when exporting two objects they retain their position relative to each other.\nOnly works when Export Baked Mesh is also enabled.", null, new ConfigurationManagerAttributes { Order = 1 }));
             ConfigExportPath = Config.Bind("Config", "Export Path Override", "", new ConfigDescription($"Textures and models will be exported to this folder. If empty, exports to {ExportPathDefault}", null, new ConfigurationManagerAttributes { Order = 1 }));
             PersistFilter = Config.Bind("Config", "Persist Filter", false, "Persist search filter across editor windows");
-            ShowTimelineButtons = Config.Bind("Config", "Show Timeline Buttons", false, "Show buttons in the UI (in studio only) to add interpolables to the timeline. Requires game restart to take effect");
 
             //Everything in these games is 10x the size of KK/KKS
 #if AI || HS2 || PH

--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -551,7 +551,7 @@ namespace MaterialEditorAPI
             interpolableButton.gameObject.SetActive(false);
 
 #if !API && !EC
-            if (MaterialEditorPluginBase.ShowTimelineButtons.Value && TimelineCompatibilityHelper.IsTimelineAvailable())
+            if (TimelineCompatibilityHelper.IsTimelineAvailable())
                 interpolableButton.gameObject.SetActive(true);
 #endif
         }


### PR DESCRIPTION
A lot of people get confused when trying to timeline ME and they don't have the buttons. So I think showing them by default is better while still hiding them in studio.