### PR TITLE
[ME] Remove ForceRebuildLayoutImmediate in tooltips

### DIFF
--- a/src/MaterialEditor.Base/UI/UI.Tooltip.cs
+++ b/src/MaterialEditor.Base/UI/UI.Tooltip.cs
@@ -56,7 +56,6 @@ namespace MaterialEditorAPI
             tooltipText.text = text;
             if (setActive)
                 SetActive(true);
-            LayoutRebuilder.ForceRebuildLayoutImmediate(panelTransform);
         }
 
         public void SetActive(bool active) 


### PR DESCRIPTION
Not needed and caused hitching when a tooltip got activated.