### PR TITLE
[ME] Fix and optimize Material Editor UI to be more neat and tidy

### DIFF
--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -68,7 +68,7 @@ namespace MaterialEditorAPI
                 toggleEnabledLE.flexibleWidth = 0;
                 toggleEnabled.isOn = true;
 
-                var reset = UIUtility.CreateButton($"RendererEnabledResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"RendererEnabledResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -103,7 +103,7 @@ namespace MaterialEditorAPI
                 dropdownShadowCastingModeLE.preferredWidth = DropdownWidth;
                 dropdownShadowCastingModeLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"RendererShadowCastingModeResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"RendererShadowCastingModeResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -129,7 +129,7 @@ namespace MaterialEditorAPI
                 toggleReceiveShadowsLE.flexibleWidth = 0;
                 toggleReceiveShadows.isOn = true;
 
-                var reset = UIUtility.CreateButton($"RendererReceiveShadowsResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"RendererReceiveShadowsResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -155,7 +155,7 @@ namespace MaterialEditorAPI
                 toggleRendererUpdateWhenOffscreenLE.flexibleWidth = 0;
                 toggleRendererUpdateWhenOffscreen.isOn = false;
 
-                var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -181,7 +181,7 @@ namespace MaterialEditorAPI
                 toggleRecalculateNormalsLE.flexibleWidth = 0;
                 toggleRecalculateNormals.isOn = false;
 
-                var reset = UIUtility.CreateButton($"RendererRecalculateNormalsResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"RendererRecalculateNormalsResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -258,7 +258,7 @@ namespace MaterialEditorAPI
                 dropdownShaderLE.preferredWidth = DropdownWidth * 3;
                 dropdownShaderLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"ShaderResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"ShaderResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -284,7 +284,7 @@ namespace MaterialEditorAPI
                 textBoxShaderRenderQueueLE.preferredWidth = TextBoxWidth;
                 textBoxShaderRenderQueueLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"ShaderRenderQueueResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"ShaderRenderQueueResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -331,7 +331,7 @@ namespace MaterialEditorAPI
                 importButtonLE.preferredWidth = ButtonWidth;
                 importButtonLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"TextureResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"TextureResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -407,7 +407,7 @@ namespace MaterialEditorAPI
                 textBoxScaleYLE.preferredWidth = TextBoxXYWidth;
                 textBoxScaleYLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"OffsetScaleResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"OffsetScaleResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -489,7 +489,7 @@ namespace MaterialEditorAPI
                 editLE.preferredWidth = ColorEditButtonWidth;
                 editLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"ColorResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"ColorResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -527,7 +527,7 @@ namespace MaterialEditorAPI
                 textBoxFloatLE.preferredWidth = TextBoxWidth;
                 textBoxFloatLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"FloatResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"FloatResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;
@@ -553,7 +553,7 @@ namespace MaterialEditorAPI
                 toggleKeywordLE.preferredWidth = TextBoxWidth;
                 toggleKeywordLE.flexibleWidth = 0;
 
-                var reset = UIUtility.CreateButton($"KeywordResetButton", itemPanel.transform, "Reset");
+                var reset = UIUtility.CreateButton($"KeywordResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.preferredWidth = ResetButtonWidth;
                 resetLE.flexibleWidth = 0;

--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -78,7 +78,7 @@ namespace MaterialEditorAPI
                 toggleEnabledLE.preferredWidth = RendererToggleWidth;
                 toggleEnabledLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"RendererEnabledResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"RendererEnabledResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -118,7 +118,7 @@ namespace MaterialEditorAPI
                 dropdownShadowCastingModeLE.preferredWidth = RendererDropdownWidth;
                 dropdownShadowCastingModeLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"RendererShadowCastingModeResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"RendererShadowCastingModeResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -149,7 +149,7 @@ namespace MaterialEditorAPI
                 toggleReceiveShadowsLE.preferredWidth = RendererToggleWidth;
                 toggleReceiveShadowsLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"RendererReceiveShadowsResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"RendererReceiveShadowsResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -180,7 +180,7 @@ namespace MaterialEditorAPI
                 toggleRendererUpdateWhenOffscreenLE.preferredWidth = RendererToggleWidth;
                 toggleRendererUpdateWhenOffscreenLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -211,7 +211,7 @@ namespace MaterialEditorAPI
                 toggleRecalculateNormalsLE.preferredWidth = RendererToggleWidth;
                 toggleRecalculateNormalsLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"RendererRecalculateNormalsResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"RendererRecalculateNormalsResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -301,7 +301,7 @@ namespace MaterialEditorAPI
                 dropdownShaderLE.preferredWidth = ShaderDropdownWidth;
                 dropdownShaderLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"ShaderResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"ShaderResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -332,7 +332,7 @@ namespace MaterialEditorAPI
                 textBoxShaderRenderQueueLE.preferredWidth = RenderQueueInputFieldWidth;
                 textBoxShaderRenderQueueLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"ShaderRenderQueueResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"ShaderRenderQueueResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -388,7 +388,7 @@ namespace MaterialEditorAPI
                 importButtonLE.preferredWidth = TextureButtonWidth;
                 importButtonLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"TextureResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"TextureResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -487,7 +487,7 @@ namespace MaterialEditorAPI
                 textBoxScaleYLE.preferredWidth = OffsetScaleInputFieldWidth;
                 textBoxScaleYLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"OffsetScaleResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"OffsetScaleResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -587,7 +587,7 @@ namespace MaterialEditorAPI
                 editLE.preferredWidth = ColorEditButtonWidth;
                 editLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"ColorResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"ColorResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -632,7 +632,7 @@ namespace MaterialEditorAPI
                 textBoxFloatLE.preferredWidth = FloatInputFieldWidth;
                 textBoxFloatLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"FloatResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"FloatResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
@@ -670,7 +670,7 @@ namespace MaterialEditorAPI
                 toggleKeywordLE.preferredWidth = KeywordToggleWidth;
                 toggleKeywordLE.flexibleWidth = 0f;
 
-                var reset = UIUtility.CreateButton($"KeywordResetButton", itemPanel.transform, "R");
+                var reset = UIUtility.CreateButton($"KeywordResetButton", itemPanel.transform, "Reset");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;

--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -18,75 +18,89 @@ namespace MaterialEditorAPI
             {
                 var itemPanel = UIUtility.CreatePanel("RendererPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = RendererColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
+
+                CreateInterpolableButton("SelectInterpolableRendererButton", itemPanel.transform);
 
                 var label = UIUtility.CreateText("RendererLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
-                labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.minWidth = 0f;
+                labelLE.preferredWidth = 0f;
+                labelLE.flexibleWidth = 0f;
 
                 Text labelRenderer = UIUtility.CreateText("RendererText", itemPanel.transform);
-                labelRenderer.alignment = TextAnchor.MiddleRight;
+                labelRenderer.alignment = TextAnchor.MiddleLeft;
                 labelRenderer.color = Color.black;
                 var labelRendererLE = labelRenderer.gameObject.AddComponent<LayoutElement>();
-                labelRendererLE.preferredWidth = 200;
-                labelRendererLE.flexibleWidth = 0;
-
-                CreateInterpolableButton("SelectInterpolableRendererButton", itemPanel.transform);
-
+                labelRendererLE.minWidth = LabelWidth;
+                labelRendererLE.preferredWidth = LabelWidth;
+                labelRendererLE.flexibleWidth = 1f;
+                 
                 Button exportUVButton = UIUtility.CreateButton("ExportUVButton", itemPanel.transform, "Export UV Map");
                 var exportUVButtonLE = exportUVButton.gameObject.AddComponent<LayoutElement>();
-                exportUVButtonLE.preferredWidth = 110;
-                exportUVButtonLE.flexibleWidth = 0;
+                exportUVButtonLE.minWidth = RendererButtonWidth;
+                exportUVButtonLE.preferredWidth = RendererButtonWidth;
+                exportUVButtonLE.flexibleWidth = 0f;
 
                 Button exportMeshButton = UIUtility.CreateButton("ExportObjButton", itemPanel.transform, "Export .obj");
                 var exportMeshButtonLE = exportMeshButton.gameObject.AddComponent<LayoutElement>();
-                exportMeshButtonLE.preferredWidth = 85;
-                exportMeshButtonLE.flexibleWidth = 0;
+                exportMeshButtonLE.minWidth = RendererButtonWidth;
+                exportMeshButtonLE.preferredWidth = RendererButtonWidth;
+                exportMeshButtonLE.flexibleWidth = 0f;
             }
 
             //Renderer Enabled
             {
                 var itemPanel = UIUtility.CreatePanel("RendererEnabledPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("RendererEnabledLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
                 Toggle toggleEnabled = UIUtility.CreateToggle("RendererEnabledToggle", itemPanel.transform, "");
-                var toggleEnabledLE = toggleEnabled.gameObject.AddComponent<LayoutElement>();
-                toggleEnabledLE.preferredWidth = 12;
-                toggleEnabledLE.flexibleWidth = 0;
                 toggleEnabled.isOn = true;
+                var toggleEnabledLE = toggleEnabled.gameObject.AddComponent<LayoutElement>();
+                toggleEnabledLE.minWidth = RendererToggleWidth;
+                toggleEnabledLE.preferredWidth = RendererToggleWidth;
+                toggleEnabledLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"RendererEnabledResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Renderer ShadowCastingMode
             {
                 var itemPanel = UIUtility.CreatePanel("RendererShadowCastingModePanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("RendererShadowCastingModeLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
                 Dropdown dropdownShadowCastingMode = UIUtility.CreateDropdown("RendererShadowCastingModeDropdown", itemPanel.transform);
                 dropdownShadowCastingMode.transform.SetRect(0f, 0f, 0f, 1f, 0f, 0f, 100f);
@@ -100,150 +114,178 @@ namespace MaterialEditorAPI
                 dropdownShadowCastingMode.value = 0;
                 dropdownShadowCastingMode.captionText.text = "Off";
                 var dropdownShadowCastingModeLE = dropdownShadowCastingMode.gameObject.AddComponent<LayoutElement>();
-                dropdownShadowCastingModeLE.preferredWidth = DropdownWidth;
-                dropdownShadowCastingModeLE.flexibleWidth = 0;
+                dropdownShadowCastingModeLE.minWidth = RendererDropdownWidth;
+                dropdownShadowCastingModeLE.preferredWidth = RendererDropdownWidth;
+                dropdownShadowCastingModeLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"RendererShadowCastingModeResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Renderer ReceiveShadows
             {
                 var itemPanel = UIUtility.CreatePanel("RendererReceiveShadowsPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("RendererReceiveShadowsLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
                 Toggle toggleReceiveShadows = UIUtility.CreateToggle("RendererReceiveShadowsToggle", itemPanel.transform, "");
-                var toggleReceiveShadowsLE = toggleReceiveShadows.gameObject.AddComponent<LayoutElement>();
-                toggleReceiveShadowsLE.preferredWidth = 12;
-                toggleReceiveShadowsLE.flexibleWidth = 0;
                 toggleReceiveShadows.isOn = true;
-
+                var toggleReceiveShadowsLE = toggleReceiveShadows.gameObject.AddComponent<LayoutElement>();
+                toggleReceiveShadowsLE.minWidth = RendererToggleWidth;
+                toggleReceiveShadowsLE.preferredWidth = RendererToggleWidth;
+                toggleReceiveShadowsLE.flexibleWidth = 0f;
+                
                 var reset = UIUtility.CreateButton($"RendererReceiveShadowsResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Renderer RendererUpdateWhenOffscreen
             {
                 var itemPanel = UIUtility.CreatePanel("RendererUpdateWhenOffscreenPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("RendererUpdateWhenOffscreenLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
                 Toggle toggleRendererUpdateWhenOffscreen = UIUtility.CreateToggle("RendererUpdateWhenOffscreenToggle", itemPanel.transform, "");
-                var toggleRendererUpdateWhenOffscreenLE = toggleRendererUpdateWhenOffscreen.gameObject.AddComponent<LayoutElement>();
-                toggleRendererUpdateWhenOffscreenLE.preferredWidth = 12;
-                toggleRendererUpdateWhenOffscreenLE.flexibleWidth = 0;
                 toggleRendererUpdateWhenOffscreen.isOn = false;
-
+                var toggleRendererUpdateWhenOffscreenLE = toggleRendererUpdateWhenOffscreen.gameObject.AddComponent<LayoutElement>();
+                toggleRendererUpdateWhenOffscreenLE.minWidth = RendererToggleWidth;
+                toggleRendererUpdateWhenOffscreenLE.preferredWidth = RendererToggleWidth;
+                toggleRendererUpdateWhenOffscreenLE.flexibleWidth = 0f;
+                
                 var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Renderer RecalulateNormals
             {
                 var itemPanel = UIUtility.CreatePanel("RendererRecalculateNormalsPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("RendererRecalculateNormalsLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
                 Toggle toggleRecalculateNormals = UIUtility.CreateToggle("RendererRecalculateNormalsToggle", itemPanel.transform, "");
-                var toggleRecalculateNormalsLE = toggleRecalculateNormals.gameObject.AddComponent<LayoutElement>();
-                toggleRecalculateNormalsLE.preferredWidth = 12;
-                toggleRecalculateNormalsLE.flexibleWidth = 0;
                 toggleRecalculateNormals.isOn = false;
+                var toggleRecalculateNormalsLE = toggleRecalculateNormals.gameObject.AddComponent<LayoutElement>();
+                toggleRecalculateNormalsLE.minWidth = RendererToggleWidth;
+                toggleRecalculateNormalsLE.preferredWidth = RendererToggleWidth;
+                toggleRecalculateNormalsLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"RendererRecalculateNormalsResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Material
             {
                 var itemPanel = UIUtility.CreatePanel("MaterialPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = MaterialColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("MaterialLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
-                labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.minWidth = 0f;
+                labelLE.preferredWidth = 0f;
+                labelLE.flexibleWidth = 0f;
 
-                Text materialText = UIUtility.CreateText("MaterialText", itemPanel.transform);
-                materialText.alignment = TextAnchor.MiddleRight;
-                materialText.color = Color.black;
-                var materialTextLE = materialText.gameObject.AddComponent<LayoutElement>();
-                materialTextLE.preferredWidth = 200;
-                materialTextLE.flexibleWidth = 0;
+                Text labelMaterial = UIUtility.CreateText("MaterialText", itemPanel.transform);
+                labelMaterial.alignment = TextAnchor.MiddleLeft;
+                labelMaterial.color = Color.black;
+                var labelMaterialLE = labelMaterial.gameObject.AddComponent<LayoutElement>();
+                labelMaterialLE.minWidth = LabelWidth;
+                labelMaterialLE.preferredWidth = LabelWidth;
+                labelMaterialLE.flexibleWidth = 1f;
 
                 var copyEdits = UIUtility.CreateButton($"MaterialCopy", itemPanel.transform, "Copy Edits");
                 var copyEditsLE = copyEdits.gameObject.AddComponent<LayoutElement>();
-                copyEditsLE.preferredWidth = ButtonWidth;
-                copyEditsLE.flexibleWidth = 0;
+                copyEditsLE.minWidth = MaterialButtonWidth;
+                copyEditsLE.preferredWidth = MaterialButtonWidth;
+                copyEditsLE.flexibleWidth = 0f;
 
                 var pasteEdits = UIUtility.CreateButton($"MaterialPaste", itemPanel.transform, "Paste Edits");
                 var pasteEditsLE = pasteEdits.gameObject.AddComponent<LayoutElement>();
-                pasteEditsLE.preferredWidth = ButtonWidth;
-                pasteEditsLE.flexibleWidth = 0;
+                pasteEditsLE.minWidth = MaterialButtonWidth;
+                pasteEditsLE.preferredWidth = MaterialButtonWidth;
+                pasteEditsLE.flexibleWidth = 0f;
 
                 var copy = UIUtility.CreateButton($"MaterialCopyRemove", itemPanel.transform, "Copy Material");
                 var copyLE = copy.gameObject.AddComponent<LayoutElement>();
-                copyLE.preferredWidth = ButtonWidth;
-                copyLE.flexibleWidth = 0;
+                copyLE.minWidth = MaterialButtonWidth;
+                copyLE.preferredWidth = MaterialButtonWidth;
+                copyLE.flexibleWidth = 0f;
 
                 var rename = UIUtility.CreateButton($"MaterialRename", itemPanel.transform, ">");
                 var renameLE = rename.gameObject.AddComponent<LayoutElement>();
-                renameLE.preferredWidth = ButtonWidth / 4;
-                renameLE.flexibleWidth = 0;
+                renameLE.minWidth = MaterialRenameButtonWidth;
+                renameLE.preferredWidth = MaterialRenameButtonWidth;
+                renameLE.flexibleWidth = 0f;
             }
 
             //Material Shader
             {
                 var itemPanel = UIUtility.CreatePanel("ShaderPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
+
+                CreateInterpolableButton("SelectInterpolableShaderButton", itemPanel.transform);
 
                 var label = UIUtility.CreateText("ShaderLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
-
-                CreateInterpolableButton("SelectInterpolableShaderButton", itemPanel.transform);
+                labelLE.flexibleWidth = 1f;
 
                 Dropdown dropdownShader = UIUtility.CreateDropdown("ShaderDropdown", itemPanel.transform);
                 dropdownShader.transform.SetRect(0f, 0f, 0f, 1f, 0f, 0f, 100f);
@@ -255,162 +297,201 @@ namespace MaterialEditorAPI
                     if (shader.Key != "default")
                         dropdownShader.options.Add(new Dropdown.OptionData(shader.Key));
                 var dropdownShaderLE = dropdownShader.gameObject.AddComponent<LayoutElement>();
-                dropdownShaderLE.preferredWidth = DropdownWidth * 3;
-                dropdownShaderLE.flexibleWidth = 0;
+                dropdownShaderLE.minWidth = ShaderDropdownWidth;
+                dropdownShaderLE.preferredWidth = ShaderDropdownWidth;
+                dropdownShaderLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"ShaderResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Material RenderQueue
             {
                 var itemPanel = UIUtility.CreatePanel("ShaderRenderQueuePanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("ShaderRenderQueueLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
                 InputField textBoxShaderRenderQueue = UIUtility.CreateInputField("ShaderRenderQueueInput", itemPanel.transform);
                 textBoxShaderRenderQueue.text = "0";
                 var textBoxShaderRenderQueueLE = textBoxShaderRenderQueue.gameObject.AddComponent<LayoutElement>();
-                textBoxShaderRenderQueueLE.preferredWidth = TextBoxWidth;
-                textBoxShaderRenderQueueLE.flexibleWidth = 0;
+                textBoxShaderRenderQueueLE.minWidth = RenderQueueInputFieldWidth;
+                textBoxShaderRenderQueueLE.preferredWidth = RenderQueueInputFieldWidth;
+                textBoxShaderRenderQueueLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"ShaderRenderQueueResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             // Property Category
             {
                 var itemPanel = UIUtility.CreatePanel("PropertyCategoryPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = CategoryColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("PropertyCategoryLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
             }
 
             //Texture properties
             {
                 var itemPanel = UIUtility.CreatePanel("TexturePanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false; 
+                
+                CreateInterpolableButton("SelectInterpolableTextureButton", itemPanel.transform);
 
                 var label = UIUtility.CreateText("TextureLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
-
-                CreateInterpolableButton("SelectInterpolableTextureButton", itemPanel.transform);
+                labelLE.flexibleWidth = 1f; 
 
                 Button exportButton = UIUtility.CreateButton($"TextureExportButton", itemPanel.transform, $"Export Texture");
                 var exportButtonLE = exportButton.gameObject.AddComponent<LayoutElement>();
-                exportButtonLE.preferredWidth = ButtonWidth;
-                exportButtonLE.flexibleWidth = 0;
+                exportButtonLE.minWidth = TextureButtonWidth;
+                exportButtonLE.preferredWidth = TextureButtonWidth;
+                exportButtonLE.flexibleWidth = 0f;
 
                 Button importButton = UIUtility.CreateButton($"TextureImportButton", itemPanel.transform, $"Import Texture");
                 var importButtonLE = importButton.gameObject.AddComponent<LayoutElement>();
-                importButtonLE.preferredWidth = ButtonWidth;
-                importButtonLE.flexibleWidth = 0;
+                importButtonLE.minWidth = TextureButtonWidth;
+                importButtonLE.preferredWidth = TextureButtonWidth;
+                importButtonLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"TextureResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             //Offset and Scale
             {
                 var itemPanel = UIUtility.CreatePanel("OffsetScalePanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("OffsetScaleLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.flexibleWidth = 1f;
 
-                Text labelOffsetX = UIUtility.CreateText("OffsetXText", itemPanel.transform, "Offset X");
+                Text labelOffsetX = UIUtility.CreateText("OffsetXText", itemPanel.transform, "Ox");
                 labelOffsetX.alignment = TextAnchor.MiddleLeft;
                 labelOffsetX.color = Color.black;
                 var labelOffsetXLE = labelOffsetX.gameObject.AddComponent<LayoutElement>();
-                labelOffsetXLE.preferredWidth = LabelXWidth;
-                labelOffsetXLE.flexibleWidth = 0;
+                labelOffsetXLE.minWidth = OffsetScaleLabelWidth;
+                labelOffsetXLE.preferredWidth = OffsetScaleLabelWidth;
+                labelOffsetXLE.flexibleWidth = 0f;
 
                 InputField textBoxOffsetX = UIUtility.CreateInputField("OffsetXInput", itemPanel.transform);
                 textBoxOffsetX.text = "0";
+                textBoxOffsetX.characterLimit = 7;
                 var textBoxOffsetXLE = textBoxOffsetX.gameObject.AddComponent<LayoutElement>();
-                textBoxOffsetXLE.preferredWidth = TextBoxXYWidth;
-                textBoxOffsetXLE.flexibleWidth = 0;
+                textBoxOffsetXLE.minWidth = OffsetScaleInputFieldWidth;
+                textBoxOffsetXLE.preferredWidth = OffsetScaleInputFieldWidth;
+                textBoxOffsetXLE.flexibleWidth = 0f;
 
-                Text labelOffsetY = UIUtility.CreateText("OffsetYText", itemPanel.transform, "Y");
+                Text labelOffsetY = UIUtility.CreateText("OffsetYText", itemPanel.transform, "Oy");
                 labelOffsetY.alignment = TextAnchor.MiddleLeft;
                 labelOffsetY.color = Color.black;
                 var labelOffsetYLE = labelOffsetY.gameObject.AddComponent<LayoutElement>();
-                labelOffsetYLE.preferredWidth = LabelYWidth;
-                labelOffsetYLE.flexibleWidth = 0;
+                labelOffsetYLE.minWidth = OffsetScaleLabelWidth;
+                labelOffsetYLE.preferredWidth = OffsetScaleLabelWidth;
+                labelOffsetYLE.flexibleWidth = 0f;
 
                 InputField textBoxOffsetY = UIUtility.CreateInputField("OffsetYInput", itemPanel.transform);
                 textBoxOffsetY.text = "0";
+                textBoxOffsetY.characterLimit = 7;
                 var textBoxOffsetYLE = textBoxOffsetY.gameObject.AddComponent<LayoutElement>();
-                textBoxOffsetYLE.preferredWidth = TextBoxXYWidth;
-                textBoxOffsetYLE.flexibleWidth = 0;
+                textBoxOffsetYLE.minWidth = OffsetScaleInputFieldWidth;
+                textBoxOffsetYLE.preferredWidth = OffsetScaleInputFieldWidth;
+                textBoxOffsetYLE.flexibleWidth = 0f;
 
                 labelOffsetX.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxOffsetX, new[] { textBoxOffsetY });
                 labelOffsetY.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxOffsetY, new[] { textBoxOffsetX });
 
                 //Scale
-                Text labelScaleX = UIUtility.CreateText("ScaleXText", itemPanel.transform, "Scale X");
+                Text labelScaleX = UIUtility.CreateText("ScaleXText", itemPanel.transform, "Sx");
                 labelScaleX.alignment = TextAnchor.MiddleLeft;
                 labelScaleX.color = Color.black;
                 var labelScaleXLE = labelScaleX.gameObject.AddComponent<LayoutElement>();
-                labelScaleXLE.preferredWidth = LabelXWidth;
-                labelScaleXLE.flexibleWidth = 0;
+                labelScaleXLE.minWidth = OffsetScaleLabelWidth;
+                labelScaleXLE.preferredWidth = OffsetScaleLabelWidth;
+                labelScaleXLE.flexibleWidth = 0f;
 
                 InputField textBoxScaleX = UIUtility.CreateInputField("ScaleXInput", itemPanel.transform);
                 textBoxScaleX.text = "0";
+                textBoxScaleX.characterLimit = 7;
                 var textBoxScaleXLE = textBoxScaleX.gameObject.AddComponent<LayoutElement>();
-                textBoxScaleXLE.preferredWidth = TextBoxXYWidth;
-                textBoxScaleXLE.flexibleWidth = 0;
+                textBoxScaleXLE.minWidth = OffsetScaleInputFieldWidth;
+                textBoxScaleXLE.preferredWidth = OffsetScaleInputFieldWidth;
+                textBoxScaleXLE.flexibleWidth = 0f;
 
-                Text labelScaleY = UIUtility.CreateText("ScaleYText", itemPanel.transform, "Y");
+                Text labelScaleY = UIUtility.CreateText("ScaleYText", itemPanel.transform, "Sy");
                 labelScaleY.alignment = TextAnchor.MiddleLeft;
                 labelScaleY.color = Color.black;
                 var labelScaleYLE = labelScaleY.gameObject.AddComponent<LayoutElement>();
-                labelScaleYLE.preferredWidth = LabelYWidth;
-                labelScaleYLE.flexibleWidth = 0;
+                labelScaleYLE.minWidth = OffsetScaleLabelWidth;
+                labelScaleYLE.preferredWidth = OffsetScaleLabelWidth;
+                labelScaleYLE.flexibleWidth = 0f;
 
                 InputField textBoxScaleY = UIUtility.CreateInputField("ScaleYInput", itemPanel.transform);
                 textBoxScaleY.text = "0";
+                textBoxScaleY.characterLimit = 7;
                 var textBoxScaleYLE = textBoxScaleY.gameObject.AddComponent<LayoutElement>();
-                textBoxScaleYLE.preferredWidth = TextBoxXYWidth;
-                textBoxScaleYLE.flexibleWidth = 0;
+                textBoxScaleYLE.minWidth = OffsetScaleInputFieldWidth;
+                textBoxScaleYLE.preferredWidth = OffsetScaleInputFieldWidth;
+                textBoxScaleYLE.flexibleWidth = 0f;
+
+                Text emptySpace = UIUtility.CreateText("EmptySpace", itemPanel.transform, "");
+                emptySpace.alignment = TextAnchor.MiddleLeft;
+                var emptySpaceLE = emptySpace.gameObject.AddComponent<LayoutElement>();
+                emptySpaceLE.minWidth = OffsetScaleEmptySpaceWidth;
+                emptySpaceLE.preferredWidth = OffsetScaleEmptySpaceWidth;
+                emptySpaceLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"OffsetScaleResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
 
                 labelScaleX.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxScaleX, new[] { textBoxScaleY });
                 labelScaleY.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxScaleY, new[] { textBoxScaleX });
@@ -420,79 +501,97 @@ namespace MaterialEditorAPI
             {
                 var itemPanel = UIUtility.CreatePanel("ColorPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
+
+                CreateInterpolableButton("SelectInterpolableColorButton", itemPanel.transform);
 
                 var label = UIUtility.CreateText("ColorLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
-
-                CreateInterpolableButton("SelectInterpolableColorButton", itemPanel.transform);
+                labelLE.flexibleWidth = 1f;
 
                 Text labelR = UIUtility.CreateText("ColorRText", itemPanel.transform, "R");
                 labelR.alignment = TextAnchor.MiddleLeft;
                 labelR.color = Color.black;
                 var labelRLE = labelR.gameObject.AddComponent<LayoutElement>();
+                labelRLE.minWidth = ColorLabelWidth;
                 labelRLE.preferredWidth = ColorLabelWidth;
-                labelRLE.flexibleWidth = 0;
+                labelRLE.flexibleWidth = 0f;
 
                 InputField textBoxR = UIUtility.CreateInputField("ColorRInput", itemPanel.transform);
                 textBoxR.text = "0";
+                textBoxR.characterLimit = 7;
                 var textBoxRLE = textBoxR.gameObject.AddComponent<LayoutElement>();
-                textBoxRLE.preferredWidth = TextBoxWidth;
-                textBoxRLE.flexibleWidth = 0;
+                textBoxRLE.minWidth = ColorInputFieldWidth;
+                textBoxRLE.preferredWidth = ColorInputFieldWidth;
+                textBoxRLE.flexibleWidth = 0f;
+         
 
                 Text labelG = UIUtility.CreateText("ColorGText", itemPanel.transform, "G");
                 labelG.alignment = TextAnchor.MiddleLeft;
                 labelG.color = Color.black;
                 var labelGLE = labelG.gameObject.AddComponent<LayoutElement>();
+                labelGLE.minWidth = ColorLabelWidth;
                 labelGLE.preferredWidth = ColorLabelWidth;
-                labelGLE.flexibleWidth = 0;
+                labelGLE.flexibleWidth = 0f;
 
                 InputField textBoxG = UIUtility.CreateInputField("ColorGInput", itemPanel.transform);
                 textBoxG.text = "0";
+                textBoxG.characterLimit = 7;
                 var textBoxGLE = textBoxG.gameObject.AddComponent<LayoutElement>();
-                textBoxGLE.preferredWidth = TextBoxWidth;
-                textBoxGLE.flexibleWidth = 0;
+                textBoxGLE.minWidth = ColorInputFieldWidth;
+                textBoxGLE.preferredWidth = ColorInputFieldWidth;
+                textBoxGLE.flexibleWidth = 0f;
 
                 Text labelB = UIUtility.CreateText("ColorBText", itemPanel.transform, "B");
                 labelB.alignment = TextAnchor.MiddleLeft;
                 labelB.color = Color.black;
                 var labelBLE = labelB.gameObject.AddComponent<LayoutElement>();
+                labelBLE.minWidth = ColorLabelWidth;
                 labelBLE.preferredWidth = ColorLabelWidth;
-                labelBLE.flexibleWidth = 0;
+                labelBLE.flexibleWidth = 0f;
 
                 InputField textBoxB = UIUtility.CreateInputField("ColorBInput", itemPanel.transform);
                 textBoxB.text = "0";
+                textBoxB.characterLimit = 7;
                 var textBoxBLE = textBoxB.gameObject.AddComponent<LayoutElement>();
-                textBoxBLE.preferredWidth = TextBoxWidth;
-                textBoxBLE.flexibleWidth = 0;
+                textBoxBLE.minWidth = ColorInputFieldWidth;
+                textBoxBLE.preferredWidth = ColorInputFieldWidth;
+                textBoxBLE.flexibleWidth = 0f;
 
                 Text labelA = UIUtility.CreateText("ColorAText", itemPanel.transform, "A");
                 labelA.alignment = TextAnchor.MiddleLeft;
                 labelA.color = Color.black;
                 var labelALE = labelA.gameObject.AddComponent<LayoutElement>();
+                labelALE.minWidth = ColorLabelWidth;
                 labelALE.preferredWidth = ColorLabelWidth;
-                labelALE.flexibleWidth = 0;
+                labelALE.flexibleWidth = 0f;
 
                 InputField textBoxA = UIUtility.CreateInputField("ColorAInput", itemPanel.transform);
                 textBoxA.text = "0";
+                textBoxA.characterLimit = 7;
                 var textBoxALE = textBoxA.gameObject.AddComponent<LayoutElement>();
-                textBoxALE.preferredWidth = TextBoxWidth;
-                textBoxALE.flexibleWidth = 0;
+                textBoxALE.minWidth = ColorInputFieldWidth;
+                textBoxALE.preferredWidth = ColorInputFieldWidth;
+                textBoxALE.flexibleWidth = 0f;
 
                 var edit = UIUtility.CreateButton("ColorEditButton", itemPanel.transform, "");
                 var editLE = edit.gameObject.AddComponent<LayoutElement>();
+                editLE.minWidth = ColorEditButtonWidth;
                 editLE.preferredWidth = ColorEditButtonWidth;
-                editLE.flexibleWidth = 0;
+                editLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"ColorResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
 
                 labelR.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxR, new[] { textBoxG, textBoxB });
                 labelG.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxG, new[] { textBoxR, textBoxB });
@@ -504,33 +603,40 @@ namespace MaterialEditorAPI
             {
                 var itemPanel = UIUtility.CreatePanel("FloatPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
+
+                CreateInterpolableButton("SelectInterpolableFloatButton", itemPanel.transform);
 
                 var label = UIUtility.CreateText("FloatLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
+                labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
-
-                CreateInterpolableButton("SelectInterpolableFloatButton", itemPanel.transform);
+                labelLE.flexibleWidth = 1f;
 
                 Slider sliderFloat = UIUtility.CreateSlider("FloatSlider", itemPanel.transform);
                 var sliderFloatLE = sliderFloat.gameObject.AddComponent<LayoutElement>();
-                sliderFloatLE.preferredWidth = SliderWidth;
-                sliderFloatLE.flexibleWidth = 0;
+                sliderFloatLE.minWidth = FloatSliderWidth;
+                sliderFloatLE.preferredWidth = FloatSliderWidth;
+                sliderFloatLE.flexibleWidth = 0f;
 
                 InputField textBoxFloat = UIUtility.CreateInputField("FloatInputField", itemPanel.transform);
                 textBoxFloat.text = "0";
+                textBoxFloat.characterLimit = 9;
                 var textBoxFloatLE = textBoxFloat.gameObject.AddComponent<LayoutElement>();
-                textBoxFloatLE.preferredWidth = TextBoxWidth;
-                textBoxFloatLE.flexibleWidth = 0;
+                textBoxFloatLE.minWidth = FloatInputFieldWidth;
+                textBoxFloatLE.preferredWidth = FloatInputFieldWidth;
+                textBoxFloatLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"FloatResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
                 label.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxFloat);
             }
 
@@ -538,25 +644,30 @@ namespace MaterialEditorAPI
             {
                 var itemPanel = UIUtility.CreatePanel("KeywordPanel", contentList.transform);
                 itemPanel.gameObject.AddComponent<CanvasGroup>();
-                itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>().padding = Padding;
                 itemPanel.color = ItemColor;
+                var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
+                itemHLG.padding = Padding;
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("KeywordLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
-                labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = LabelWidth;
+                labelLE.minWidth = LabelWidth; 
+                labelLE.preferredWidth = LabelWidth; 
+                labelLE.flexibleWidth = 1f;
 
                 Toggle toggleKeyword = UIUtility.CreateToggle("KeywordToggle", itemPanel.transform, "");
                 var toggleKeywordLE = toggleKeyword.gameObject.AddComponent<LayoutElement>();
-                toggleKeywordLE.preferredWidth = TextBoxWidth;
-                toggleKeywordLE.flexibleWidth = 0;
+                toggleKeywordLE.minWidth = KeywordToggleWidth;
+                toggleKeywordLE.preferredWidth = KeywordToggleWidth;
+                toggleKeywordLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"KeywordResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
+                resetLE.minWidth = ResetButtonWidth;
                 resetLE.preferredWidth = ResetButtonWidth;
-                resetLE.flexibleWidth = 0;
+                resetLE.flexibleWidth = 0f;
             }
 
             return contentList.gameObject;
@@ -566,8 +677,9 @@ namespace MaterialEditorAPI
         {
             Button interpolableButton = UIUtility.CreateButton(objectName, parent, "O");
             var sinterpolableButtonLE = interpolableButton.gameObject.AddComponent<LayoutElement>();
-            sinterpolableButtonLE.preferredWidth = 15;
-            sinterpolableButtonLE.flexibleWidth = 0;
+            sinterpolableButtonLE.minWidth = InterpolableButtonWidth;
+            sinterpolableButtonLE.preferredWidth = InterpolableButtonWidth;
+            sinterpolableButtonLE.flexibleWidth = 0f;
             interpolableButton.gameObject.SetActive(false);
 
 #if !API && !EC

--- a/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
+++ b/src/MaterialEditor.Base/UI/UI.ItemTemplate.cs
@@ -23,8 +23,6 @@ namespace MaterialEditorAPI
                 itemHLG.padding = Padding;
                 itemHLG.childForceExpandWidth = false;
 
-                CreateInterpolableButton("SelectInterpolableRendererButton", itemPanel.transform);
-
                 var label = UIUtility.CreateText("RendererLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
@@ -40,7 +38,9 @@ namespace MaterialEditorAPI
                 labelRendererLE.minWidth = LabelWidth;
                 labelRendererLE.preferredWidth = LabelWidth;
                 labelRendererLE.flexibleWidth = 1f;
-                 
+
+                CreateInterpolableButton("SelectInterpolableRendererButton", itemPanel.transform);
+
                 Button exportUVButton = UIUtility.CreateButton("ExportUVButton", itemPanel.transform, "Export UV Map");
                 var exportUVButtonLE = exportUVButton.gameObject.AddComponent<LayoutElement>();
                 exportUVButtonLE.minWidth = RendererButtonWidth;
@@ -148,7 +148,7 @@ namespace MaterialEditorAPI
                 toggleReceiveShadowsLE.minWidth = RendererToggleWidth;
                 toggleReceiveShadowsLE.preferredWidth = RendererToggleWidth;
                 toggleReceiveShadowsLE.flexibleWidth = 0f;
-                
+
                 var reset = UIUtility.CreateButton($"RendererReceiveShadowsResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
@@ -179,7 +179,7 @@ namespace MaterialEditorAPI
                 toggleRendererUpdateWhenOffscreenLE.minWidth = RendererToggleWidth;
                 toggleRendererUpdateWhenOffscreenLE.preferredWidth = RendererToggleWidth;
                 toggleRendererUpdateWhenOffscreenLE.flexibleWidth = 0f;
-                
+
                 var reset = UIUtility.CreateButton($"RendererUpdateWhenOffscreenResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
                 resetLE.minWidth = ResetButtonWidth;
@@ -277,8 +277,6 @@ namespace MaterialEditorAPI
                 itemHLG.padding = Padding;
                 itemHLG.childForceExpandWidth = false;
 
-                CreateInterpolableButton("SelectInterpolableShaderButton", itemPanel.transform);
-
                 var label = UIUtility.CreateText("ShaderLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
@@ -286,6 +284,8 @@ namespace MaterialEditorAPI
                 labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
                 labelLE.flexibleWidth = 1f;
+
+                CreateInterpolableButton("SelectInterpolableShaderButton", itemPanel.transform);
 
                 Dropdown dropdownShader = UIUtility.CreateDropdown("ShaderDropdown", itemPanel.transform);
                 dropdownShader.transform.SetRect(0f, 0f, 0f, 1f, 0f, 0f, 100f);
@@ -364,9 +364,7 @@ namespace MaterialEditorAPI
                 itemPanel.color = ItemColor;
                 var itemHLG = itemPanel.gameObject.AddComponent<HorizontalLayoutGroup>();
                 itemHLG.padding = Padding;
-                itemHLG.childForceExpandWidth = false; 
-                
-                CreateInterpolableButton("SelectInterpolableTextureButton", itemPanel.transform);
+                itemHLG.childForceExpandWidth = false;
 
                 var label = UIUtility.CreateText("TextureLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
@@ -374,7 +372,9 @@ namespace MaterialEditorAPI
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
                 labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
-                labelLE.flexibleWidth = 1f; 
+                labelLE.flexibleWidth = 1f;
+
+                CreateInterpolableButton("SelectInterpolableTextureButton", itemPanel.transform);
 
                 Button exportButton = UIUtility.CreateButton($"TextureExportButton", itemPanel.transform, $"Export Texture");
                 var exportButtonLE = exportButton.gameObject.AddComponent<LayoutElement>();
@@ -412,12 +412,19 @@ namespace MaterialEditorAPI
                 labelLE.preferredWidth = LabelWidth;
                 labelLE.flexibleWidth = 1f;
 
-                Text labelOffsetX = UIUtility.CreateText("OffsetXText", itemPanel.transform, "Ox");
+                Text emptySpace = UIUtility.CreateText("EmptySpace", itemPanel.transform, "");
+                emptySpace.alignment = TextAnchor.MiddleLeft;
+                var emptySpaceLE = emptySpace.gameObject.AddComponent<LayoutElement>();
+                emptySpaceLE.minWidth = InterpolableButtonWidth;
+                emptySpaceLE.preferredWidth = InterpolableButtonWidth;
+                emptySpaceLE.flexibleWidth = 0f;
+
+                Text labelOffsetX = UIUtility.CreateText("OffsetXText", itemPanel.transform, "OffsetX");
                 labelOffsetX.alignment = TextAnchor.MiddleLeft;
                 labelOffsetX.color = Color.black;
                 var labelOffsetXLE = labelOffsetX.gameObject.AddComponent<LayoutElement>();
-                labelOffsetXLE.minWidth = OffsetScaleLabelWidth;
-                labelOffsetXLE.preferredWidth = OffsetScaleLabelWidth;
+                labelOffsetXLE.minWidth = OffsetScaleLabelXWidth;
+                labelOffsetXLE.preferredWidth = OffsetScaleLabelXWidth;
                 labelOffsetXLE.flexibleWidth = 0f;
 
                 InputField textBoxOffsetX = UIUtility.CreateInputField("OffsetXInput", itemPanel.transform);
@@ -428,12 +435,12 @@ namespace MaterialEditorAPI
                 textBoxOffsetXLE.preferredWidth = OffsetScaleInputFieldWidth;
                 textBoxOffsetXLE.flexibleWidth = 0f;
 
-                Text labelOffsetY = UIUtility.CreateText("OffsetYText", itemPanel.transform, "Oy");
+                Text labelOffsetY = UIUtility.CreateText("OffsetYText", itemPanel.transform, "Y");
                 labelOffsetY.alignment = TextAnchor.MiddleLeft;
                 labelOffsetY.color = Color.black;
                 var labelOffsetYLE = labelOffsetY.gameObject.AddComponent<LayoutElement>();
-                labelOffsetYLE.minWidth = OffsetScaleLabelWidth;
-                labelOffsetYLE.preferredWidth = OffsetScaleLabelWidth;
+                labelOffsetYLE.minWidth = OffsetScaleLabelYWidth;
+                labelOffsetYLE.preferredWidth = OffsetScaleLabelYWidth;
                 labelOffsetYLE.flexibleWidth = 0f;
 
                 InputField textBoxOffsetY = UIUtility.CreateInputField("OffsetYInput", itemPanel.transform);
@@ -448,12 +455,12 @@ namespace MaterialEditorAPI
                 labelOffsetY.gameObject.AddComponent<FloatLabelDragTrigger>().Initialize(textBoxOffsetY, new[] { textBoxOffsetX });
 
                 //Scale
-                Text labelScaleX = UIUtility.CreateText("ScaleXText", itemPanel.transform, "Sx");
+                Text labelScaleX = UIUtility.CreateText("ScaleXText", itemPanel.transform, "ScaleX");
                 labelScaleX.alignment = TextAnchor.MiddleLeft;
                 labelScaleX.color = Color.black;
                 var labelScaleXLE = labelScaleX.gameObject.AddComponent<LayoutElement>();
-                labelScaleXLE.minWidth = OffsetScaleLabelWidth;
-                labelScaleXLE.preferredWidth = OffsetScaleLabelWidth;
+                labelScaleXLE.minWidth = OffsetScaleLabelXWidth;
+                labelScaleXLE.preferredWidth = OffsetScaleLabelXWidth;
                 labelScaleXLE.flexibleWidth = 0f;
 
                 InputField textBoxScaleX = UIUtility.CreateInputField("ScaleXInput", itemPanel.transform);
@@ -464,12 +471,12 @@ namespace MaterialEditorAPI
                 textBoxScaleXLE.preferredWidth = OffsetScaleInputFieldWidth;
                 textBoxScaleXLE.flexibleWidth = 0f;
 
-                Text labelScaleY = UIUtility.CreateText("ScaleYText", itemPanel.transform, "Sy");
+                Text labelScaleY = UIUtility.CreateText("ScaleYText", itemPanel.transform, "Y");
                 labelScaleY.alignment = TextAnchor.MiddleLeft;
                 labelScaleY.color = Color.black;
                 var labelScaleYLE = labelScaleY.gameObject.AddComponent<LayoutElement>();
-                labelScaleYLE.minWidth = OffsetScaleLabelWidth;
-                labelScaleYLE.preferredWidth = OffsetScaleLabelWidth;
+                labelScaleYLE.minWidth = OffsetScaleLabelYWidth;
+                labelScaleYLE.preferredWidth = OffsetScaleLabelYWidth;
                 labelScaleYLE.flexibleWidth = 0f;
 
                 InputField textBoxScaleY = UIUtility.CreateInputField("ScaleYInput", itemPanel.transform);
@@ -479,13 +486,6 @@ namespace MaterialEditorAPI
                 textBoxScaleYLE.minWidth = OffsetScaleInputFieldWidth;
                 textBoxScaleYLE.preferredWidth = OffsetScaleInputFieldWidth;
                 textBoxScaleYLE.flexibleWidth = 0f;
-
-                Text emptySpace = UIUtility.CreateText("EmptySpace", itemPanel.transform, "");
-                emptySpace.alignment = TextAnchor.MiddleLeft;
-                var emptySpaceLE = emptySpace.gameObject.AddComponent<LayoutElement>();
-                emptySpaceLE.minWidth = OffsetScaleEmptySpaceWidth;
-                emptySpaceLE.preferredWidth = OffsetScaleEmptySpaceWidth;
-                emptySpaceLE.flexibleWidth = 0f;
 
                 var reset = UIUtility.CreateButton($"OffsetScaleResetButton", itemPanel.transform, "R");
                 var resetLE = reset.gameObject.AddComponent<LayoutElement>();
@@ -506,8 +506,6 @@ namespace MaterialEditorAPI
                 itemHLG.padding = Padding;
                 itemHLG.childForceExpandWidth = false;
 
-                CreateInterpolableButton("SelectInterpolableColorButton", itemPanel.transform);
-
                 var label = UIUtility.CreateText("ColorLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
@@ -515,6 +513,8 @@ namespace MaterialEditorAPI
                 labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
                 labelLE.flexibleWidth = 1f;
+
+                CreateInterpolableButton("SelectInterpolableColorButton", itemPanel.transform);
 
                 Text labelR = UIUtility.CreateText("ColorRText", itemPanel.transform, "R");
                 labelR.alignment = TextAnchor.MiddleLeft;
@@ -531,7 +531,7 @@ namespace MaterialEditorAPI
                 textBoxRLE.minWidth = ColorInputFieldWidth;
                 textBoxRLE.preferredWidth = ColorInputFieldWidth;
                 textBoxRLE.flexibleWidth = 0f;
-         
+
 
                 Text labelG = UIUtility.CreateText("ColorGText", itemPanel.transform, "G");
                 labelG.alignment = TextAnchor.MiddleLeft;
@@ -608,8 +608,6 @@ namespace MaterialEditorAPI
                 itemHLG.padding = Padding;
                 itemHLG.childForceExpandWidth = false;
 
-                CreateInterpolableButton("SelectInterpolableFloatButton", itemPanel.transform);
-
                 var label = UIUtility.CreateText("FloatLabel", itemPanel.transform, "");
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
@@ -617,6 +615,8 @@ namespace MaterialEditorAPI
                 labelLE.minWidth = LabelWidth;
                 labelLE.preferredWidth = LabelWidth;
                 labelLE.flexibleWidth = 1f;
+
+                CreateInterpolableButton("SelectInterpolableFloatButton", itemPanel.transform);
 
                 Slider sliderFloat = UIUtility.CreateSlider("FloatSlider", itemPanel.transform);
                 var sliderFloatLE = sliderFloat.gameObject.AddComponent<LayoutElement>();
@@ -653,9 +653,16 @@ namespace MaterialEditorAPI
                 label.alignment = TextAnchor.MiddleLeft;
                 label.color = Color.black;
                 var labelLE = label.gameObject.AddComponent<LayoutElement>();
-                labelLE.minWidth = LabelWidth; 
-                labelLE.preferredWidth = LabelWidth; 
+                labelLE.minWidth = LabelWidth;
+                labelLE.preferredWidth = LabelWidth;
                 labelLE.flexibleWidth = 1f;
+
+                Text emptySpace = UIUtility.CreateText("EmptySpace", itemPanel.transform, "");
+                emptySpace.alignment = TextAnchor.MiddleLeft;
+                var emptySpaceLE = emptySpace.gameObject.AddComponent<LayoutElement>();
+                emptySpaceLE.minWidth = InterpolableButtonWidth;
+                emptySpaceLE.preferredWidth = InterpolableButtonWidth;
+                emptySpaceLE.flexibleWidth = 0f;
 
                 Toggle toggleKeyword = UIUtility.CreateToggle("KeywordToggle", itemPanel.transform, "");
                 var toggleKeywordLE = toggleKeyword.gameObject.AddComponent<LayoutElement>();

--- a/src/MaterialEditor.Base/UI/UI.ListEntry.cs
+++ b/src/MaterialEditor.Base/UI/UI.ListEntry.cs
@@ -139,6 +139,7 @@ namespace MaterialEditorAPI
                         SelectInterpolableRendererButton.onClick.AddListener(() => item.SelectInterpolableButtonRendererOnClick());
                         TooltipManager.AddTooltip(SelectInterpolableRendererButton.gameObject, "Select the properties (Enabled, Shadow casting mode and Receive shadows) of the currently selected renderer as interpolables in timeline");
                         RendererText.text = item.RendererName;
+                        TooltipManager.AddTooltip(RendererText.gameObject, "Renderer name");
                         break;
                     case ItemInfo.RowItemType.RendererEnabled:
                         ShowRendererEnabled();
@@ -252,6 +253,7 @@ namespace MaterialEditorAPI
                         ShowMaterial();
                         SetLabelText(MaterialLabel, item.LabelText);
                         MaterialText.text = item.MaterialName;
+                        TooltipManager.AddTooltip(MaterialText.gameObject, "Material name");
                         MaterialCopyButton.onClick.RemoveAllListeners();
                         MaterialCopyButton.onClick.AddListener(() => item.MaterialOnCopy.Invoke());
                         TooltipManager.AddTooltip(MaterialCopyButton.gameObject, "Copy all the <b>edits</b> of this material");
@@ -370,6 +372,7 @@ namespace MaterialEditorAPI
                     case ItemInfo.RowItemType.PropertyCategory:
                         ShowPropertyCategory();
                         SetLabelText(PropertyCategoryLabel, item.LabelText);
+                        TooltipManager.AddTooltip(PropertyCategoryLabel.gameObject, "Category name");
                         break;
                     case ItemInfo.RowItemType.TextureProperty:
                         ShowTexture();
@@ -523,6 +526,10 @@ namespace MaterialEditorAPI
                             item.ScaleOnReset();
                             SetLabelText(OffsetScaleLabel, item.LabelText, item.Offset != item.OffsetOriginal || item.Scale != item.ScaleOriginal, OffsetScaleResetButton, OffsetScalePanel);
                         });
+                        TooltipManager.AddTooltip(OffsetXInput.gameObject, "Adjust the horizontal offset of the texture. It can move the texture left or right.");
+                        TooltipManager.AddTooltip(OffsetYInput.gameObject, "Adjust the vertical offset of the texture. It can move the texture up or down.");
+                        TooltipManager.AddTooltip(ScaleXInput.gameObject, "Adjust the horizontal scale of the texture. Values greater than 1 make the texture appear smaller horizontally, values less than 1 make it appear larger horizontally.");
+                        TooltipManager.AddTooltip(ScaleYInput.gameObject, "Adjust the vertical scale of the texture. Values greater than 1 make the texture appear smaller vertically, values less than 1 make it appear larger vertically.");
                         TooltipManager.AddTooltip(OffsetScaleResetButton.gameObject, "Reset both the scale and offset properties to their original values");
 
                         break;

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -58,20 +58,47 @@ namespace MaterialEditorAPI
         internal const float HeaderSize = 20f;
         internal const float ScrollOffsetX = -15f;
         internal const float PanelHeight = 20f;
-        internal const float LabelWidth = 50f;
-        internal const float ButtonWidth = 100f;
-        internal const float DropdownWidth = 100f;
-        internal const float TextBoxWidth = 75f;
-        internal const float ColorLabelWidth = 10f;
-        internal const float ResetButtonWidth = 30f;
-        internal const float ColorEditButtonWidth = 20f;
-        internal const float SliderWidth = 150f;
-        internal const float LabelXWidth = 60f;
-        internal const float LabelYWidth = 10f;
-        internal const float TextBoxXYWidth = 50f;
-        internal static RectOffset Padding;
-        internal static readonly Color RowColor = new Color(1f, 1f, 1f, 0.6f);
 
+        #region Entry Item Width
+        // General
+        internal const float LabelWidth = 0f;
+        internal const float ButtonWidth = 100f;
+        internal const float SmallButtonWidth = 24f;
+        internal const float ResetButtonWidth = SmallButtonWidth;
+        internal const float InterpolableButtonWidth = SmallButtonWidth;
+        internal const float ContentFullWidth = 316f;
+        // Renderer (Enbale/ShadowCastingMode/ReceiveShadows/RendererUpdateWhenOffscreen/RecalulateNormals)
+        internal const float RendererButtonWidth = ButtonWidth;
+        internal const float RendererToggleWidth = 20f;
+        internal const float RendererDropdownWidth = 94f;
+        // Material
+        internal const float MaterialButtonWidth = ButtonWidth * 0.75f;
+        internal const float MaterialRenameButtonWidth = SmallButtonWidth;
+        // Shader
+        internal const float ShaderDropdownWidth = ContentFullWidth;
+        // RenderQueue
+        internal const float RenderQueueInputFieldWidth = 94f;
+        // Texture
+        internal const float TextureButtonWidth = ContentFullWidth / 2f;
+        // Texture Offset and Scale
+        internal const float OffsetScaleLabelWidth = 24f;
+        internal const float OffsetScaleInputFieldWidth = 50f;
+        internal const float OffsetScaleEmptySpaceWidth = 20f;
+        // Color
+        internal const float ColorLabelWidth = 24f;
+        internal const float ColorInputFieldWidth = 50f;
+        internal const float ColorEditButtonWidth = 20f;
+        // Float
+        internal const float FloatSliderWidth = ContentFullWidth - 94f;
+        internal const float FloatInputFieldWidth = 94f;
+        // Keyword
+        internal const float KeywordToggleWidth = ContentFullWidth;
+        #endregion
+
+        internal static RectOffset Padding;
+
+        #region Colors
+        internal static readonly Color RowColor = new Color(1f, 1f, 1f, 0.6f);
         // https://simplified.com/blog/colors/triadic-colors
         internal static readonly Color RendererColor = new Color(0.984f, 0.600f, 0.008f, 0.5f);
         internal static readonly Color MaterialColor = new Color(0.400f, 0.690f, 0.196f, 0.5f);
@@ -79,6 +106,7 @@ namespace MaterialEditorAPI
 
         internal static readonly Color ItemColor = new Color(1f, 1f, 1f, 0f);
         internal static readonly Color ItemColorChanged = new Color(0f, 0f, 0f, 0.3f);
+        #endregion
 
         private protected IMaterialEditorColorPalette ColorPalette;
 
@@ -96,7 +124,7 @@ namespace MaterialEditorAPI
         /// </summary>
         protected void InitUI()
         {
-            Padding = new RectOffset(3, 2, 0, 1);
+            Padding = new RectOffset(1, 1, 0, 0);
 
             MaterialEditorWindow = UIUtility.CreateNewUISystem("MaterialEditorCanvas");
             MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -57,7 +57,7 @@ namespace MaterialEditorAPI
         internal const float MarginSize = 5f;
         internal const float HeaderSize = 20f;
         internal const float ScrollOffsetX = -15f;
-        internal const float PanelHeight = 20f;
+        internal const float PanelHeight = 22f;
 
         #region Entry Item Width
         // General
@@ -124,7 +124,7 @@ namespace MaterialEditorAPI
         /// </summary>
         protected void InitUI()
         {
-            Padding = new RectOffset(1, 1, 0, 0);
+            Padding = new RectOffset(1, 1, 1, 1);
 
             MaterialEditorWindow = UIUtility.CreateNewUISystem("MaterialEditorCanvas");
             MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -63,7 +63,7 @@ namespace MaterialEditorAPI
         // General
         internal const float LabelWidth = 0f;
         internal const float ButtonWidth = 100f;
-        internal const float SmallButtonWidth = 24f;
+        internal const float SmallButtonWidth = 20f;
         internal const float ResetButtonWidth = SmallButtonWidth;
         internal const float InterpolableButtonWidth = SmallButtonWidth;
         internal const float ContentFullWidth = 316f;
@@ -81,12 +81,12 @@ namespace MaterialEditorAPI
         // Texture
         internal const float TextureButtonWidth = ContentFullWidth / 2f;
         // Texture Offset and Scale
-        internal const float OffsetScaleLabelWidth = 24f;
+        internal const float OffsetScaleLabelXWidth = 48f;
+        internal const float OffsetScaleLabelYWidth = 10f;
         internal const float OffsetScaleInputFieldWidth = 50f;
-        internal const float OffsetScaleEmptySpaceWidth = 20f;
         // Color
-        internal const float ColorLabelWidth = 24f;
-        internal const float ColorInputFieldWidth = 50f;
+        internal const float ColorLabelWidth = 10f;
+        internal const float ColorInputFieldWidth = 64f;
         internal const float ColorEditButtonWidth = 20f;
         // Float
         internal const float FloatSliderWidth = ContentFullWidth - 94f;

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -124,7 +124,7 @@ namespace MaterialEditorAPI
         /// </summary>
         protected void InitUI()
         {
-            Padding = new RectOffset(1, 1, 0, 0);
+            Padding = new RectOffset(1, 1, 1, 1);
 
             MaterialEditorWindow = UIUtility.CreateNewUISystem("MaterialEditorCanvas");
             MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -64,7 +64,7 @@ namespace MaterialEditorAPI
         internal const float LabelWidth = 0f;
         internal const float ButtonWidth = 100f;
         internal const float SmallButtonWidth = 20f;
-        internal const float ResetButtonWidth = SmallButtonWidth;
+        internal const float ResetButtonWidth = SmallButtonWidth * 2f;
         internal const float InterpolableButtonWidth = SmallButtonWidth;
         internal const float ContentFullWidth = 316f;
         // Renderer (Enbale/ShadowCastingMode/ReceiveShadows/RendererUpdateWhenOffscreen/RecalulateNormals)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -124,7 +124,7 @@ namespace MaterialEditorAPI
         /// </summary>
         protected void InitUI()
         {
-            Padding = new RectOffset(1, 1, 1, 1);
+            Padding = new RectOffset(1, 1, 0, 0);
 
             MaterialEditorWindow = UIUtility.CreateNewUISystem("MaterialEditorCanvas");
             MaterialEditorWindow.GetComponent<CanvasScaler>().referenceResolution = new Vector2(1920f / UIScale.Value, 1080f / UIScale.Value);


### PR DESCRIPTION
This PR will fix the issue where the auto-expand feature in ME UI is not working correctly. 
It will also bring a neat and tidy alignment to the shader properties in ME, ensuring that the interface remains readable even when users choose not to sort properties by type or name.