### PR TITLE
[ME] Add material renaming

### DIFF
--- a/src/MaterialEditor.Base/Extensions.cs
+++ b/src/MaterialEditor.Base/Extensions.cs
@@ -20,6 +20,7 @@ namespace MaterialEditorAPI
                 list[n] = value;
             }
         }
+        public static string FormatShadingObjectName(this string name) => name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this GameObject go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Material go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Renderer go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -202,6 +202,32 @@ namespace MaterialEditorAPI
         }
 
         /// <summary>
+        /// Remove any material copies added by MaterialEditor for the specified GameObject
+        /// </summary>
+        /// <param name="gameObject">GameObject to which the material belongs</param>
+        /// <param name="rendererName">NameFormatted() name of the renderer</param>
+        /// <param name="materialName">Raw name of the material</param>
+        /// <param name="value">New name of the material</param>
+        public static bool SetName(GameObject gameObject, string rendererName, string materialName, string value)
+        {
+            bool didSet = false;
+
+            foreach (var renderer in GetRendererList(gameObject))
+            {
+                if (renderer.NameFormatted() == rendererName)
+                {
+                    var materials = GetMaterials(gameObject, renderer).Where(mat => mat.name == materialName);
+                    foreach (var mat in materials)
+                    {
+                        mat.name = value;
+                        didSet = true;
+                    }
+                }
+            }
+            return didSet;
+        }
+
+        /// <summary>
         /// Set the value of the specified material property
         /// </summary>
         /// <param name="gameObject">GameObject to search for the material. If this GameObject is a ChaControl, only parts comprising the body and face will be searched, not clothes, accessories, etc.</param>

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -205,8 +205,8 @@ namespace MaterialEditorAPI
         /// Rename the material specified by GameObject, Renderer name, and Material name
         /// </summary>
         /// <param name="gameObject">GameObject to which the material belongs</param>
-        /// <param name="rendererName">NameFormatted() name of the renderer</param>
-        /// <param name="materialName">Raw name of the material</param>
+        /// <param name="rendererName">Name of the renderer</param>
+        /// <param name="materialName">Name of the material</param>
         /// <param name="value">New name of the material</param>
         public static bool SetName(GameObject gameObject, string rendererName, string materialName, string value)
         {
@@ -214,9 +214,9 @@ namespace MaterialEditorAPI
 
             foreach (var renderer in GetRendererList(gameObject))
             {
-                if (renderer.NameFormatted() == rendererName)
+                if (renderer.NameFormatted() == rendererName.FormatShadingObjectName())
                 {
-                    var materials = GetMaterials(gameObject, renderer).Where(mat => mat.name == materialName);
+                    var materials = GetMaterials(gameObject, renderer).Where(mat => mat.NameFormatted() == materialName.FormatShadingObjectName());
                     foreach (var mat in materials)
                     {
                         mat.name = value;

--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -202,7 +202,7 @@ namespace MaterialEditorAPI
         }
 
         /// <summary>
-        /// Remove any material copies added by MaterialEditor for the specified GameObject
+        /// Rename the material specified by GameObject, Renderer name, and Material name
         /// </summary>
         /// <param name="gameObject">GameObject to which the material belongs</param>
         /// <param name="rendererName">NameFormatted() name of the renderer</param>

--- a/src/MaterialEditor.Base/UI/UI.ItemInfo.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemInfo.cs
@@ -42,6 +42,7 @@ namespace MaterialEditorAPI
         public Action MaterialOnCopy { get; set; }
         public Action MaterialOnPaste { get; set; }
         public Action MaterialOnCopyRemove { get; set; }
+        public Action MaterialOnRename { get; set; }
 
         public string ShaderName { get; set; }
         public string ShaderNameOriginal { get; set; }

--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -222,6 +222,11 @@ namespace MaterialEditorAPI
                 var copyLE = copy.gameObject.AddComponent<LayoutElement>();
                 copyLE.preferredWidth = ButtonWidth;
                 copyLE.flexibleWidth = 0;
+
+                var rename = UIUtility.CreateButton($"MaterialRename", itemPanel.transform, ">");
+                var renameLE = rename.gameObject.AddComponent<LayoutElement>();
+                renameLE.preferredWidth = ButtonWidth / 4;
+                renameLE.flexibleWidth = 0;
             }
 
             //Material Shader

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -46,6 +46,7 @@ namespace MaterialEditorAPI
         public Button MaterialCopyButton;
         public Button MaterialPasteButton;
         public Button MaterialCopyRemove;
+        public Button MaterialRename;
 
         public CanvasGroup ShaderPanel;
         public Text ShaderLabel;
@@ -266,6 +267,14 @@ namespace MaterialEditorAPI
                         }
                         else
                             MaterialCopyRemove.gameObject.SetActive(false);
+                        if (item.MaterialOnRename != null)
+                        {
+                            MaterialRename.gameObject.SetActive(true);
+                            MaterialRename.onClick.RemoveAllListeners();
+                            MaterialRename.onClick.AddListener(delegate { item.MaterialOnRename.Invoke(); });
+                        }
+                        else
+                            MaterialRename.gameObject.SetActive(false);
 
                         break;
                     case ItemInfo.RowItemType.Shader:

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -295,6 +295,7 @@ namespace MaterialEditorAPI
                         }
                         else
                             MaterialRename.gameObject.SetActive(false);
+                        TooltipManager.AddTooltip(MaterialRename.gameObject, "Rename material instances");
 
                         break;
                     case ItemInfo.RowItemType.Shader:

--- a/src/MaterialEditor.Base/UI/UI.VirtualList.cs
+++ b/src/MaterialEditor.Base/UI/UI.VirtualList.cs
@@ -91,6 +91,7 @@ namespace MaterialEditorAPI
             listEntry.MaterialCopyButton = listEntry.GetUIComponent<Button>("MaterialCopy");
             listEntry.MaterialPasteButton = listEntry.GetUIComponent<Button>("MaterialPaste");
             listEntry.MaterialCopyRemove = listEntry.GetUIComponent<Button>("MaterialCopyRemove");
