### PR TITLE
[ME] Fix the issue: sometimes texture properties may not be found

### DIFF
--- a/src/MaterialEditor.Base/MaterialAPI.cs
+++ b/src/MaterialEditor.Base/MaterialAPI.cs
@@ -707,9 +707,12 @@ namespace MaterialEditorAPI
                 // The shader has the final say over these properties, not the texture itself.
                 var texturePropertyData = MaterialEditorPluginBase.XMLShaderProperties[MaterialEditorPluginBase.XMLShaderProperties.ContainsKey(material.shader.NameFormatted()) ? material.shader.NameFormatted() : "default"]
                 .Where(p => p.Value.Name == propertyName && p.Value.Type == ShaderPropertyType.Texture).FirstOrDefault().Value;
-                if (texturePropertyData.AnisoLevel.HasValue) value.anisoLevel = texturePropertyData.AnisoLevel.Value;
-                if (texturePropertyData.FilterMode.HasValue) value.filterMode = texturePropertyData.FilterMode.Value;
-                if (texturePropertyData.WrapMode.HasValue) value.wrapMode = texturePropertyData.WrapMode.Value;
+                if (texturePropertyData != null)
+                {
+                    if (texturePropertyData.AnisoLevel.HasValue) value.anisoLevel = texturePropertyData.AnisoLevel.Value;
+                    if (texturePropertyData.FilterMode.HasValue) value.filterMode = texturePropertyData.FilterMode.Value;
+                    if (texturePropertyData.WrapMode.HasValue) value.wrapMode = texturePropertyData.WrapMode.Value;
+                }
 
                 material.SetTexture($"_{propertyName}", value);
                 didSet = true;


### PR DESCRIPTION
Fixing the bug #365 : sometimes texture properties may not be found or even not loaded during `MaterialAPI.SetTexture`. In the reported issue, it is the `Matcap` texture property that exhibit this problem.

This seems related to the order in which the shader manifests and other data are loaded. It doesn’t always cause an error, but the possibility still exists. The timing of loading the shader manifests may need to be reconsidered.

This is merely a fix-only pull request. If the fixing logic works, it suggests that a texture's `anisoLevel`, `filterMode` and `wrapMode` may not have been successfully applied.