### PR TITLE
[ME] never load/set updateWhenOffscreen in KK

### DIFF
--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -420,6 +420,7 @@ namespace MaterialEditorAPI
         /// <returns>True if the value was set, false if it could not be set</returns>
         public static bool SetRendererUpdateWhenOffscreen(GameObject gameObject, string rendererName, bool value)
         {
+#if !KK
             bool didSet = false;
             foreach (var renderer in GetRendererList(gameObject))
             {
@@ -430,6 +431,9 @@ namespace MaterialEditorAPI
                 }
             }
             return didSet;
+#else
+            return false;
+#endif
         }
 
         public static bool SetRendererRecalculateNormals(GameObject gameObject, string rendererName, bool value)

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -561,6 +561,7 @@ namespace MaterialEditorAPI
                 if (rend is SkinnedMeshRenderer meshRenderer) // recalculate normals should only exist on skinned renderers
                 {
                     //Renderer UpdateWhenOffscreen
+#if !KK
                     bool valueUpdateWhenOffscreenOriginal = meshRenderer.updateWhenOffscreen;
                     temp = GetRendererPropertyValueOriginal(data, rend, RendererProperties.UpdateWhenOffscreen, go);
                     if (!temp.IsNullOrEmpty())
@@ -573,6 +574,7 @@ namespace MaterialEditorAPI
                         RendererUpdateWhenOffscreenOnReset = () => RemoveRendererProperty(data, rend, RendererProperties.UpdateWhenOffscreen, go)
                     };
                     items.Add(rendererUpdateWhenOffscreenItem);
+#endif
 
                     //Renderer RecalculateNormals
                     bool valueRecalculateNormalsOriginal = false; // this is not a real renderproperty so I cannot be true by default

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -264,6 +264,9 @@ namespace KK_Plugins.MaterialEditor
                 for (var i = 0; i < properties.Count; i++)
                 {
                     var loadedProperty = properties[i];
+#if KK
+                    if (loadedProperty.Property == RendererProperties.UpdateWhenOffscreen) continue;
+#endif
                     GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
                     if (go != null)
                         if (MaterialAPI.SetRendererProperty(go, loadedProperty.RendererName, loadedProperty.Property, int.Parse(loadedProperty.Value)))

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -872,6 +872,9 @@ namespace KK_Plugins.MaterialEditor
             for (var i = 0; i < RendererPropertyList.Count; i++)
             {
                 var property = RendererPropertyList[i];
+# if KK
+                if (property.Property == RendererProperties.UpdateWhenOffscreen) continue;
+#endif
                 if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
                 if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
                 if (property.ObjectType == ObjectType.Hair && !hair) continue;


### PR DESCRIPTION
This property can crash KK when set (not sure if this also occurs on other games,, but it doesn't on KKS). This will prevent the following in KK:
- The saved property value from being loaded and thus applied on load
- Showing the UI element to set it
- The value from being set if some other plugin calls the method