+            listEntry.MaterialRename = listEntry.GetUIComponent<Button>("MaterialRename");
 
             listEntry.ShaderPanel = listEntry.GetUIComponent<CanvasGroup>("ShaderPanel");
             listEntry.ShaderLabel = listEntry.GetUIComponent<Text>("ShaderLabel");

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -368,6 +368,7 @@ namespace MaterialEditorAPI
             if (RenameListVisible)
             {
                 MaterialEditorRenameList.ToggleVisibility(false);
+                ViewListButton.GetComponentInChildren<Text>().text = ">";
                 RenameListVisible = false;
             }
 

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -310,7 +310,7 @@ namespace MaterialEditorAPI
         /// Populate the rename list
         /// </summary>
         /// <param name="go">GameObject for which to read the renderers</param>
-        /// <param name="matName">Material name</param>
+        /// <param name="material">Material to be renamed</param>
         private void PopulateRenameList(GameObject go, Material material)
         {
             SelectedMaterialRenderers.Clear();

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -311,22 +311,25 @@ namespace MaterialEditorAPI
         /// </summary>
         /// <param name="go">GameObject for which to read the renderers</param>
         /// <param name="material">Material to be renamed</param>
-        private void PopulateRenameList(GameObject go, Material material)
+        private void PopulateRenameList(GameObject go, Material material, object data)
         {
             SelectedMaterialRenderers.Clear();
             MaterialEditorRenameList.ClearList();
 
             // Setup text field
-            string original = material.name;
             string formattedName = material.NameFormatted().Split(new[] { MaterialCopyPostfix }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
-            string suffix = material.NameFormatted().Replace(formattedName, "");
             MaterialEditorRenameField.text = formattedName;
 
             // Setup button
+            string original = material.name;
+            string suffix = material.NameFormatted().Replace(formattedName, "");
             MaterialEditorRenameButton.onClick.RemoveAllListeners();
             MaterialEditorRenameButton.onClick.AddListener(() =>
             {
-                // TODO
+                string safeNewName = MaterialEditorRenameField.text.Replace(MaterialCopyPostfix, "").Trim() + suffix;
+                foreach (var renderer in SelectedMaterialRenderers)
+                    SetMaterialName(data, renderer, material, safeNewName, go);
+                RefreshUI();
             });
 
             // Setup renderer list
@@ -339,6 +342,7 @@ namespace MaterialEditorAPI
                         SelectedMaterialRenderers.Add(renderer);
                     else
                         SelectedMaterialRenderers.Remove(renderer);
+                    MaterialEditorRenameButton.interactable = SelectedMaterialRenderers.Count > 0;
                 });
             }
         }
@@ -553,7 +557,7 @@ namespace MaterialEditorAPI
                     }
                     ViewListButton.GetComponentInChildren<Text>().text = "<";
                     MaterialEditorRenameList.ToggleVisibility(true);
-                    PopulateRenameList(go, mat);
+                    PopulateRenameList(go, mat, data);
                     RenameListVisible = true;
                 };
                 items.Add(materialItem);
@@ -909,6 +913,10 @@ namespace MaterialEditorAPI
         public abstract void MaterialCopyEdits(object data, Material material, GameObject gameObject);
         public abstract void MaterialPasteEdits(object data, Material material, GameObject gameObject);
         public abstract void MaterialCopyRemove(object data, Material material, GameObject gameObject);
+
+        public abstract string GetMaterialNameOriginal(object data, Renderer renderer, Material material, GameObject gameObject);
+        public abstract void SetMaterialName(object data, Renderer renderer, Material material, string value, GameObject gameObject);
+        public abstract void RemoveMaterialName(object data, Renderer renderer, Material material, GameObject gameObject);
 
         public abstract string GetMaterialShaderNameOriginal(object data, Material material, GameObject gameObject);
         public abstract void SetMaterialShaderName(object data, Material material, string value, GameObject gameObject);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -321,8 +321,8 @@ namespace MaterialEditorAPI
             MaterialEditorRenameField.text = formattedName;
 
             // Setup button
-            string original = material.name;
             string suffix = material.NameFormatted().Replace(formattedName, "");
+            MaterialEditorRenameButton.interactable = false;
             MaterialEditorRenameButton.onClick.RemoveAllListeners();
             MaterialEditorRenameButton.onClick.AddListener(() =>
             {
@@ -333,9 +333,9 @@ namespace MaterialEditorAPI
             });
 
             // Setup renderer list
