### PR TITLE
[ME] Fix item type dropdown dissapearing if accessory list lengths don't match

### DIFF
--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -181,11 +181,16 @@ namespace KK_Plugins.MaterialEditor
             var accessories = chaControl.GetAccessoryObjects();
             for (var i = 0; i < accessories.Length; i++)
                 if (accessories[i] != null)
+                {
+                    string optionName = $"Accessory {AccessoryIndexToString(i)}";
 #if !PH
-                    ItemTypeDropDown.options.Add(new Dropdown.OptionData($"Accessory {AccessoryIndexToString(i)} {chaControl.infoAccessory[i].Name}"));
+                    if (i < chaControl.infoAccessory.Length)
+                        optionName += $" {chaControl.infoAccessory[i].Name}";
+                    ItemTypeDropDown.options.Add(new Dropdown.OptionData(optionName));
 #else
-                    ItemTypeDropDown.options.Add(new Dropdown.OptionData($"Accessory {AccessoryIndexToString(i)}"));
+                    ItemTypeDropDown.options.Add(new Dropdown.OptionData(optionName));
 #endif
+                }
         }
 
         private void ChangeItemType(int selectedItem, ChaControl chaControl)

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -186,10 +186,8 @@ namespace KK_Plugins.MaterialEditor
 #if !PH
                     if (i < chaControl.infoAccessory.Length)
                         optionName += $" {chaControl.infoAccessory[i].Name}";
-                    ItemTypeDropDown.options.Add(new Dropdown.OptionData(optionName));
-#else
-                    ItemTypeDropDown.options.Add(new Dropdown.OptionData(optionName));
 #endif
+                    ItemTypeDropDown.options.Add(new Dropdown.OptionData(optionName));
                 }
         }
 


### PR DESCRIPTION
Fixes both #277  and #307.
It can happen that the `infoAccessory` list does not match the length of actual accessory list, causing the drop-down to fail initialising because it can't get the name of the accessory.