-            var renderers = GetRendererList(go).Where(rend => rend.materials.Where(mat => mat.name == material.name).Count() > 0);
-            foreach (var renderer in renderers)
+            foreach (var renderer in GetRendererList(go))
             {
+                if (!renderer.materials.Any(mat => mat.name.Contains(formattedName))) continue;
                 MaterialEditorRenameList.AddEntry(renderer.NameFormatted(), value =>
                 {
                     if (value)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -356,7 +356,7 @@ namespace MaterialEditorAPI
             // Setup renderer list
             foreach (var renderer in GetRendererList(go))
             {
-                if (!renderer.materials.Any(mat => mat.name.Contains(formattedName))) continue;
+                if (!renderer.materials.Any(mat => mat.NameFormatted() == material.NameFormatted())) continue;
                 MaterialEditorRenameList.AddEntry(renderer.NameFormatted(), value =>
                 {
                     if (value)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -355,6 +355,12 @@ namespace MaterialEditorAPI
         /// <param name="filter">Comma separated list of text to filter the results</param>
         protected void PopulateList(GameObject go, object data, string filter = null)
         {
+            if (RenameListVisible)
+            {
+                MaterialEditorRenameList.ToggleVisibility(false);
+                RenameListVisible = false;
+            }
+
             if (filter == null)
             {
                 if (PersistFilter.Value) filter = CurrentFilter;

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -45,6 +45,7 @@ namespace MaterialEditorAPI
         private static SelectListPanel MaterialEditorRenameList;
         private static InputField MaterialEditorRenameField;
         private static Button MaterialEditorRenameButton;
+        private static Text MaterialEditorRenameMaterial;
         private static List<Renderer> SelectedMaterialRenderers = new List<Renderer>();
         private static bool RenameListVisible = false;
 
@@ -193,6 +194,12 @@ namespace MaterialEditorAPI
             MaterialEditorRenameField.transform.SetRect(0, 0, 1, 0, 0, -(PanelHeight + MarginSize / 2), 0, -(MarginSize / 2));
             MaterialEditorRenameButton = UIUtility.CreateButton("MaterialEditorRenameButton", MaterialEditorRenameList.Panel.transform, "Rename");
             MaterialEditorRenameButton.transform.SetRect(0, 0, 1, 0, 0, -(2 * PanelHeight + MarginSize), 0, -(PanelHeight + MarginSize));
+            MaterialEditorRenameList.Panel.transform.GetChild(0).SetRect(0, 1, 0.4f, 1, 5, -40, -2, -27.5f);
+            MaterialEditorRenameList.Panel.transform.GetChild(1).SetRect(0.4f, 1, 1, 1, 2, -42.5f, -2, -25);
+            MaterialEditorRenameList.Panel.transform.GetChild(2).SetRect(0, 0, 1, 1, 2, 2, -2, -42.5f);
+            MaterialEditorRenameMaterial = Instantiate(MaterialEditorRenameList.Panel.transform.GetChild(0), MaterialEditorRenameList.Panel.transform).GetComponent<Text>();
+            MaterialEditorRenameMaterial.gameObject.name = nameof(MaterialEditorRenameMaterial);
+            MaterialEditorRenameMaterial.transform.SetRect(0, 1, 1, 1, 5, -20, -2, -5);
         }
 
         /// <summary>
@@ -315,6 +322,9 @@ namespace MaterialEditorAPI
         {
             SelectedMaterialRenderers.Clear();
             MaterialEditorRenameList.ClearList();
+
+            // Setup title
+            MaterialEditorRenameMaterial.text = material.NameFormatted();
 
             // Setup text field
             string formattedName = material.NameFormatted().Split(new[] { MaterialCopyPostfix }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();

--- a/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
+++ b/src/MaterialEditor.Core.Maker/Core.MaterialEditor.Maker.cs
@@ -7,6 +7,7 @@ using MaterialEditorAPI;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static Illusion.Utils;
 using static MaterialEditorAPI.MaterialAPI;
 #if AI || HS2
 using AIChara;
@@ -363,6 +364,22 @@ namespace KK_Plugins.MaterialEditor
         {
             ObjectData objectData = (ObjectData)data;
             MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).MaterialCopyRemove(objectData.Slot, objectData.ObjectType, material, go);
+        }
+
+        public override string GetMaterialNameOriginal(object data, Renderer renderer, Material material, GameObject gameObject)
+        {
+            ObjectData objectData = (ObjectData)data;
+            return MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).GetMaterialNamePropertyValueOriginal(objectData.Slot, objectData.ObjectType, renderer, material, gameObject);
+        }
+        public override void SetMaterialName(object data, Renderer renderer, Material material, string value, GameObject gameObject)
+        {
+            ObjectData objectData = (ObjectData)data;
+            MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).SetMaterialNameProperty(objectData.Slot, objectData.ObjectType, renderer, material, value, gameObject);
+        }
+        public override void RemoveMaterialName(object data, Renderer renderer, Material material, GameObject gameObject)
+        {
+            ObjectData objectData = (ObjectData)data;
+            MaterialEditorPlugin.GetCharaController(MakerAPI.GetCharacterControl()).RemoveMaterialNameProperty(objectData.Slot, objectData.ObjectType, renderer, material, gameObject);
         }
 
         public override string GetMaterialShaderNameOriginal(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -636,7 +636,7 @@ namespace KK_Plugins.MaterialEditor
 
         internal void HandleMaterialNameChange(int id, Renderer renderer, Material material, string value, GameObject go)
         {
-            value = value.Replace("(Instance)", "").Replace(" Instance", "").Trim();
+            value = value.FormatShadingObjectName();
             Material existing = null;
             foreach (var rend in GetRendererList(go))
             {
@@ -1067,7 +1067,7 @@ namespace KK_Plugins.MaterialEditor
             }
             else
             {
-                if (value == materialProperty.MaterialName.Replace("(Instance)", "").Replace(" Instance", "").Trim())
+                if (value.FormatShadingObjectName() == materialProperty.MaterialName.FormatShadingObjectName())
                     RemoveMaterialNameProperty(id, renderer, material, false);
                 else
                 {
@@ -1891,7 +1891,7 @@ namespace KK_Plugins.MaterialEditor
             public RendererProperty(int id, string rendererName, RendererProperties property, string value, string valueOriginal)
             {
                 ID = id;
-                RendererName = rendererName.Replace("(Instance)", "").Trim();
+                RendererName = rendererName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -1992,7 +1992,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialFloatProperty(int id, string materialName, string property, string value, string valueOriginal)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -2043,7 +2043,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialKeywordProperty(int id, string materialName, string property, bool value, bool valueOriginal)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -2094,7 +2094,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialColorProperty(int id, string materialName, string property, Color value, Color valueOriginal)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -2168,7 +2168,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialTextureProperty(int id, string materialName, string property, int? texID = null, Vector2? offset = null, Vector2? offsetOriginal = null, Vector2? scale = null, Vector2? scaleOriginal = null, MEAnimationDefine texAnimationDef = null)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 TexID = texID;
                 Offset = offset;
@@ -2235,7 +2235,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialShader(int id, string materialName, string shaderName, string shaderNameOriginal, int? renderQueue, int? renderQueueOriginal)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 ShaderName = shaderName;
                 ShaderNameOriginal = shaderNameOriginal;
                 RenderQueue = renderQueue;
@@ -2251,7 +2251,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialShader(int id, string materialName, string shaderName, string shaderNameOriginal)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 ShaderName = shaderName;
                 ShaderNameOriginal = shaderNameOriginal;
             }
@@ -2265,7 +2265,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialShader(int id, string materialName, int renderQueue, int renderQueueOriginal)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 RenderQueue = renderQueue;
                 RenderQueueOriginal = renderQueueOriginal;
             }
@@ -2303,7 +2303,7 @@ namespace KK_Plugins.MaterialEditor
             public MaterialCopy(int id, string materialName, string materialCopyName)
             {
                 ID = id;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 MaterialCopyName = materialCopyName;
             }
         }
@@ -2352,7 +2352,7 @@ namespace KK_Plugins.MaterialEditor
             public ProjectorProperty(int id, string projectorName, ProjectorProperties property, string value, string valueOriginal)
             {
                 ID = id;
-                ProjectorName = projectorName.Replace("(Instance)", "").Trim();
+                ProjectorName = projectorName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -15,6 +15,7 @@ using UILib;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using static Illusion.Utils;
 using static MaterialEditorAPI.MaterialAPI;
 #if AI || HS2
 using AIChara;
@@ -517,6 +518,37 @@ namespace KK_Plugins.MaterialEditor
             }
             else
                 GetSceneController().MaterialCopyRemove((int)data, material, go);
+        }
+
+        public override string GetMaterialNameOriginal(object data, Renderer renderer, Material material, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                return MaterialEditorPlugin.GetCharaController(chaControl).GetMaterialNamePropertyValueOriginal(objectData.Slot, objectData.ObjectType, renderer, material, gameObject);
+            }
+            else
+                return GetSceneController().GetMaterialNamePropertyValueOriginal((int)data, renderer, material);
+        }
+        public override void SetMaterialName(object data, Renderer renderer, Material material, string value, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                MaterialEditorPlugin.GetCharaController(chaControl).SetMaterialNameProperty(objectData.Slot, objectData.ObjectType, renderer, material, value, gameObject);
+            }
+            else
+                GetSceneController().SetMaterialNameProperty((int)data, renderer, material, value);
+        }
+        public override void RemoveMaterialName(object data, Renderer renderer, Material material, GameObject gameObject)
+        {
+            if (data is ObjectData objectData)
+            {
+                var chaControl = gameObject.GetComponentInParent<ChaControl>();
+                MaterialEditorPlugin.GetCharaController(chaControl).RemoveMaterialNameProperty(objectData.Slot, objectData.ObjectType, renderer, material, gameObject);
+            }
+            else
+                GetSceneController().RemoveMaterialNameProperty((int)data, renderer, material);
         }
 
         public override string GetMaterialShaderNameOriginal(object data, Material material, GameObject go)

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -1316,7 +1316,7 @@ namespace KK_Plugins.MaterialEditor
 
         internal void HandleMaterialNameChange(int slot, ObjectType objectType, Renderer renderer, Material material, string value, GameObject go)
         {
-            value = value.Replace("(Instance)", "").Replace(" Instance", "").Trim();
+            value = value.FormatShadingObjectName();
             Material existing = null;
             foreach (var rend in GetRendererList(go))
             {
@@ -1792,7 +1792,7 @@ namespace KK_Plugins.MaterialEditor
             }
             else
             {
-                if (value == materialProperty.ValueOriginal)
+                if (value.FormatShadingObjectName() == materialProperty.ValueOriginal.FormatShadingObjectName())
                     RemoveMaterialNameProperty(slot, objectType, renderer, material, go, false);
                 else
                 {
@@ -2948,7 +2948,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                RendererName = rendererName.Replace("(Instance)", "").Trim();
+                RendererName = rendererName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -3075,7 +3075,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -3140,7 +3140,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -3205,7 +3205,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;
@@ -3294,7 +3294,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 Property = property;
                 TexID = texID;
                 Offset = offset;
@@ -3383,7 +3383,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 ShaderName = shaderName;
                 ShaderNameOriginal = shaderNameOriginal;
                 RenderQueue = renderQueue;
@@ -3403,7 +3403,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 ShaderName = shaderName;
                 ShaderNameOriginal = shaderNameOriginal;
             }
@@ -3421,7 +3421,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 RenderQueue = renderQueue;
                 RenderQueueOriginal = renderQueueOriginal;
             }
@@ -3471,7 +3471,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                MaterialName = materialName.Replace("(Instance)", "").Trim();
+                MaterialName = materialName.FormatShadingObjectName();
                 MaterialCopyName = materialCopyName;
             }
         }
@@ -3532,7 +3532,7 @@ namespace KK_Plugins.MaterialEditor
                 ObjectType = objectType;
                 CoordinateIndex = coordinateIndex;
                 Slot = slot;
-                ProjectorName = projectorName.Replace("(Instance)", "").Trim();
+                ProjectorName = projectorName.FormatShadingObjectName();
                 Property = property;
                 Value = value;
                 ValueOriginal = valueOriginal;

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -775,7 +775,7 @@ namespace KK_Plugins.MaterialEditor
                 CorrectFace();
 #endif
 
-            //Instantiate all material copies before applying any edits to endure edits are applied to copies
+            //Instantiate all material copies before applying any edits to ensure edits are applied to copies
             for (var i = 0; i < MaterialCopyList.Count; i++)
             {
                 var property = MaterialCopyList[i];

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -100,6 +100,11 @@ namespace KK_Plugins.MaterialEditor
                 else
                     data.data.Add(nameof(ProjectorPropertyList), null);
 
+                if (MaterialNamePropertyList.Count > 0)
+                    data.data.Add(nameof(MaterialNamePropertyList), MessagePackSerializer.Serialize(MaterialNamePropertyList));
+                else
+                    data.data.Add(nameof(MaterialNamePropertyList), null);
+
                 if (MaterialFloatPropertyList.Count > 0)
                     data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(MaterialFloatPropertyList));
                 else
@@ -296,8 +301,8 @@ namespace KK_Plugins.MaterialEditor
 
             var coordinateRendererPropertyList = RendererPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
             var coordinateProjectorPropertyList = ProjectorPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
+            var coordinateMaterialNamePropertyList = MaterialNamePropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
             var coordinateMaterialFloatPropertyList = MaterialFloatPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
-
             var coordinateMaterialKeywordPropertyList = MaterialKeywordPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
             var coordinateMaterialColorPropertyList = MaterialColorPropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
             var coordinateMaterialTexturePropertyList = MaterialTexturePropertyList.Where(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType != ObjectType.Hair && x.ObjectType != ObjectType.Character).ToList();
@@ -313,7 +318,7 @@ namespace KK_Plugins.MaterialEditor
                     coordinateTextureDictionary.Add(tex.Key, tex.Value.Data);
             }
 
-            if (coordinateRendererPropertyList.Count == 0 && coordinateMaterialFloatPropertyList.Count == 0 && coordinateMaterialKeywordPropertyList.Count == 0 && coordinateMaterialColorPropertyList.Count == 0 && coordinateMaterialTexturePropertyList.Count == 0 && coordinateMaterialShaderList.Count == 0 && coordinateMaterialCopyList.Count == 0)
+            if (coordinateRendererPropertyList.Count == 0 && coordinateMaterialNamePropertyList.Count == 0 && coordinateMaterialFloatPropertyList.Count == 0 && coordinateMaterialKeywordPropertyList.Count == 0 && coordinateMaterialColorPropertyList.Count == 0 && coordinateMaterialTexturePropertyList.Count == 0 && coordinateMaterialShaderList.Count == 0 && coordinateMaterialCopyList.Count == 0)
             {
                 SetCoordinateExtendedData(coordinate, null);
             }
@@ -334,6 +339,11 @@ namespace KK_Plugins.MaterialEditor
                     data.data.Add(nameof(ProjectorPropertyList), MessagePackSerializer.Serialize(coordinateProjectorPropertyList));
                 else
                     data.data.Add(nameof(ProjectorPropertyList), null);
+
+                if (coordinateMaterialNamePropertyList.Count > 0)
+                    data.data.Add(nameof(MaterialNamePropertyList), MessagePackSerializer.Serialize(coordinateMaterialNamePropertyList));
+                else
+                    data.data.Add(nameof(MaterialNamePropertyList), null);
 
                 if (coordinateMaterialFloatPropertyList.Count > 0)
                     data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(coordinateMaterialFloatPropertyList));
@@ -400,6 +410,7 @@ namespace KK_Plugins.MaterialEditor
             {
                 RendererPropertyList.Clear();
                 ProjectorPropertyList.Clear();
+                MaterialNamePropertyList.Clear();
                 MaterialFloatPropertyList.Clear();
                 MaterialKeywordPropertyList.Clear();
                 MaterialColorPropertyList.Clear();
@@ -421,6 +432,7 @@ namespace KK_Plugins.MaterialEditor
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
+                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
@@ -436,6 +448,7 @@ namespace KK_Plugins.MaterialEditor
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
+                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
@@ -446,6 +459,7 @@ namespace KK_Plugins.MaterialEditor
 
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
+                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
@@ -460,6 +474,7 @@ namespace KK_Plugins.MaterialEditor
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
+                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
@@ -540,6 +555,18 @@ namespace KK_Plugins.MaterialEditor
                     }
                 }
 
+                if (data.data.TryGetValue(nameof(MaterialNamePropertyList), out var materialNameProperties) && materialNameProperties != null)
+                {
+                    var properties = MessagePackSerializer.Deserialize<List<MaterialNameProperty>>((byte[])materialNameProperties);
+                    for (var i = 0; i < properties.Count; i++)
+                    {
+                        var loadedProperty = properties[i];
+                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
+                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
+                            MaterialNamePropertyList.Add(new MaterialNameProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
+                    }
+                }
+
                 if (data.data.TryGetValue(nameof(MaterialFloatPropertyList), out var materialFloatProperties) && materialFloatProperties != null)
                 {
                     var properties = MessagePackSerializer.Deserialize<List<MaterialFloatProperty>>((byte[])materialFloatProperties);
@@ -551,7 +578,6 @@ namespace KK_Plugins.MaterialEditor
                             MaterialFloatPropertyList.Add(new MaterialFloatProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
                     }
                 }
-
 
                 if (data.data.TryGetValue(nameof(MaterialKeywordPropertyList), out var materialKeywordProperties) && materialKeywordProperties != null)
                 {
@@ -618,6 +644,7 @@ namespace KK_Plugins.MaterialEditor
             if (loadFlags == null)
             {
                 RendererPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
+                MaterialNamePropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
                 MaterialFloatPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
                 MaterialKeywordPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
                 MaterialColorPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
@@ -635,6 +662,7 @@ namespace KK_Plugins.MaterialEditor
                 if (loadFlags.Clothes)
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
+                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
@@ -646,6 +674,7 @@ namespace KK_Plugins.MaterialEditor
                 if (loadFlags.Accessories)
                 {
                     RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
+                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
                     MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
                     MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
                     MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
@@ -689,6 +718,17 @@ namespace KK_Plugins.MaterialEditor
                         var loadedProperty = properties[i];
                         if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
                             RendererPropertyList.Add(new RendererProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+                    }
+                }
+
+                if (data.data.TryGetValue(nameof(MaterialNamePropertyList), out var materialNameProperties) && materialNameProperties != null)
+                {
+                    var properties = MessagePackSerializer.Deserialize<List<MaterialNameProperty>>((byte[])materialNameProperties);
+                    for (var i = 0; i < properties.Count; i++)
+                    {
+                        var loadedProperty = properties[i];
+                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
+                            MaterialNamePropertyList.Add(new MaterialNameProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
                     }
                 }
 
@@ -785,6 +825,19 @@ namespace KK_Plugins.MaterialEditor
                 if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
 
                 CopyMaterial(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.MaterialCopyName);
+            }
+
+            // Rename materials before applying edits, but after copying materials, to ensure no missing material mishaps occur
+            // Do not move this anywhere else
+            for (var i = 0; i < MaterialNamePropertyList.Count; i++)
+            {
+                var property = MaterialNamePropertyList[i];
+                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
+                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
+                if (property.ObjectType == ObjectType.Hair && !hair) continue;
+                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
+
+                MaterialAPI.SetName(FindGameObject(property.ObjectType, property.Slot), property.Renderer, property.MaterialName, property.Value);
             }
 
             for (var i = 0; i < MaterialShaderList.Count; i++)
@@ -1030,6 +1083,7 @@ namespace KK_Plugins.MaterialEditor
                 int slot = copySlots[i];
                 MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copyDestination && x.Slot == slot);
                 RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copyDestination && x.Slot == slot);
+                MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copyDestination && x.Slot == slot);
                 MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copyDestination && x.Slot == slot);
                 MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copyDestination && x.Slot == slot);
                 MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copyDestination && x.Slot == slot);
@@ -1037,6 +1091,7 @@ namespace KK_Plugins.MaterialEditor
 
                 List<MaterialShader> newAccessoryMaterialShaderList = new List<MaterialShader>();
                 List<RendererProperty> newAccessoryRendererPropertyList = new List<RendererProperty>();
+                List<MaterialNameProperty> newAccessoryMaterialNamePropertyList = new List<MaterialNameProperty>();
                 List<MaterialFloatProperty> newAccessoryMaterialFloatPropertyList = new List<MaterialFloatProperty>();
                 List<MaterialColorProperty> newAccessoryMaterialColorPropertyList = new List<MaterialColorProperty>();
                 List<MaterialTextureProperty> newAccessoryMaterialTexturePropertyList = new List<MaterialTextureProperty>();
@@ -1046,6 +1101,8 @@ namespace KK_Plugins.MaterialEditor
                     newAccessoryMaterialShaderList.Add(new MaterialShader(property.ObjectType, copyDestination, slot, property.MaterialName, property.ShaderName, property.ShaderNameOriginal, property.RenderQueue, property.RenderQueueOriginal));
                 foreach (var property in RendererPropertyList.Where(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copySource && x.Slot == slot))
                     newAccessoryRendererPropertyList.Add(new RendererProperty(property.ObjectType, copyDestination, slot, property.RendererName, property.Property, property.Value, property.ValueOriginal));
+                foreach (var property in MaterialNamePropertyList.Where(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copySource && x.Slot == slot))
+                    newAccessoryMaterialNamePropertyList.Add(new MaterialNameProperty(property.ObjectType, copyDestination, slot, property.Renderer, property.MaterialName, property.Value));
                 foreach (var property in MaterialFloatPropertyList.Where(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copySource && x.Slot == slot))
                     newAccessoryMaterialFloatPropertyList.Add(new MaterialFloatProperty(property.ObjectType, copyDestination, slot, property.MaterialName, property.Property, property.Value, property.ValueOriginal));
                 foreach (var property in MaterialColorPropertyList.Where(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == copySource && x.Slot == slot))
@@ -1057,6 +1114,7 @@ namespace KK_Plugins.MaterialEditor
 
                 MaterialShaderList.AddRange(newAccessoryMaterialShaderList);
                 RendererPropertyList.AddRange(newAccessoryRendererPropertyList);
+                MaterialNamePropertyList.AddRange(newAccessoryMaterialNamePropertyList);
                 MaterialFloatPropertyList.AddRange(newAccessoryMaterialFloatPropertyList);
                 MaterialColorPropertyList.AddRange(newAccessoryMaterialColorPropertyList);
                 MaterialTexturePropertyList.AddRange(newAccessoryMaterialTexturePropertyList);
@@ -1080,6 +1138,7 @@ namespace KK_Plugins.MaterialEditor
             //User switched accessories, remove all edited properties for this slot
             MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SlotIndex);
             RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SlotIndex);
+            MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SlotIndex);
             MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SlotIndex);
             MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SlotIndex);
             MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SlotIndex);
@@ -1124,6 +1183,7 @@ namespace KK_Plugins.MaterialEditor
         {
             MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.DestinationSlotIndex);
             RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.DestinationSlotIndex);
+            MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.DestinationSlotIndex);
             MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.DestinationSlotIndex);
             MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.DestinationSlotIndex);
             MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.DestinationSlotIndex);
@@ -1132,6 +1192,7 @@ namespace KK_Plugins.MaterialEditor
 
             List<MaterialShader> newAccessoryMaterialShaderList = new List<MaterialShader>();
             List<RendererProperty> newAccessoryRendererPropertyList = new List<RendererProperty>();
+            List<MaterialNameProperty> newAccessoryMaterialNamePropertyList = new List<MaterialNameProperty>();
             List<MaterialFloatProperty> newAccessoryMaterialFloatPropertyList = new List<MaterialFloatProperty>();
             List<MaterialKeywordProperty> newAccessoryMaterialKeywordPropertyList = new List<MaterialKeywordProperty>();
             List<MaterialColorProperty> newAccessoryMaterialColorPropertyList = new List<MaterialColorProperty>();
@@ -1142,6 +1203,8 @@ namespace KK_Plugins.MaterialEditor
                 newAccessoryMaterialShaderList.Add(new MaterialShader(property.ObjectType, CurrentCoordinateIndex, e.DestinationSlotIndex, property.MaterialName, property.ShaderName, property.ShaderNameOriginal, property.RenderQueue, property.RenderQueueOriginal));
             foreach (var property in RendererPropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SourceSlotIndex))
                 newAccessoryRendererPropertyList.Add(new RendererProperty(property.ObjectType, CurrentCoordinateIndex, e.DestinationSlotIndex, property.RendererName, property.Property, property.Value, property.ValueOriginal));
+            foreach (var property in MaterialNamePropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SourceSlotIndex))
+                newAccessoryMaterialNamePropertyList.Add(new MaterialNameProperty(property.ObjectType, CurrentCoordinateIndex, e.DestinationSlotIndex, property.Renderer, property.MaterialName, property.Value));
             foreach (var property in MaterialFloatPropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SourceSlotIndex))
                 newAccessoryMaterialFloatPropertyList.Add(new MaterialFloatProperty(property.ObjectType, CurrentCoordinateIndex, e.DestinationSlotIndex, property.MaterialName, property.Property, property.Value, property.ValueOriginal));
             foreach (var property in MaterialKeywordPropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == e.SourceSlotIndex))
@@ -1155,6 +1218,7 @@ namespace KK_Plugins.MaterialEditor
 
             MaterialShaderList.AddRange(newAccessoryMaterialShaderList);
             RendererPropertyList.AddRange(newAccessoryRendererPropertyList);
+            MaterialNamePropertyList.AddRange(newAccessoryMaterialNamePropertyList);
             MaterialFloatPropertyList.AddRange(newAccessoryMaterialFloatPropertyList);
             MaterialKeywordPropertyList.AddRange(newAccessoryMaterialKeywordPropertyList);
             MaterialColorPropertyList.AddRange(newAccessoryMaterialColorPropertyList);
@@ -1176,6 +1240,7 @@ namespace KK_Plugins.MaterialEditor
             {
                 MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopyDestination && x.Slot == slot);
                 RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopyDestination && x.Slot == slot);
+                MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopyDestination && x.Slot == slot);
                 MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopyDestination && x.Slot == slot);
                 MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopyDestination && x.Slot == slot);
                 MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopyDestination && x.Slot == slot);
@@ -1183,6 +1248,7 @@ namespace KK_Plugins.MaterialEditor
 
                 List<MaterialShader> newAccessoryMaterialShaderList = new List<MaterialShader>();
                 List<RendererProperty> newAccessoryRendererPropertyList = new List<RendererProperty>();
+                List<MaterialNameProperty> newAccessoryMaterialNamePropertyList = new List<MaterialNameProperty>();
                 List<MaterialFloatProperty> newAccessoryMaterialFloatPropertyList = new List<MaterialFloatProperty>();
                 List<MaterialColorProperty> newAccessoryMaterialColorPropertyList = new List<MaterialColorProperty>();
                 List<MaterialTextureProperty> newAccessoryMaterialTexturePropertyList = new List<MaterialTextureProperty>();
@@ -1192,6 +1258,8 @@ namespace KK_Plugins.MaterialEditor
                     newAccessoryMaterialShaderList.Add(new MaterialShader(property.ObjectType, (int)e.CopyDestination, slot, property.MaterialName, property.ShaderName, property.ShaderNameOriginal, property.RenderQueue, property.RenderQueueOriginal));
                 foreach (var property in RendererPropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopySource && x.Slot == slot))
                     newAccessoryRendererPropertyList.Add(new RendererProperty(property.ObjectType, (int)e.CopyDestination, slot, property.RendererName, property.Property, property.Value, property.ValueOriginal));
+                foreach (var property in MaterialNamePropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopySource && x.Slot == slot))
+                    newAccessoryMaterialNamePropertyList.Add(new MaterialNameProperty(property.ObjectType, (int)e.CopyDestination, slot, property.Renderer, property.MaterialName, property.Value));
                 foreach (var property in MaterialFloatPropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopySource && x.Slot == slot))
                     newAccessoryMaterialFloatPropertyList.Add(new MaterialFloatProperty(property.ObjectType, (int)e.CopyDestination, slot, property.MaterialName, property.Property, property.Value, property.ValueOriginal));
                 foreach (var property in MaterialColorPropertyList.Where(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == (int)e.CopySource && x.Slot == slot))
@@ -1203,6 +1271,7 @@ namespace KK_Plugins.MaterialEditor
 
                 MaterialShaderList.AddRange(newAccessoryMaterialShaderList);
                 RendererPropertyList.AddRange(newAccessoryRendererPropertyList);
+                MaterialNamePropertyList.AddRange(newAccessoryMaterialNamePropertyList);
                 MaterialFloatPropertyList.AddRange(newAccessoryMaterialFloatPropertyList);
                 MaterialColorPropertyList.AddRange(newAccessoryMaterialColorPropertyList);
                 MaterialTexturePropertyList.AddRange(newAccessoryMaterialTexturePropertyList);
@@ -1237,6 +1306,7 @@ namespace KK_Plugins.MaterialEditor
 
             MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
+            MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
@@ -1267,6 +1337,7 @@ namespace KK_Plugins.MaterialEditor
 
             MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
+            MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
             MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex && x.Slot == slot);
@@ -1294,6 +1365,7 @@ namespace KK_Plugins.MaterialEditor
 
             MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Hair && x.Slot == slot);
             RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair && x.Slot == slot);
+            MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair && x.Slot == slot);
             MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair && x.Slot == slot);
             MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair && x.Slot == slot);
             MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair && x.Slot == slot);
@@ -1317,7 +1389,11 @@ namespace KK_Plugins.MaterialEditor
         internal void HandleMaterialNameChange(int slot, ObjectType objectType, Renderer renderer, Material material, string value, GameObject go)
         {
             value = value.FormatShadingObjectName();
+
+            // Check for an existing material on the renderer by the same name
+            // Also check if we're renaming a copied material, and find the actual material being renamed
             Material existing = null;
+            Material copiedOriginalMat = null;
             foreach (var rend in GetRendererList(go))
             {
                 foreach (var mat in GetMaterials(go, rend))
@@ -1326,11 +1402,12 @@ namespace KK_Plugins.MaterialEditor
                     {
                         if (rend == renderer) return;
                         existing = mat;
-                        break;
+                    }
+                    else if (material.name.Contains(MaterialCopyPostfix) && rend == renderer && mat.NameFormatted() == material.NameFormatted())
+                    {
+                        copiedOriginalMat = mat;
                     }
                 }
-                if (existing != null)
-                    break;
             }
 
             if (existing == null)
@@ -1347,7 +1424,7 @@ namespace KK_Plugins.MaterialEditor
                 foreach (var _float in floats) MaterialFloatPropertyList.Add(new MaterialFloatProperty(objectType, idx, slot, value, _float.Property, _float.Value, _float.ValueOriginal));
                 foreach (var kw in keywords) MaterialKeywordPropertyList.Add(new MaterialKeywordProperty(objectType, idx, slot, value, kw.Property, kw.Value, kw.ValueOriginal));
             }
-            else
+            else if (!material.name.Contains(MaterialCopyPostfix))
             {
                 material.shader = existing.shader;
                 material.shaderKeywords = existing.shaderKeywords;
@@ -1356,6 +1433,16 @@ namespace KK_Plugins.MaterialEditor
                 material.mainTextureOffset = existing.mainTextureOffset;
                 material.mainTextureScale = existing.mainTextureScale;
                 material.renderQueue = existing.renderQueue;
+            }
+            else if (copiedOriginalMat != null)
+            {
+                copiedOriginalMat.shader = existing.shader;
+                copiedOriginalMat.shaderKeywords = existing.shaderKeywords;
+                copiedOriginalMat.color = existing.color;
+                copiedOriginalMat.mainTexture = existing.mainTexture;
+                copiedOriginalMat.mainTextureOffset = existing.mainTextureOffset;
+                copiedOriginalMat.mainTextureScale = existing.mainTextureScale;
+                copiedOriginalMat.renderQueue = existing.renderQueue;
             }
         }
 
@@ -1543,6 +1630,8 @@ namespace KK_Plugins.MaterialEditor
             string matName = material.NameFormatted();
             if (matName.Contains(MaterialCopyPostfix))
             {
+                MaterialNamePropertyList.RemoveAll(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType == objectType && x.Slot == slot && x.Value == material.name);
+
                 RemoveMaterial(go, material);
                 MaterialShaderList.RemoveAll(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType == objectType && x.Slot == slot && x.MaterialName == matName);
                 MaterialFloatPropertyList.RemoveAll(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType == objectType && x.Slot == slot && x.MaterialName == matName);
@@ -1551,7 +1640,7 @@ namespace KK_Plugins.MaterialEditor
                 MaterialTexturePropertyList.RemoveAll(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType == objectType && x.Slot == slot && x.MaterialName == matName);
                 MaterialCopyList.RemoveAll(x => x.CoordinateIndex == CurrentCoordinateIndex && x.ObjectType == objectType && x.Slot == slot && x.MaterialCopyName == matName);
             }
-            else
+            else if (GetMaterialNamePropertyValue(slot, objectType, GetRendererList(go).FirstOrDefault(x => x.materials.Contains(material)), material, go) == string.Empty)
             {
                 string newMatName = CopyMaterial(go, matName);
                 MaterialCopyList.Add(new MaterialCopy(objectType, CurrentCoordinateIndex, slot, matName, newMatName));
@@ -1578,6 +1667,10 @@ namespace KK_Plugins.MaterialEditor
                 MaterialKeywordPropertyList.AddRange(newAccessoryMaterialKeywordPropertyList);
                 MaterialColorPropertyList.AddRange(newAccessoryMaterialColorPropertyList);
                 MaterialTexturePropertyList.AddRange(newAccessoryMaterialTexturePropertyList);
+            }
+            else
+            {
+                MaterialEditorPlugin.Logger.LogMessage("Cannot copy renamed materials!");
             }
 
             PurgeUnusedAnimation();
@@ -1831,7 +1924,7 @@ namespace KK_Plugins.MaterialEditor
         /// <returns>Saved material property's current name or empty string if none is saved</returns>
         public string GetMaterialNamePropertyValue(int slot, ObjectType objectType, Renderer renderer, Material material, GameObject go)
         {
-            return MaterialNamePropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Renderer == renderer.NameFormatted() && x.Value == material.name)?.Value ?? "";
+            return MaterialNamePropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Renderer == renderer?.NameFormatted() && x.Value == material?.name)?.Value ?? string.Empty;
         }
         /// <summary>
         /// Get the saved material property's original name or empty string if none is saved
@@ -1843,7 +1936,7 @@ namespace KK_Plugins.MaterialEditor
         /// <returns>Saved material property's original value or null if none is saved</returns>
         public string GetMaterialNamePropertyValueOriginal(int slot, ObjectType objectType, Renderer renderer, Material material, GameObject go)
         {
-            return MaterialNamePropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Renderer == renderer.NameFormatted() && x.Value == material.name)?.ValueOriginal ?? "";
+            return MaterialNamePropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Renderer == renderer?.NameFormatted() && x.Value == material?.name)?.ValueOriginal ?? string.Empty;
         }
 
         /// <summary>
@@ -2714,6 +2807,7 @@ namespace KK_Plugins.MaterialEditor
         {
             RendererPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
             ProjectorPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
+            MaterialNamePropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
             MaterialFloatPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
             MaterialColorPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
             MaterialKeywordPropertyList.RemoveAll(x => ChaControl.chaFile.coordinate.ElementAtOrDefault(x.CoordinateIndex) == null);
@@ -2766,6 +2860,13 @@ namespace KK_Plugins.MaterialEditor
                     && x.Slot == slot
                     && x.ObjectType == objectType
                     && !renderers.Select(rend => rend.NameFormatted()).Contains(x.RendererName)
+                );
+                removedCount += MaterialNamePropertyList.RemoveAll(
+                    x => x.CoordinateIndex == CurrentCoordinateIndex
+                    && x.Slot == slot
+                    && x.ObjectType == objectType
+                    && !materialNames.Contains(x.MaterialName.FormatShadingObjectName())
+                    && !materialNames.Contains(x.Value)
                 );
                 removedCount += MaterialFloatPropertyList.RemoveAll(
                     x => x.CoordinateIndex == CurrentCoordinateIndex
@@ -2996,7 +3097,7 @@ namespace KK_Plugins.MaterialEditor
             public string ValueOriginal;
 
             /// <summary>
-            /// Data storage class for float properties
+            /// Data storage class for name properties
             /// </summary>
             /// <param name="objectType">Type of the object</param>
             /// <param name="coordinateIndex">Coordinate index, always 0 except in Koikatsu</param>
@@ -3013,6 +3114,26 @@ namespace KK_Plugins.MaterialEditor
                 MaterialName = material.name;
                 Value = value;
                 ValueOriginal = material.name;
+            }
+            /// <summary>
+            /// Data storage class for name properties
+            /// </summary>
+            /// <param name="objectType">Type of the object</param>
+            /// <param name="coordinateIndex">Coordinate index, always 0 except in Koikatsu</param>
+            /// <param name="slot">Slot of the accessory, hair, or clothing</param>
+            /// <param name="renderer">NameFormatted() name of the Renderer being modified</param>
+            /// <param name="materialName">Raw, unmodified name of the Material being renamed</param>
+            /// <param name="value">New name for the material</param>
+            [SerializationConstructor]
+            public MaterialNameProperty(ObjectType objectType, int coordinateIndex, int slot, string renderer, string materialName, string value)
+            {
+                ObjectType = objectType;
+                CoordinateIndex = coordinateIndex;
+                Slot = slot;
+                Renderer = renderer;
+                MaterialName = materialName;
+                Value = value;
+                ValueOriginal = materialName;
             }
         }
 

--- a/src/Shared/Shared.Extensions.cs
+++ b/src/Shared/Shared.Extensions.cs
@@ -21,6 +21,7 @@ namespace KK_Plugins
                 list[n] = value;
             }
         }
+        public static string FormatShadingObjectName(this string name) => name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this GameObject go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Material go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();
         public static string NameFormatted(this Renderer go) => go == null ? "" : go.name.Replace("(Instance)", "").Replace(" Instance", "").Trim();


### PR DESCRIPTION
- Adds a ">" button to Material lines in the main UI scrollview that open a rename window
- The rename window lets you select renderers on the GameObject that have materials named like the selected
- The selected materials can then be renamed to a name inputted above the "Rename" button
- Accounts for material copying
- Cannot copy renamed materials, but can rename copied materials (due to save/load restrictions)