### PR TITLE
[ME][KK/KKS] Add Shift shader hints and synchronize siru material copies

### DIFF
--- a/Guides/Material Editor Guide/Extension API.md
+++ b/Guides/Material Editor Guide/Extension API.md
@@ -142,6 +142,11 @@ Providers are evaluated when the Material Editor row list is rebuilt. They must 
 
 Shader asset authors can provide equivalent built-in shader, category, and property metadata through XML `TextAsset` catalogs. See [Shader Tooltip Catalogs.md](Shader%20Tooltip%20Catalogs.md).
 
+Descriptor `TooltipText` uses the same interaction as catalog metadata: hold
+Shift to reveal the blue dashed hint marker, then hover the label while
+continuing to hold Shift. These authored hints remain available when ordinary
+Material Editor tooltips are disabled.
+
 ## Custom Property Editors
 
 Plugins can register a reusable semantic editor without creating or locating Unity controls:

--- a/Guides/Material Editor Guide/Shader Tooltip Catalogs.md
+++ b/Guides/Material Editor Guide/Shader Tooltip Catalogs.md
@@ -31,6 +31,22 @@ the shader still loads, but the catalog tooltips are not displayed.
 6. Check the BepInEx log after loading the mod. Catalog errors are reported as
    warnings and never block the shader itself.
 
+## In-Game Interaction
+
+Shader-authored hints use an intentional help mode so they do not obscure the
+editor during normal use:
+
+- Hold either Shift key to mark every visible Shader, category, and property
+  label that has authored hint text with a blue dashed underline.
+- While continuing to hold Shift, hover an underlined label to display its
+  hint.
+- Release Shift to hide the authored hint and all hint underlines.
+
+This behavior is independent of the existing `Show Tooltips` setting, which
+continues to control Material Editor's ordinary button and control tooltips.
+Users can disable the Shift help mode separately with `Enable Shader Hints`.
+Hints are suppressed while a property label is being dragged.
+
 ## Manifest Reference
 
 ```xml

--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -68,6 +68,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.RowBinder.FloatKeyword.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.RowView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.Tooltip.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.TooltipPolicy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ShaderHintUnderline.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.SelectListPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.TooltipManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.VirtualList.cs" />

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -111,6 +111,10 @@ namespace MaterialEditorAPI
         /// </summary>
         public static ConfigEntry<bool> Showtooltips { get; set; }
         /// <summary>
+        /// Whether Shift-activated shader-authored hints are available
+        /// </summary>
+        internal static ConfigEntry<bool> EnableShaderHints { get; private set; }
+        /// <summary>
         /// Whether to sort shader properties by their types
         /// </summary>
         public static ConfigEntry<bool> SortPropertiesByType { get; set; }
@@ -173,6 +177,11 @@ namespace MaterialEditorAPI
             ConfigExportPath = Config.Bind("Config", "Export Path Override", "", new ConfigDescription($"Textures and models will be exported to this folder. If empty, exports to {ExportPathDefault}", null, new ConfigurationManagerAttributes { Order = 1 }));
             PersistFilter = Config.Bind("Config", "Persist Filter", false, "Persist search filter across editor windows");
             Showtooltips = Config.Bind("Config", "Show Tooltips", true, "Whether to show tooltips or not");
+            EnableShaderHints = Config.Bind(
+                "Config",
+                "Enable Shader Hints",
+                true,
+                "Show shader-authored hints while holding Shift. This is independent of the Show Tooltips setting.");
             SortPropertiesByType = Config.Bind("Config", "Sort Properties by Type", true, "Whether to sort shader properties by their types.");
             SortPropertiesByName = Config.Bind("Config", "Sort Properties by Name", true, "Whether to sort shader properties by their names.");
             SortPropertiesByCategory = Config.Bind("Config", "Sort Properties by Category", true, "Whether to sort shader properties by their category.");

--- a/src/MaterialEditor.Base/UI/UI.CategoryNavigator.cs
+++ b/src/MaterialEditor.Base/UI/UI.CategoryNavigator.cs
@@ -209,11 +209,10 @@ namespace MaterialEditorAPI
             navigateLayout.minWidth = 0f;
             navigateLayout.preferredWidth = 0f;
             navigateLayout.flexibleWidth = 1f;
-            TooltipManager.AddTooltip(
+            TooltipBinding.Bind(
                 navigate.gameObject,
-                string.IsNullOrEmpty(target.TooltipText)
-                    ? "Jump to this property category"
-                    : target.TooltipText);
+                target.TooltipText,
+                "Jump to this property category");
             navigate.onClick.AddListener(() => _navigate(target));
 
             return new Entry(root, target);

--- a/src/MaterialEditor.Base/UI/UI.RowBinding.Common.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinding.Common.cs
@@ -119,17 +119,20 @@ namespace MaterialEditorAPI
             if (target == null)
                 return;
 
-            var text = string.IsNullOrEmpty(tooltipText)
-                ? fallbackText
-                : tooltipText;
+            var text = tooltipText ?? string.Empty;
             var tooltip = target.GetComponent<Tooltip>();
-            if (tooltip == null && !string.IsNullOrEmpty(text))
-                tooltip = TooltipManager.AddTooltip(target, text);
+            if (tooltip == null
+                && (!string.IsNullOrEmpty(text)
+                    || !string.IsNullOrEmpty(fallbackText)))
+            {
+                tooltip = target.AddComponent<Tooltip>();
+            }
             if (tooltip == null)
                 return;
 
-            tooltip.TooltipText = text ?? string.Empty;
-            tooltip.enabled = !string.IsNullOrEmpty(text);
+            var label = target.GetComponent<Text>()
+                        ?? target.GetComponentInChildren<Text>(true);
+            tooltip.Configure(fallbackText, text, label);
         }
     }
 

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.Color.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.Color.cs
@@ -8,7 +8,11 @@ namespace MaterialEditorAPI
     {
         internal static void CreateRows(Transform parent)
         {
-            var panel = RowViewFactorySupport.CreatePanel("ColorPanel", parent, ItemColor);
+            var panel = RowViewFactorySupport.CreatePanel(
+                "ColorPanel",
+                parent,
+                ItemColor,
+                true);
             panel.GetComponent<HorizontalLayoutGroup>().childControlWidth = true;
 
             var label = RowViewFactorySupport.CreateLabel(

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.FloatKeyword.cs
@@ -14,7 +14,11 @@ namespace MaterialEditorAPI
 
         private static void CreateFloatRow(Transform parent)
         {
-            var panel = RowViewFactorySupport.CreatePanel("FloatPanel", parent, ItemColor);
+            var panel = RowViewFactorySupport.CreatePanel(
+                "FloatPanel",
+                parent,
+                ItemColor,
+                true);
 
             var label = RowViewFactorySupport.CreateLabel(
                 "FloatLabel",
@@ -50,7 +54,11 @@ namespace MaterialEditorAPI
 
         private static void CreateKeywordRow(Transform parent)
         {
-            var panel = RowViewFactorySupport.CreatePanel("KeywordPanel", parent, ItemColor);
+            var panel = RowViewFactorySupport.CreatePanel(
+                "KeywordPanel",
+                parent,
+                ItemColor,
+                true);
 
             var label = RowViewFactorySupport.CreateLabel(
                 "KeywordLabel",

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.MaterialShader.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.MaterialShader.cs
@@ -128,7 +128,8 @@ namespace MaterialEditorAPI
             var panel = RowViewFactorySupport.CreatePanel(
                 "ShaderRenderQueuePanel",
                 parent,
-                ItemColor);
+                ItemColor,
+                true);
             var label = MaterialEditorControlFactory.CreateText(
                 "ShaderRenderQueueLabel",
                 panel.transform,

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.Support.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.Support.cs
@@ -6,14 +6,24 @@ namespace MaterialEditorAPI
 {
     internal static class RowViewFactorySupport
     {
-        internal static Image CreatePanel(string name, Transform parent, Color color)
+        internal static Image CreatePanel(
+            string name,
+            Transform parent,
+            Color color,
+            bool insetPropertyLabel = false)
         {
             var panel = MaterialEditorControlFactory.CreatePanel(name, parent);
             panel.gameObject.AddComponent<CanvasGroup>();
             panel.color = color;
 
             var layout = panel.gameObject.AddComponent<HorizontalLayoutGroup>();
-            layout.padding = Padding;
+            layout.padding = insetPropertyLabel
+                ? new RectOffset(
+                    Padding.left + MaterialEditorLayout.PropertyLabelInset,
+                    Padding.right,
+                    Padding.top,
+                    Padding.bottom)
+                : Padding;
             layout.childForceExpandWidth = false;
             layout.childAlignment = TextAnchor.MiddleLeft;
             return panel;

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.Texture.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.Texture.cs
@@ -41,7 +41,11 @@ namespace MaterialEditorAPI
 
         private static void CreateTextureRow(Transform parent)
         {
-            var panel = RowViewFactorySupport.CreatePanel("TexturePanel", parent, ItemColor);
+            var panel = RowViewFactorySupport.CreatePanel(
+                "TexturePanel",
+                parent,
+                ItemColor,
+                true);
             var label = RowViewFactorySupport.CreateLabel(
                 "TextureLabel",
                 panel.transform,
@@ -82,7 +86,8 @@ namespace MaterialEditorAPI
             var panel = RowViewFactorySupport.CreatePanel(
                 "OffsetScalePanel",
                 parent,
-                ItemColor);
+                ItemColor,
+                true);
 
             var label = MaterialEditorControlFactory.CreateText(
                 "OffsetScaleLabel",

--- a/src/MaterialEditor.Base/UI/UI.ShaderHintUnderline.cs
+++ b/src/MaterialEditor.Base/UI/UI.ShaderHintUnderline.cs
@@ -1,0 +1,170 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MaterialEditorAPI
+{
+    [RequireComponent(typeof(CanvasRenderer))]
+    internal sealed class ShaderHintUnderline : MaskableGraphic
+    {
+        private const float DashWidth = 3f;
+        private const float DashGap = 2f;
+        private const float LineThickness = 1f;
+        private const float UnderlineOffset = 0.5f;
+
+        private Text _label;
+        private string _lastText;
+        private float _lastPreferredWidth = -1f;
+        private float _lastPreferredHeight = -1f;
+        private float _lastRectWidth = -1f;
+        private float _lastRectHeight = -1f;
+
+        internal static ShaderHintUnderline GetOrCreate(Text label)
+        {
+            if (label == null)
+                return null;
+
+            var existing = label.GetComponentInChildren<ShaderHintUnderline>(true);
+            if (existing != null)
+            {
+                existing._label = label;
+                return existing;
+            }
+
+            var indicatorObject = new GameObject(
+                "ShaderHintUnderline",
+                typeof(RectTransform),
+                typeof(CanvasRenderer));
+            indicatorObject.transform.SetParent(label.transform, false);
+
+            var indicatorTransform = (RectTransform)indicatorObject.transform;
+            indicatorTransform.anchorMin = Vector2.zero;
+            indicatorTransform.anchorMax = Vector2.one;
+            indicatorTransform.offsetMin = Vector2.zero;
+            indicatorTransform.offsetMax = Vector2.zero;
+            indicatorTransform.localScale = Vector3.one;
+
+            var indicator = indicatorObject.AddComponent<ShaderHintUnderline>();
+            indicator._label = label;
+            indicator.color = MaterialEditorStyles.ShaderHintUnderlineColor;
+            indicator.raycastTarget = false;
+            indicatorObject.SetActive(false);
+            return indicator;
+        }
+
+        internal void SetVisible(bool visible)
+        {
+            if (gameObject.activeSelf == visible)
+                return;
+
+            gameObject.SetActive(visible);
+            if (visible)
+            {
+                ResetCachedLayout();
+                SetVerticesDirty();
+            }
+        }
+
+        public override void OnPopulateMesh(VertexHelper vertexHelper)
+        {
+            vertexHelper.Clear();
+            if (_label == null || string.IsNullOrEmpty(_label.text))
+                return;
+
+            var bounds = GetUnderlineBounds(rectTransform.rect, _label);
+            if (bounds.y <= bounds.x)
+                return;
+
+            var yMin = GetTextBottom(rectTransform.rect, _label) + UnderlineOffset;
+            var yMax = yMin + LineThickness;
+            for (var x = bounds.x; x < bounds.y; x += DashWidth + DashGap)
+                AddQuad(vertexHelper, x, Mathf.Min(x + DashWidth, bounds.y), yMin, yMax);
+        }
+
+        private void LateUpdate()
+        {
+            if (_label == null)
+                return;
+
+            var preferredWidth = _label.preferredWidth;
+            var preferredHeight = _label.preferredHeight;
+            var rectWidth = rectTransform.rect.width;
+            var rectHeight = rectTransform.rect.height;
+            if (_lastText == _label.text
+                && Mathf.Approximately(_lastPreferredWidth, preferredWidth)
+                && Mathf.Approximately(_lastPreferredHeight, preferredHeight)
+                && Mathf.Approximately(_lastRectWidth, rectWidth)
+                && Mathf.Approximately(_lastRectHeight, rectHeight))
+            {
+                return;
+            }
+
+            _lastText = _label.text;
+            _lastPreferredWidth = preferredWidth;
+            _lastPreferredHeight = preferredHeight;
+            _lastRectWidth = rectWidth;
+            _lastRectHeight = rectHeight;
+            SetVerticesDirty();
+        }
+
+        private static Vector2 GetUnderlineBounds(Rect rect, Text label)
+        {
+            var width = Mathf.Min(rect.width, label.preferredWidth);
+            switch (label.alignment)
+            {
+                case TextAnchor.UpperCenter:
+                case TextAnchor.MiddleCenter:
+                case TextAnchor.LowerCenter:
+                    return new Vector2(rect.center.x - width * 0.5f, rect.center.x + width * 0.5f);
+                case TextAnchor.UpperRight:
+                case TextAnchor.MiddleRight:
+                case TextAnchor.LowerRight:
+                    return new Vector2(rect.xMax - width, rect.xMax);
+                default:
+                    return new Vector2(rect.xMin, rect.xMin + width);
+            }
+        }
+
+        private static float GetTextBottom(Rect rect, Text label)
+        {
+            var textHeight = Mathf.Min(rect.height, label.preferredHeight);
+            switch (label.alignment)
+            {
+                case TextAnchor.UpperLeft:
+                case TextAnchor.UpperCenter:
+                case TextAnchor.UpperRight:
+                    return rect.yMax - textHeight;
+                case TextAnchor.LowerLeft:
+                case TextAnchor.LowerCenter:
+                case TextAnchor.LowerRight:
+                    return rect.yMin;
+                default:
+                    return rect.center.y - textHeight * 0.5f;
+            }
+        }
+
+        private void AddQuad(
+            VertexHelper vertexHelper,
+            float xMin,
+            float xMax,
+            float yMin,
+            float yMax)
+        {
+            var start = vertexHelper.currentVertCount;
+            vertexHelper.AddVert(new Vector3(xMin, yMin), color, Vector2.zero);
+            vertexHelper.AddVert(new Vector3(xMin, yMax), color, Vector2.zero);
+            vertexHelper.AddVert(new Vector3(xMax, yMax), color, Vector2.zero);
+            vertexHelper.AddVert(new Vector3(xMax, yMin), color, Vector2.zero);
+            vertexHelper.AddTriangle(start, start + 1, start + 2);
+            vertexHelper.AddTriangle(start + 2, start + 3, start);
+        }
+
+        private void ResetCachedLayout()
+        {
+            _lastText = null;
+            _lastPreferredWidth = -1f;
+            _lastPreferredHeight = -1f;
+            _lastRectWidth = -1f;
+            _lastRectHeight = -1f;
+        }
+    }
+}

--- a/src/MaterialEditor.Base/UI/UI.ShaderHintUnderline.cs
+++ b/src/MaterialEditor.Base/UI/UI.ShaderHintUnderline.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -8,25 +9,32 @@ namespace MaterialEditorAPI
     {
         private const float DashWidth = 3f;
         private const float DashGap = 2f;
-        private const float LineThickness = 1f;
-        private const float UnderlineOffset = 0.5f;
+        private const float LineThicknessPixels = 2f;
+        private const float UnderlineRise = 2f;
+        private const float MinimumSegmentSize = 0.01f;
+        private const float MinimumGlyphSize = 0.01f;
+        private const float MinimumBodyHeightRatio = 0.5f;
 
         private Text _label;
+        private ShaderHintTextMeshCapture _meshCapture;
         private string _lastText;
-        private float _lastPreferredWidth = -1f;
-        private float _lastPreferredHeight = -1f;
         private float _lastRectWidth = -1f;
         private float _lastRectHeight = -1f;
+        private int _lastFontSize = -1;
+        private int _lastBestFitFontSize = -1;
+        private int _lastCaptureVersion = -1;
+        private bool _retryMeshRead;
 
         internal static ShaderHintUnderline GetOrCreate(Text label)
         {
             if (label == null)
                 return null;
 
-            var existing = label.GetComponentInChildren<ShaderHintUnderline>(true);
+            var existing =
+                label.GetComponentInChildren<ShaderHintUnderline>(true);
             if (existing != null)
             {
-                existing._label = label;
+                existing.Attach(label);
                 return existing;
             }
 
@@ -36,32 +44,101 @@ namespace MaterialEditorAPI
                 typeof(CanvasRenderer));
             indicatorObject.transform.SetParent(label.transform, false);
 
-            var indicatorTransform = (RectTransform)indicatorObject.transform;
+            var indicatorTransform =
+                (RectTransform)indicatorObject.transform;
             indicatorTransform.anchorMin = Vector2.zero;
             indicatorTransform.anchorMax = Vector2.one;
             indicatorTransform.offsetMin = Vector2.zero;
             indicatorTransform.offsetMax = Vector2.zero;
+            indicatorTransform.pivot = label.rectTransform.pivot;
             indicatorTransform.localScale = Vector3.one;
 
-            var indicator = indicatorObject.AddComponent<ShaderHintUnderline>();
-            indicator._label = label;
-            indicator.color = MaterialEditorStyles.ShaderHintUnderlineColor;
+            var indicator =
+                indicatorObject.AddComponent<ShaderHintUnderline>();
+            indicator.Attach(label);
+            indicator.color =
+                MaterialEditorStyles.ShaderHintUnderlineColor;
             indicator.raycastTarget = false;
-            indicatorObject.SetActive(false);
+            indicator.SetVisible(false);
             return indicator;
         }
 
         internal void SetVisible(bool visible)
         {
             if (gameObject.activeSelf == visible)
+            {
+                if (_meshCapture != null)
+                    _meshCapture.enabled = visible;
                 return;
+            }
+
+            if (visible)
+            {
+                if (_meshCapture != null)
+                    _meshCapture.enabled = true;
+                ResetCachedLayout();
+                if (_label != null)
+                    _label.SetVerticesDirty();
+            }
+            else if (_meshCapture != null)
+            {
+                _meshCapture.enabled = false;
+            }
 
             gameObject.SetActive(visible);
             if (visible)
-            {
-                ResetCachedLayout();
                 SetVerticesDirty();
+        }
+
+        private void Attach(Text label)
+        {
+            if (_label == label)
+                return;
+
+            _label = label;
+            _meshCapture =
+                label.GetComponent<ShaderHintTextMeshCapture>();
+            if (_meshCapture == null)
+            {
+                _meshCapture =
+                    label.gameObject.AddComponent<ShaderHintTextMeshCapture>();
             }
+
+            _meshCapture.enabled = gameObject.activeSelf;
+            ResetCachedLayout();
+        }
+
+        private void LateUpdate()
+        {
+            if (_label == null)
+                return;
+
+            var rect = _label.rectTransform.rect;
+            var bestFitFontSize =
+                _label.cachedTextGenerator.fontSizeUsedForBestFit;
+            if (!_retryMeshRead
+                && _lastText == _label.text
+                && Mathf.Approximately(_lastRectWidth, rect.width)
+                && Mathf.Approximately(_lastRectHeight, rect.height)
+                && _lastFontSize == _label.fontSize
+                && _lastBestFitFontSize == bestFitFontSize
+                && _lastCaptureVersion == _meshCapture.Version
+                && _meshCapture.Matches(_label))
+            {
+                return;
+            }
+
+            _retryMeshRead = false;
+            _lastText = _label.text;
+            _lastRectWidth = rect.width;
+            _lastRectHeight = rect.height;
+            _lastFontSize = _label.fontSize;
+            _lastBestFitFontSize = bestFitFontSize;
+
+            // Register the label before this child graphic so the text mesh is
+            // current even when a virtualized row is rebound while scrolling.
+            _label.SetVerticesDirty();
+            SetVerticesDirty();
         }
 
         public override void OnPopulateMesh(VertexHelper vertexHelper)
@@ -70,75 +147,156 @@ namespace MaterialEditorAPI
             if (_label == null || string.IsNullOrEmpty(_label.text))
                 return;
 
-            var bounds = GetUnderlineBounds(rectTransform.rect, _label);
-            if (bounds.y <= bounds.x)
+            // Rebuild synchronously so the capture effect holds the final text
+            // vertices before this independent Graphic draws its underline.
+            _label.Rebuild(CanvasUpdate.PreRender);
+            if (!_meshCapture.Matches(_label))
+            {
+                _retryMeshRead = true;
                 return;
+            }
 
-            var yMin = GetTextBottom(rectTransform.rect, _label) + UnderlineOffset;
-            var yMax = yMin + LineThickness;
-            for (var x = bounds.x; x < bounds.y; x += DashWidth + DashGap)
-                AddQuad(vertexHelper, x, Mathf.Min(x + DashWidth, bounds.y), yMin, yMax);
-        }
+            _lastCaptureVersion = _meshCapture.Version;
 
-        private void LateUpdate()
-        {
-            if (_label == null)
-                return;
-
-            var preferredWidth = _label.preferredWidth;
-            var preferredHeight = _label.preferredHeight;
-            var rectWidth = rectTransform.rect.width;
-            var rectHeight = rectTransform.rect.height;
-            if (_lastText == _label.text
-                && Mathf.Approximately(_lastPreferredWidth, preferredWidth)
-                && Mathf.Approximately(_lastPreferredHeight, preferredHeight)
-                && Mathf.Approximately(_lastRectWidth, rectWidth)
-                && Mathf.Approximately(_lastRectHeight, rectHeight))
+            float left;
+            float right;
+            float bodyBottom;
+            if (!TryGetVisibleTextBounds(
+                    _meshCapture.Vertices,
+                    out left,
+                    out right,
+                    out bodyBottom))
             {
                 return;
             }
 
-            _lastText = _label.text;
-            _lastPreferredWidth = preferredWidth;
-            _lastPreferredHeight = preferredHeight;
-            _lastRectWidth = rectWidth;
-            _lastRectHeight = rectHeight;
-            SetVerticesDirty();
+            var yMax = bodyBottom + UnderlineRise;
+            var yMin = yMax - GetLineThickness();
+            AddDashes(vertexHelper, left, right, yMin, yMax);
         }
 
-        private static Vector2 GetUnderlineBounds(Rect rect, Text label)
+        private float GetLineThickness()
         {
-            var width = Mathf.Min(rect.width, label.preferredWidth);
-            switch (label.alignment)
+            var scaleFactor =
+                canvas != null ? canvas.scaleFactor : 1f;
+            if (scaleFactor <= 0f)
+                scaleFactor = 1f;
+
+            return LineThicknessPixels / scaleFactor;
+        }
+
+        private static bool TryGetVisibleTextBounds(
+            IList<Vector3> vertices,
+            out float left,
+            out float right,
+            out float bodyBottom)
+        {
+            left = float.PositiveInfinity;
+            right = float.NegativeInfinity;
+            bodyBottom = float.NegativeInfinity;
+
+            const int verticesPerGlyph = 4;
+            var glyphCount = vertices.Count / verticesPerGlyph;
+            var maximumGlyphHeight = 0f;
+            for (var glyphIndex = 0;
+                 glyphIndex < glyphCount;
+                 glyphIndex++)
             {
-                case TextAnchor.UpperCenter:
-                case TextAnchor.MiddleCenter:
-                case TextAnchor.LowerCenter:
-                    return new Vector2(rect.center.x - width * 0.5f, rect.center.x + width * 0.5f);
-                case TextAnchor.UpperRight:
-                case TextAnchor.MiddleRight:
-                case TextAnchor.LowerRight:
-                    return new Vector2(rect.xMax - width, rect.xMax);
-                default:
-                    return new Vector2(rect.xMin, rect.xMin + width);
+                GlyphBounds bounds;
+                if (!TryGetGlyphBounds(
+                        vertices,
+                        glyphIndex,
+                        verticesPerGlyph,
+                        out bounds))
+                    continue;
+
+                left = Mathf.Min(left, bounds.Left);
+                right = Mathf.Max(right, bounds.Right);
+                maximumGlyphHeight =
+                    Mathf.Max(maximumGlyphHeight, bounds.Height);
             }
+
+            if (float.IsInfinity(left)
+                || float.IsInfinity(right)
+                || right <= left)
+                return false;
+
+            var minimumBodyHeight =
+                maximumGlyphHeight * MinimumBodyHeightRatio;
+            for (var glyphIndex = 0;
+                 glyphIndex < glyphCount;
+                 glyphIndex++)
+            {
+                GlyphBounds bounds;
+                if (!TryGetGlyphBounds(
+                        vertices,
+                        glyphIndex,
+                        verticesPerGlyph,
+                        out bounds)
+                    || bounds.Height < minimumBodyHeight)
+                    continue;
+
+                bodyBottom = Mathf.Max(bodyBottom, bounds.Bottom);
+            }
+
+            return !float.IsInfinity(bodyBottom);
         }
 
-        private static float GetTextBottom(Rect rect, Text label)
+        private static bool TryGetGlyphBounds(
+            IList<Vector3> vertices,
+            int glyphIndex,
+            int verticesPerGlyph,
+            out GlyphBounds bounds)
         {
-            var textHeight = Mathf.Min(rect.height, label.preferredHeight);
-            switch (label.alignment)
+            var left = float.PositiveInfinity;
+            var right = float.NegativeInfinity;
+            var bottom = float.PositiveInfinity;
+            var top = float.NegativeInfinity;
+
+            for (var vertexIndex = 0;
+                 vertexIndex < verticesPerGlyph;
+                 vertexIndex++)
             {
-                case TextAnchor.UpperLeft:
-                case TextAnchor.UpperCenter:
-                case TextAnchor.UpperRight:
-                    return rect.yMax - textHeight;
-                case TextAnchor.LowerLeft:
-                case TextAnchor.LowerCenter:
-                case TextAnchor.LowerRight:
-                    return rect.yMin;
-                default:
-                    return rect.center.y - textHeight * 0.5f;
+                var position =
+                    vertices[glyphIndex * verticesPerGlyph + vertexIndex];
+                left = Mathf.Min(left, position.x);
+                right = Mathf.Max(right, position.x);
+                bottom = Mathf.Min(bottom, position.y);
+                top = Mathf.Max(top, position.y);
+            }
+
+            bounds = new GlyphBounds(left, right, bottom, top);
+            return bounds.Width > MinimumGlyphSize
+                   && bounds.Height > MinimumGlyphSize;
+        }
+
+        private void AddDashes(
+            VertexHelper vertexHelper,
+            float left,
+            float right,
+            float yMin,
+            float yMax)
+        {
+            var lastDashEnd = left;
+            for (var x = left; x < right; x += DashWidth + DashGap)
+            {
+                lastDashEnd = Mathf.Min(x + DashWidth, right);
+                AddQuad(
+                    vertexHelper,
+                    x,
+                    lastDashEnd,
+                    yMin,
+                    yMax);
+            }
+
+            if (right - lastDashEnd > MinimumSegmentSize)
+            {
+                AddQuad(
+                    vertexHelper,
+                    Mathf.Max(left, right - DashWidth),
+                    right,
+                    yMin,
+                    yMax);
             }
         }
 
@@ -150,10 +308,22 @@ namespace MaterialEditorAPI
             float yMax)
         {
             var start = vertexHelper.currentVertCount;
-            vertexHelper.AddVert(new Vector3(xMin, yMin), color, Vector2.zero);
-            vertexHelper.AddVert(new Vector3(xMin, yMax), color, Vector2.zero);
-            vertexHelper.AddVert(new Vector3(xMax, yMax), color, Vector2.zero);
-            vertexHelper.AddVert(new Vector3(xMax, yMin), color, Vector2.zero);
+            vertexHelper.AddVert(
+                new Vector3(xMin, yMin),
+                color,
+                Vector2.zero);
+            vertexHelper.AddVert(
+                new Vector3(xMin, yMax),
+                color,
+                Vector2.zero);
+            vertexHelper.AddVert(
+                new Vector3(xMax, yMax),
+                color,
+                Vector2.zero);
+            vertexHelper.AddVert(
+                new Vector3(xMax, yMin),
+                color,
+                Vector2.zero);
             vertexHelper.AddTriangle(start, start + 1, start + 2);
             vertexHelper.AddTriangle(start + 2, start + 3, start);
         }
@@ -161,10 +331,99 @@ namespace MaterialEditorAPI
         private void ResetCachedLayout()
         {
             _lastText = null;
-            _lastPreferredWidth = -1f;
-            _lastPreferredHeight = -1f;
             _lastRectWidth = -1f;
             _lastRectHeight = -1f;
+            _lastFontSize = -1;
+            _lastBestFitFontSize = -1;
+            _lastCaptureVersion = -1;
+            _retryMeshRead = true;
+        }
+
+        private struct GlyphBounds
+        {
+            internal readonly float Left;
+            internal readonly float Right;
+            internal readonly float Bottom;
+            internal readonly float Top;
+
+            internal float Width => Right - Left;
+            internal float Height => Top - Bottom;
+
+            internal GlyphBounds(
+                float left,
+                float right,
+                float bottom,
+                float top)
+            {
+                Left = left;
+                Right = right;
+                Bottom = bottom;
+                Top = top;
+            }
+        }
+    }
+
+    [RequireComponent(typeof(Text))]
+    internal sealed class ShaderHintTextMeshCapture : BaseMeshEffect
+    {
+        private readonly List<Vector3> _vertices =
+            new List<Vector3>();
+
+        private string _capturedText;
+        private float _capturedRectWidth = -1f;
+        private float _capturedRectHeight = -1f;
+        private int _capturedFontSize = -1;
+        private int _capturedBestFitFontSize = -1;
+
+        internal IList<Vector3> Vertices => _vertices;
+        internal int Version { get; private set; }
+
+        internal bool Matches(Text label)
+        {
+            if (label == null)
+                return false;
+
+            var rect = label.rectTransform.rect;
+            return _capturedText == label.text
+                   && Mathf.Approximately(
+                       _capturedRectWidth,
+                       rect.width)
+                   && Mathf.Approximately(
+                       _capturedRectHeight,
+                       rect.height)
+                   && _capturedFontSize == label.fontSize
+                   && _capturedBestFitFontSize
+                   == label.cachedTextGenerator.fontSizeUsedForBestFit;
+        }
+
+        public override void ModifyMesh(VertexHelper vertexHelper)
+        {
+            if (!IsActive())
+                return;
+
+            _vertices.Clear();
+            var vertex = new UIVertex();
+            for (var index = 0;
+                 index < vertexHelper.currentVertCount;
+                 index++)
+            {
+                vertexHelper.PopulateUIVertex(ref vertex, index);
+                _vertices.Add(vertex.position);
+            }
+
+            var label = graphic as Text;
+            if (label != null)
+            {
+                var rect = label.rectTransform.rect;
+                _capturedText = label.text;
+                _capturedRectWidth = rect.width;
+                _capturedRectHeight = rect.height;
+                _capturedFontSize = label.fontSize;
+                _capturedBestFitFontSize =
+                    label.cachedTextGenerator.fontSizeUsedForBestFit;
+            }
+
+            Version++;
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
+++ b/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
@@ -76,6 +76,8 @@ namespace MaterialEditorAPI
         internal static readonly Color TransparentRowColor = new Color(1f, 1f, 1f, 0f);
         internal static readonly Color ChangedRowColor = new Color(0f, 0f, 0f, 0.3f);
         internal static readonly Color ScrollbarColor = new Color(1f, 1f, 1f, 0.6f);
+        internal static readonly Color ShaderHintUnderlineColor =
+            new Color(0.05f, 0.45f, 1f, 1f);
 
         internal static void ApplyPanel(Image panel, MaterialEditorPanelRole role)
         {

--- a/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
+++ b/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
@@ -11,6 +11,7 @@ namespace MaterialEditorAPI
         internal const float ScrollbarOffset = -15f;
         internal const float RowHeight = 22f;
         internal const float CategoryNavigatorWidth = 150f;
+        internal const int PropertyLabelInset = 3;
 
         internal const float LabelWidth = 0f;
         internal const float ButtonWidth = 100f;

--- a/src/MaterialEditor.Base/UI/UI.Tooltip.cs
+++ b/src/MaterialEditor.Base/UI/UI.Tooltip.cs
@@ -1,31 +1,97 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace MaterialEditorAPI
 {
-    internal class Tooltip : UIBehaviour, IPointerEnterHandler, IPointerExitHandler
+    internal class Tooltip : UIBehaviour,
+        IPointerEnterHandler,
+        IPointerExitHandler,
+        IBeginDragHandler,
+        IEndDragHandler
     {
-        public Action<PointerEventData> onPointerEnter;
-        public Action<PointerEventData> onPointerExit;
+        private ShaderHintUnderline _hintUnderline;
 
-        public string TooltipText;
+        internal string StandardTooltipText { get; private set; }
+        internal string ShaderHintText { get; private set; }
+        internal bool IsHovered { get; private set; }
+        internal bool InteractionSuppressed { get; private set; }
+        internal bool HasStandardTooltip =>
+            !string.IsNullOrEmpty(StandardTooltipText);
+        internal bool HasShaderHint =>
+            !string.IsNullOrEmpty(ShaderHintText);
 
-        public override void Start()
+        internal void Configure(
+            string standardTooltipText,
+            string shaderHintText,
+            Text hintLabel)
         {
-            onPointerEnter = (e) => { TooltipManager.SetToolTipText(TooltipText, true); };
-            onPointerExit = (e) => { TooltipManager.SetActive(false); };
+            StandardTooltipText = standardTooltipText ?? string.Empty;
+            ShaderHintText = shaderHintText ?? string.Empty;
+
+            if (HasShaderHint && hintLabel != null)
+                _hintUnderline = ShaderHintUnderline.GetOrCreate(hintLabel);
+            if (_hintUnderline != null && !HasShaderHint)
+                _hintUnderline.SetVisible(false);
+
+            enabled = HasStandardTooltip || HasShaderHint;
+            TooltipManager.NotifyTooltipChanged(this);
+        }
+
+        internal void SetStandardTooltipText(string text)
+        {
+            Configure(text, ShaderHintText, null);
+        }
+
+        internal void SetHintIndicatorVisible(bool visible)
+        {
+            if (_hintUnderline != null)
+                _hintUnderline.SetVisible(visible && HasShaderHint);
+        }
+
+        public override void OnEnable()
+        {
+            base.OnEnable();
+            TooltipManager.Register(this);
+        }
+
+        public override void OnDisable()
+        {
+            IsHovered = false;
+            InteractionSuppressed = false;
+            SetHintIndicatorVisible(false);
+            TooltipManager.Unregister(this);
+            base.OnDisable();
+        }
+
+        public override void OnDestroy()
+        {
+            TooltipManager.Unregister(this);
+            base.OnDestroy();
         }
 
         public void OnPointerEnter(PointerEventData eventData)
         {
-            onPointerEnter?.Invoke(eventData);
+            IsHovered = true;
+            TooltipManager.PointerStateChanged(this);
         }
 
         public void OnPointerExit(PointerEventData eventData)
         {
-            onPointerExit?.Invoke(eventData);
+            IsHovered = false;
+            InteractionSuppressed = false;
+            TooltipManager.PointerStateChanged(this);
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            InteractionSuppressed = true;
+            TooltipManager.PointerStateChanged(this);
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            InteractionSuppressed = false;
+            TooltipManager.PointerStateChanged(this);
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.TooltipManager.cs
+++ b/src/MaterialEditor.Base/UI/UI.TooltipManager.cs
@@ -1,4 +1,5 @@
-﻿using UILib;
+using System.Collections.Generic;
+using UILib;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,44 +10,47 @@ namespace MaterialEditorAPI
         private const float TooltipWidth = 280f;
         private const float TooltipMaximumHeight = 360f;
         private static TooltipManager Instance;
+        private readonly HashSet<Tooltip> _tooltips = new HashSet<Tooltip>();
+
         public Image Panel { get; private set; } = null;
         private RectTransform panelTransform = null;
         private Text tooltipText;
+        private Tooltip _hoveredTooltip;
+        private bool _shiftPressed;
+        private bool _standardTooltipsEnabled;
+        private bool _shaderHintsEnabled;
 
         private void Update()
         {
-            if (MaterialEditorPluginBase.Showtooltips.Value && Panel.gameObject.activeSelf)
+            var shiftPressed = Input.GetKey(KeyCode.LeftShift)
+                               || Input.GetKey(KeyCode.RightShift);
+            var standardTooltipsEnabled =
+                MaterialEditorPluginBase.Showtooltips == null
+                || MaterialEditorPluginBase.Showtooltips.Value;
+            var shaderHintsEnabled =
+                MaterialEditorPluginBase.EnableShaderHints == null
+                || MaterialEditorPluginBase.EnableShaderHints.Value;
+
+            if (_shiftPressed != shiftPressed
+                || _standardTooltipsEnabled != standardTooltipsEnabled
+                || _shaderHintsEnabled != shaderHintsEnabled)
             {
-                var parent = panelTransform.parent as RectTransform;
-                Vector2 position;
-                if (parent != null
-                    && RectTransformUtility.ScreenPointToLocalPointInRectangle(
-                        parent,
-                        Input.mousePosition,
-                        null,
-                        out position))
-                {
-                    position += new Vector2(5f, 5f);
-                    var parentRect = parent.rect;
-                    var size = panelTransform.rect.size;
-                    position.x = Mathf.Clamp(
-                        position.x,
-                        parentRect.xMin,
-                        parentRect.xMax - size.x);
-                    position.y = Mathf.Clamp(
-                        position.y,
-                        parentRect.yMin,
-                        parentRect.yMax - size.y);
-                    panelTransform.localPosition = position;
-                }
+                _shiftPressed = shiftPressed;
+                _standardTooltipsEnabled = standardTooltipsEnabled;
+                _shaderHintsEnabled = shaderHintsEnabled;
+                RefreshHintIndicators();
+                RefreshTooltipState();
             }
+
+            if (Panel.gameObject.activeSelf)
+                UpdatePanelPosition();
         }
 
         internal static void Init(Transform parent)
         {
             var tooltip = parent.gameObject.AddComponent<TooltipManager>();
 
-            var panel = MaterialEditorControlFactory.CreatePanel($"TooltipPanel", parent);
+            var panel = MaterialEditorControlFactory.CreatePanel("TooltipPanel", parent);
             var panelTransform = (RectTransform)panel.transform;
 
             panel.color = new Color(0.2f, 0.2f, 0.2f, 0.98f);
@@ -58,7 +62,7 @@ namespace MaterialEditorAPI
                 TooltipWidth);
 
             var tooltipText = MaterialEditorControlFactory.CreateText(
-                $"ToolTipText",
+                "ToolTipText",
                 panel.transform,
                 "",
                 MaterialEditorTextRole.Tooltip);
@@ -84,15 +88,147 @@ namespace MaterialEditorAPI
             tooltip.Panel = panel;
             tooltip.panelTransform = panelTransform;
             tooltip.tooltipText = tooltipText;
+            tooltip._shiftPressed = Input.GetKey(KeyCode.LeftShift)
+                                      || Input.GetKey(KeyCode.RightShift);
+            tooltip._standardTooltipsEnabled =
+                MaterialEditorPluginBase.Showtooltips == null
+                || MaterialEditorPluginBase.Showtooltips.Value;
+            tooltip._shaderHintsEnabled =
+                MaterialEditorPluginBase.EnableShaderHints == null
+                || MaterialEditorPluginBase.EnableShaderHints.Value;
             Instance = tooltip;
+
+            foreach (var existing in parent.GetComponentsInChildren<Tooltip>(true))
+                tooltip.RegisterInternal(existing);
         }
 
-        public static void SetToolTipText(string text, bool setActive = false)
+        internal static void Register(Tooltip tooltip)
         {
-            Instance.tooltipText.text = text;
-            Instance.RefreshLayout();
-            if (setActive)
-                SetActive(true);
+            if (Instance != null)
+                Instance.RegisterInternal(tooltip);
+        }
+
+        internal static void Unregister(Tooltip tooltip)
+        {
+            if (Instance != null)
+                Instance.UnregisterInternal(tooltip);
+        }
+
+        internal static void NotifyTooltipChanged(Tooltip tooltip)
+        {
+            if (Instance == null || tooltip == null)
+                return;
+
+            if (tooltip.isActiveAndEnabled)
+                Instance.RegisterInternal(tooltip);
+            else
+                Instance.UnregisterInternal(tooltip);
+            tooltip.SetHintIndicatorVisible(
+                Instance._shiftPressed && Instance._shaderHintsEnabled);
+            if (Instance._hoveredTooltip == tooltip)
+                Instance.RefreshTooltipState();
+        }
+
+        internal static void PointerStateChanged(Tooltip tooltip)
+        {
+            if (Instance == null || tooltip == null)
+                return;
+
+            if (tooltip.IsHovered)
+                Instance._hoveredTooltip = tooltip;
+            else if (Instance._hoveredTooltip == tooltip)
+                Instance._hoveredTooltip = null;
+            Instance.RefreshTooltipState();
+        }
+
+        public static Tooltip AddTooltip(GameObject go, string text)
+        {
+            var tooltip = go.GetComponent<Tooltip>();
+            if (tooltip == null)
+                tooltip = go.AddComponent<Tooltip>();
+            tooltip.SetStandardTooltipText(text);
+            return tooltip;
+        }
+
+        private void RegisterInternal(Tooltip tooltip)
+        {
+            if (tooltip == null)
+                return;
+
+            _tooltips.Add(tooltip);
+            tooltip.SetHintIndicatorVisible(_shiftPressed && _shaderHintsEnabled);
+        }
+
+        private void UnregisterInternal(Tooltip tooltip)
+        {
+            if (tooltip == null)
+                return;
+
+            _tooltips.Remove(tooltip);
+            tooltip.SetHintIndicatorVisible(false);
+            if (_hoveredTooltip == tooltip)
+            {
+                _hoveredTooltip = null;
+                HideTooltip();
+            }
+        }
+
+        private void RefreshHintIndicators()
+        {
+            _tooltips.RemoveWhere(item => item == null);
+            foreach (var tooltip in _tooltips)
+                tooltip.SetHintIndicatorVisible(_shiftPressed && _shaderHintsEnabled);
+        }
+
+        private void RefreshTooltipState()
+        {
+            if (_hoveredTooltip == null || !_hoveredTooltip.isActiveAndEnabled)
+            {
+                HideTooltip();
+                return;
+            }
+
+            var displayKind = TooltipDisplayPolicy.Resolve(
+                _hoveredTooltip.IsHovered,
+                _hoveredTooltip.InteractionSuppressed,
+                _standardTooltipsEnabled,
+                _shaderHintsEnabled,
+                _shiftPressed,
+                _hoveredTooltip.HasStandardTooltip,
+                _hoveredTooltip.HasShaderHint);
+            switch (displayKind)
+            {
+                case TooltipDisplayKind.ShaderHint:
+                    ShowTooltip(_hoveredTooltip.ShaderHintText);
+                    break;
+                case TooltipDisplayKind.Standard:
+                    ShowTooltip(_hoveredTooltip.StandardTooltipText);
+                    break;
+                default:
+                    HideTooltip();
+                    break;
+            }
+        }
+
+        private void ShowTooltip(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                HideTooltip();
+                return;
+            }
+
+            if (tooltipText.text != text)
+            {
+                tooltipText.text = text;
+                RefreshLayout();
+            }
+            Panel.gameObject.SetActive(true);
+        }
+
+        private void HideTooltip()
+        {
+            Panel.gameObject.SetActive(false);
         }
 
         private void RefreshLayout()
@@ -111,17 +247,38 @@ namespace MaterialEditorAPI
             LayoutRebuilder.ForceRebuildLayoutImmediate(panelTransform);
         }
 
-        public static void SetActive(bool active)
+        private void UpdatePanelPosition()
         {
-            if (MaterialEditorPluginBase.Showtooltips.Value || !active)
-                Instance.Panel.gameObject.SetActive(active);
+            var parent = panelTransform.parent as RectTransform;
+            Vector2 position;
+            if (parent == null
+                || !RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    parent,
+                    Input.mousePosition,
+                    null,
+                    out position))
+            {
+                return;
+            }
+
+            position += new Vector2(5f, 5f);
+            var parentRect = parent.rect;
+            var size = panelTransform.rect.size;
+            position.x = Mathf.Clamp(
+                position.x,
+                parentRect.xMin,
+                parentRect.xMax - size.x);
+            position.y = Mathf.Clamp(
+                position.y,
+                parentRect.yMin,
+                parentRect.yMax - size.y);
+            panelTransform.localPosition = position;
         }
 
-        public static Tooltip AddTooltip(GameObject go, string text)
+        private void OnDestroy()
         {
-            var tooltip = go.AddComponent<Tooltip>();
-            tooltip.TooltipText = text;
-            return tooltip;
+            if (Instance == this)
+                Instance = null;
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.TooltipPolicy.cs
+++ b/src/MaterialEditor.Base/UI/UI.TooltipPolicy.cs
@@ -1,0 +1,32 @@
+namespace MaterialEditorAPI
+{
+    internal enum TooltipDisplayKind
+    {
+        None,
+        Standard,
+        ShaderHint
+    }
+
+    internal static class TooltipDisplayPolicy
+    {
+        internal static TooltipDisplayKind Resolve(
+            bool hovered,
+            bool interactionSuppressed,
+            bool standardTooltipsEnabled,
+            bool shaderHintsEnabled,
+            bool shiftPressed,
+            bool hasStandardText,
+            bool hasShaderHintText)
+        {
+            if (!hovered || interactionSuppressed)
+                return TooltipDisplayKind.None;
+
+            if (shaderHintsEnabled && shiftPressed && hasShaderHintText)
+                return TooltipDisplayKind.ShaderHint;
+
+            return standardTooltipsEnabled && hasStandardText
+                ? TooltipDisplayKind.Standard
+                : TooltipDisplayKind.None;
+        }
+    }
+}

--- a/src/MaterialEditor.Base/UI/UI.WindowView.cs
+++ b/src/MaterialEditor.Base/UI/UI.WindowView.cs
@@ -11,6 +11,7 @@ namespace MaterialEditorAPI
         internal Canvas Window { get; private set; }
         internal Image MainPanel { get; private set; }
         internal Image HeaderPanel { get; private set; }
+        internal Text HeaderTitle { get; private set; }
         internal ScrollRect ScrollableUI { get; private set; }
         internal InputField FilterInputField { get; private set; }
         internal Button CategoryNavigatorButton { get; private set; }
@@ -99,6 +100,16 @@ namespace MaterialEditorAPI
             ViewListButton.GetComponentInChildren<Text>().text = glyph;
         }
 
+        internal void SetHeaderTitleHorizontalOffset(float offset)
+        {
+            if (HeaderTitle == null)
+                return;
+
+            var rect = HeaderTitle.rectTransform;
+            rect.anchoredPosition =
+                new Vector2(offset, rect.anchoredPosition.y);
+        }
+
         private void Build(
             Transform owner,
             string filter,
@@ -128,12 +139,12 @@ namespace MaterialEditorAPI
             HeaderPanel.transform.SetRect(0f, 1f, 1f, 1f, 0f, -MaterialEditorLayout.HeaderHeight);
             UIUtility.MakeObjectDraggable(HeaderPanel.rectTransform, MainPanel.rectTransform, PreventDragout.Value);
 
-            var nameText = MaterialEditorControlFactory.CreateText(
+            HeaderTitle = MaterialEditorControlFactory.CreateText(
                 "Nametext",
                 HeaderPanel.transform,
                 "Material Editor",
                 MaterialEditorTextRole.Title);
-            nameText.transform.SetRect();
+            HeaderTitle.transform.SetRect();
 
             CategoryNavigatorButton = MaterialEditorControlFactory.CreateButton(
                 "CategoryNavigatorButton",

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -215,6 +215,11 @@ namespace MaterialEditorAPI
             Visible = false;
         }
 
+        protected void SetHeaderTitleHorizontalOffset(float offset)
+        {
+            _windowView?.SetHeaderTitleHorizontalOffset(offset);
+        }
+
         /// <summary>
         /// Refresh the MaterialEditor UI
         /// </summary>

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -215,7 +215,7 @@ namespace MaterialEditorAPI
             Visible = false;
         }
 
-        protected void SetHeaderTitleHorizontalOffset(float offset)
+        private protected void SetHeaderTitleHorizontalOffset(float offset)
         {
             _windowView?.SetHeaderTitleHorizontalOffset(offset);
         }

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -79,7 +79,7 @@ namespace KK_Plugins.MaterialEditor
             InitUI();
 
             ItemTypeDropDown = UIUtility.CreateDropdown("ItemType", DragPanel.transform);
-            ItemTypeDropDown.transform.SetRect(1f, 0f, 1f, 1f, -220f, 1f, -39f, -1f);
+            ItemTypeDropDown.transform.SetRect(1f, 0f, 1f, 1f, -242f, 1f, -61f, -1f);
             ItemTypeDropDown.captionText.transform.SetRect(0.05f, 0f, 1f, 1f, 5f, 2f, -15f, -2f);
             ItemTypeDropDown.captionText.alignment = TextAnchor.MiddleLeft;
             ItemTypeDropDown.gameObject.SetActive(false);

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.cs
@@ -60,6 +60,7 @@ namespace KK_Plugins.MaterialEditor
         public static MEStudio Instance;
 
         internal static Dropdown ItemTypeDropDown;
+        private const float CharacterHeaderTitleOffset = -16f;
 
         private void Start()
         {
@@ -138,6 +139,7 @@ namespace KK_Plugins.MaterialEditor
                     {
                         PopulateList(ociItem.objectItem, GetObjectID(objectCtrlInfo));
                         ItemTypeDropDown.gameObject.SetActive(false);
+                        SetHeaderTitleHorizontalOffset(0f);
                     }
                     else if (objectCtrlInfo is OCIChar ociChar)
                     {
@@ -145,6 +147,8 @@ namespace KK_Plugins.MaterialEditor
                         var chaControl = ociChar.GetChaControl();
                         PopulateItemTypeDropdown(chaControl);
                         ItemTypeDropDown.gameObject.SetActive(true);
+                        SetHeaderTitleHorizontalOffset(
+                            CharacterHeaderTitleOffset);
                     }
         }
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.SiruSync.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.SiruSync.cs
@@ -23,37 +23,33 @@ namespace KK_Plugins.MaterialEditor
 
         private static readonly int[] SiruClothingSlots = { 0, 1, 2, 3, 5 };
 
-        private readonly Dictionary<ChaFileDefine.SiruParts, byte> _pendingSiruWrites =
-            new Dictionary<ChaFileDefine.SiruParts, byte>();
+        private readonly SiruPendingWriteBuffer<ChaFileDefine.SiruParts> _pendingSiruWrites =
+            new SiruPendingWriteBuffer<ChaFileDefine.SiruParts>();
 
         internal void QueueSiruWrite(ChaFileDefine.SiruParts part, byte value)
         {
             if (GetSiruPropertyName(part) == null)
                 return;
 
-            _pendingSiruWrites[part] = value;
+            _pendingSiruWrites.Set(part, value);
 
             // Studio only queues the vanilla Siru level here. Apply the explicitly
             // requested channel immediately so copied layers react with the UI.
             // UpdateSiru will apply it again after preserving unaffected channels.
-            bool face = part == ChaFileDefine.SiruParts.SiruKao;
-            if (ChaControl.hiPoly
-                && (face ? ChaControl.customMatFace != null : ChaControl.customMatBody != null))
+            if (CanApplyPendingSiruWrite(part))
                 ApplySiruWrite(part, value);
         }
 
         internal SiruUpdateSnapshot BeginSiruUpdate()
         {
-            if (_pendingSiruWrites.Count == 0 || !ChaControl.hiPoly)
+            if (_pendingSiruWrites.Count == 0)
                 return null;
 
-            var writesReadyToApply = new Dictionary<ChaFileDefine.SiruParts, byte>();
-            foreach (KeyValuePair<ChaFileDefine.SiruParts, byte> pendingWrite in _pendingSiruWrites)
-            {
-                bool face = pendingWrite.Key == ChaFileDefine.SiruParts.SiruKao;
-                if (face ? ChaControl.customMatFace != null : ChaControl.customMatBody != null)
-                    writesReadyToApply.Add(pendingWrite.Key, pendingWrite.Value);
-            }
+            // A queued value belongs to the current SetSiruFlags/UpdateSiru cycle.
+            // Do not carry it into a later character or material lifecycle when its
+            // target is unavailable now.
+            Dictionary<ChaFileDefine.SiruParts, byte> writesReadyToApply =
+                _pendingSiruWrites.CollectReadyWrites(CanApplyPendingSiruWrite);
 
             if (writesReadyToApply.Count == 0)
                 return null;
@@ -108,12 +104,7 @@ namespace KK_Plugins.MaterialEditor
             }
             finally
             {
-                foreach (KeyValuePair<ChaFileDefine.SiruParts, byte> appliedWrite in snapshot.PendingWrites)
-                {
-                    if (_pendingSiruWrites.TryGetValue(appliedWrite.Key, out byte pendingValue)
-                        && pendingValue == appliedWrite.Value)
-                        _pendingSiruWrites.Remove(appliedWrite.Key);
-                }
+                _pendingSiruWrites.Complete(snapshot.PendingWrites);
             }
         }
 
@@ -243,7 +234,11 @@ namespace KK_Plugins.MaterialEditor
                 Material material = materials[i];
                 if (material == null
                     || !material.HasProperty("_" + propertyName)
-                    || allowedMaterialNames != null && !MaterialNameMatchesFamily(material.NameFormatted(), allowedMaterialNames)
+                    || allowedMaterialNames != null
+                       && !SiruSyncPolicy.MaterialNameMatchesFamily(
+                           material.NameFormatted(),
+                           allowedMaterialNames,
+                           MaterialCopyPostfix)
                     || !seenMaterials.Add(material))
                     continue;
 
@@ -251,13 +246,16 @@ namespace KK_Plugins.MaterialEditor
             }
         }
 
-        private static bool MaterialNameMatchesFamily(string materialName, HashSet<string> familyNames)
+        private bool CanApplyPendingSiruWrite(ChaFileDefine.SiruParts part)
         {
-            foreach (string familyName in familyNames)
-                if (materialName == familyName || materialName.StartsWith(familyName + MaterialCopyPostfix))
-                    return true;
-
-            return false;
+            bool face = part == ChaFileDefine.SiruParts.SiruKao;
+            bool primaryMaterialAvailable =
+                face
+                    ? ChaControl.customMatFace != null
+                    : ChaControl.customMatBody != null;
+            return SiruSyncPolicy.CanApplyPendingWrite(
+                ChaControl.hiPoly,
+                primaryMaterialAvailable);
         }
 
         private static void AddDirectMaterialTarget(

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.SiruSync.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.SiruSync.cs
@@ -1,0 +1,367 @@
+#if KK || KKS
+using System.Collections.Generic;
+using UnityEngine;
+using static MaterialEditorAPI.MaterialAPI;
+
+namespace KK_Plugins.MaterialEditor
+{
+    public partial class MaterialEditorCharaController
+    {
+        private const string LiquidFaceProperty = "liquidface";
+        private const string LiquidFrontTopProperty = "liquidftop";
+        private const string LiquidFrontBottomProperty = "liquidfbot";
+        private const string LiquidBackTopProperty = "liquidbtop";
+        private const string LiquidBackBottomProperty = "liquidbbot";
+
+        private static readonly ChaFileDefine.SiruParts[] BodySiruParts =
+        {
+            ChaFileDefine.SiruParts.SiruFrontUp,
+            ChaFileDefine.SiruParts.SiruFrontDown,
+            ChaFileDefine.SiruParts.SiruBackUp,
+            ChaFileDefine.SiruParts.SiruBackDown
+        };
+
+        private static readonly int[] SiruClothingSlots = { 0, 1, 2, 3, 5 };
+
+        private readonly Dictionary<ChaFileDefine.SiruParts, byte> _pendingSiruWrites =
+            new Dictionary<ChaFileDefine.SiruParts, byte>();
+
+        internal void QueueSiruWrite(ChaFileDefine.SiruParts part, byte value)
+        {
+            if (GetSiruPropertyName(part) == null)
+                return;
+
+            _pendingSiruWrites[part] = value;
+
+            // Studio only queues the vanilla Siru level here. Apply the explicitly
+            // requested channel immediately so copied layers react with the UI.
+            // UpdateSiru will apply it again after preserving unaffected channels.
+            bool face = part == ChaFileDefine.SiruParts.SiruKao;
+            if (ChaControl.hiPoly
+                && (face ? ChaControl.customMatFace != null : ChaControl.customMatBody != null))
+                ApplySiruWrite(part, value);
+        }
+
+        internal SiruUpdateSnapshot BeginSiruUpdate()
+        {
+            if (_pendingSiruWrites.Count == 0 || !ChaControl.hiPoly)
+                return null;
+
+            var writesReadyToApply = new Dictionary<ChaFileDefine.SiruParts, byte>();
+            foreach (KeyValuePair<ChaFileDefine.SiruParts, byte> pendingWrite in _pendingSiruWrites)
+            {
+                bool face = pendingWrite.Key == ChaFileDefine.SiruParts.SiruKao;
+                if (face ? ChaControl.customMatFace != null : ChaControl.customMatBody != null)
+                    writesReadyToApply.Add(pendingWrite.Key, pendingWrite.Value);
+            }
+
+            if (writesReadyToApply.Count == 0)
+                return null;
+
+            var snapshot = new SiruUpdateSnapshot(writesReadyToApply);
+            bool bodyWillUpdate = false;
+            for (int i = 0; i < BodySiruParts.Length; i++)
+            {
+                if (snapshot.PendingWrites.ContainsKey(BodySiruParts[i]))
+                {
+                    bodyWillUpdate = true;
+                    break;
+                }
+            }
+
+            if (!bodyWillUpdate)
+                return snapshot;
+
+            // Vanilla rewrites all four body channels when any one of them changes.
+            // Preserve the per-material values of channels that SetSiruFlags did not request.
+            for (int i = 0; i < BodySiruParts.Length; i++)
+            {
+                ChaFileDefine.SiruParts part = BodySiruParts[i];
+                if (snapshot.PendingWrites.ContainsKey(part))
+                    continue;
+
+                string propertyName = GetSiruPropertyName(part);
+                List<SiruMaterialTarget> targets = GetSiruMaterialTargets(part);
+                for (int j = 0; j < targets.Count; j++)
+                {
+                    Material material = targets[j].ResolveMaterial();
+                    if (material != null)
+                        snapshot.PreservedValues.Add(new PreservedSiruValue(targets[j], propertyName, material.GetFloat("_" + propertyName)));
+                }
+            }
+
+            return snapshot;
+        }
+
+        internal void CompleteSiruUpdate(SiruUpdateSnapshot snapshot)
+        {
+            if (snapshot == null)
+                return;
+
+            try
+            {
+                for (int i = 0; i < snapshot.PreservedValues.Count; i++)
+                    snapshot.PreservedValues[i].Restore();
+
+                foreach (KeyValuePair<ChaFileDefine.SiruParts, byte> pendingWrite in snapshot.PendingWrites)
+                    ApplySiruWrite(pendingWrite.Key, pendingWrite.Value);
+            }
+            finally
+            {
+                foreach (KeyValuePair<ChaFileDefine.SiruParts, byte> appliedWrite in snapshot.PendingWrites)
+                {
+                    if (_pendingSiruWrites.TryGetValue(appliedWrite.Key, out byte pendingValue)
+                        && pendingValue == appliedWrite.Value)
+                        _pendingSiruWrites.Remove(appliedWrite.Key);
+                }
+            }
+        }
+
+        internal void CancelSiruUpdate()
+        {
+            _pendingSiruWrites.Clear();
+        }
+
+        private void ApplySiruWrite(ChaFileDefine.SiruParts part, byte value)
+        {
+            string propertyName = GetSiruPropertyName(part);
+            if (propertyName == null)
+                return;
+
+            var affectedMaterialNames = new HashSet<string>();
+            List<SiruMaterialTarget> targets = GetSiruMaterialTargets(part);
+            for (int i = 0; i < targets.Count; i++)
+            {
+                Material material = targets[i].ResolveMaterial();
+                if (material == null)
+                    continue;
+
+                material.SetFloat("_" + propertyName, value);
+                affectedMaterialNames.Add(material.NameFormatted());
+            }
+
+            RemovePersistedSiruOverrides(part, propertyName, affectedMaterialNames);
+        }
+
+        private void RemovePersistedSiruOverrides(ChaFileDefine.SiruParts part, string propertyName, HashSet<string> affectedMaterialNames)
+        {
+            if (affectedMaterialNames.Count == 0)
+                return;
+
+            bool face = part == ChaFileDefine.SiruParts.SiruKao;
+            MaterialFloatPropertyList.RemoveAll(property =>
+                property.Property == propertyName
+                && affectedMaterialNames.Contains(property.MaterialName)
+                && (face
+                    ? property.ObjectType == ObjectType.Character
+                    : property.ObjectType == ObjectType.Character
+                      || property.ObjectType == ObjectType.Clothing
+                         && property.CoordinateIndex == CurrentCoordinateIndex
+                         && IsSiruClothingSlot(property.Slot)));
+        }
+
+        private List<SiruMaterialTarget> GetSiruMaterialTargets(ChaFileDefine.SiruParts part)
+        {
+            string propertyName = GetSiruPropertyName(part);
+            var targets = new List<SiruMaterialTarget>();
+            if (propertyName == null)
+                return targets;
+
+            var seenMaterials = new HashSet<Material>();
+            var seenRenderers = new HashSet<Renderer>();
+            bool face = part == ChaFileDefine.SiruParts.SiruKao;
+            Renderer primaryRenderer = face ? ChaControl.rendFace : ChaControl.rendBody;
+            Material primaryMaterial = face ? ChaControl.customMatFace : ChaControl.customMatBody;
+            HashSet<string> characterMaterialNames = GetMaterialFamilyNames(primaryRenderer, primaryMaterial, propertyName);
+
+            // Face and body shaders expose the same liquid properties. Use the materials
+            // on the vanilla target renderer as the family boundary when finding copies.
+            AddRendererTargets(
+                primaryRenderer,
+                propertyName,
+                seenMaterials,
+                seenRenderers,
+                targets);
+
+            foreach (Renderer renderer in GetRendererList(ChaControl.gameObject))
+                AddRendererTargets(renderer, propertyName, seenMaterials, seenRenderers, targets, characterMaterialNames);
+
+            AddDirectMaterialTarget(
+                primaryMaterial,
+                propertyName,
+                seenMaterials,
+                targets);
+
+            if (!face)
+            {
+                for (int i = 0; i < SiruClothingSlots.Length; i++)
+                {
+                    int slot = SiruClothingSlots[i];
+                    GameObject clothes = FindGameObject(ObjectType.Clothing, slot);
+                    foreach (Renderer renderer in GetRendererList(clothes))
+                        AddRendererTargets(renderer, propertyName, seenMaterials, seenRenderers, targets);
+                }
+            }
+
+            return targets;
+        }
+
+        private static HashSet<string> GetMaterialFamilyNames(Renderer renderer, Material directMaterial, string propertyName)
+        {
+            var materialNames = new HashSet<string>();
+            if (renderer != null)
+            {
+                Material[] materials = renderer.sharedMaterials;
+                for (int i = 0; i < materials.Length; i++)
+                {
+                    Material material = materials[i];
+                    if (material != null && material.HasProperty("_" + propertyName))
+                        materialNames.Add(material.NameFormatted());
+                }
+            }
+
+            if (directMaterial != null && directMaterial.HasProperty("_" + propertyName))
+                materialNames.Add(directMaterial.NameFormatted());
+
+            return materialNames;
+        }
+
+        private static void AddRendererTargets(
+            Renderer renderer,
+            string propertyName,
+            HashSet<Material> seenMaterials,
+            HashSet<Renderer> seenRenderers,
+            List<SiruMaterialTarget> targets,
+            HashSet<string> allowedMaterialNames = null)
+        {
+            if (renderer == null || !seenRenderers.Add(renderer))
+                return;
+
+            Material[] materials = renderer.sharedMaterials;
+            for (int i = 0; i < materials.Length; i++)
+            {
+                Material material = materials[i];
+                if (material == null
+                    || !material.HasProperty("_" + propertyName)
+                    || allowedMaterialNames != null && !MaterialNameMatchesFamily(material.NameFormatted(), allowedMaterialNames)
+                    || !seenMaterials.Add(material))
+                    continue;
+
+                targets.Add(new SiruMaterialTarget(renderer, i));
+            }
+        }
+
+        private static bool MaterialNameMatchesFamily(string materialName, HashSet<string> familyNames)
+        {
+            foreach (string familyName in familyNames)
+                if (materialName == familyName || materialName.StartsWith(familyName + MaterialCopyPostfix))
+                    return true;
+
+            return false;
+        }
+
+        private static void AddDirectMaterialTarget(
+            Material material,
+            string propertyName,
+            HashSet<Material> seenMaterials,
+            List<SiruMaterialTarget> targets)
+        {
+            if (material == null || !material.HasProperty("_" + propertyName) || !seenMaterials.Add(material))
+                return;
+
+            targets.Add(new SiruMaterialTarget(material));
+        }
+
+        private static bool IsSiruClothingSlot(int slot)
+        {
+            for (int i = 0; i < SiruClothingSlots.Length; i++)
+                if (SiruClothingSlots[i] == slot)
+                    return true;
+
+            return false;
+        }
+
+        private static string GetSiruPropertyName(ChaFileDefine.SiruParts part)
+        {
+            switch (part)
+            {
+                case ChaFileDefine.SiruParts.SiruKao:
+                    return LiquidFaceProperty;
+                case ChaFileDefine.SiruParts.SiruFrontUp:
+                    return LiquidFrontTopProperty;
+                case ChaFileDefine.SiruParts.SiruFrontDown:
+                    return LiquidFrontBottomProperty;
+                case ChaFileDefine.SiruParts.SiruBackUp:
+                    return LiquidBackTopProperty;
+                case ChaFileDefine.SiruParts.SiruBackDown:
+                    return LiquidBackBottomProperty;
+                default:
+                    return null;
+            }
+        }
+
+        internal sealed class SiruUpdateSnapshot
+        {
+            internal readonly Dictionary<ChaFileDefine.SiruParts, byte> PendingWrites;
+            internal readonly List<PreservedSiruValue> PreservedValues = new List<PreservedSiruValue>();
+
+            internal SiruUpdateSnapshot(Dictionary<ChaFileDefine.SiruParts, byte> pendingWrites)
+            {
+                PendingWrites = new Dictionary<ChaFileDefine.SiruParts, byte>(pendingWrites);
+            }
+        }
+
+        internal sealed class SiruMaterialTarget
+        {
+            private readonly Renderer _renderer;
+            private readonly int _materialIndex;
+            private readonly Material _material;
+
+            internal SiruMaterialTarget(Renderer renderer, int materialIndex)
+            {
+                _renderer = renderer;
+                _materialIndex = materialIndex;
+            }
+
+            internal SiruMaterialTarget(Material material)
+            {
+                _material = material;
+                _materialIndex = -1;
+            }
+
+            internal Material ResolveMaterial()
+            {
+                if (_renderer != null)
+                {
+                    Material[] materials = _renderer.sharedMaterials;
+                    if (_materialIndex >= 0 && _materialIndex < materials.Length)
+                        return materials[_materialIndex];
+                }
+
+                return _material;
+            }
+        }
+
+        internal sealed class PreservedSiruValue
+        {
+            private readonly SiruMaterialTarget _target;
+            private readonly string _propertyName;
+            private readonly float _value;
+
+            internal PreservedSiruValue(SiruMaterialTarget target, string propertyName, float value)
+            {
+                _target = target;
+                _propertyName = propertyName;
+                _value = value;
+            }
+
+            internal void Restore()
+            {
+                Material material = _target.ResolveMaterial();
+                if (material != null && material.HasProperty("_" + _propertyName))
+                    material.SetFloat("_" + _propertyName, _value);
+            }
+        }
+    }
+}
+#endif

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.SiruSync.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.SiruSync.cs
@@ -1,0 +1,68 @@
+#if KK || KKS
+using HarmonyLib;
+using System;
+
+namespace KK_Plugins.MaterialEditor
+{
+    internal partial class Hooks
+    {
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.SetSiruFlags), typeof(ChaFileDefine.SiruParts), typeof(byte))]
+        private static void ChaControl_SetSiruFlags_Postfix(ChaControl __instance, ChaFileDefine.SiruParts __0, byte __1)
+        {
+            var controller = MaterialEditorPlugin.GetCharaController(__instance);
+            if (controller == null)
+                return;
+
+            try
+            {
+                controller.QueueSiruWrite(__0, __1);
+            }
+            catch (Exception ex)
+            {
+                controller.CancelSiruUpdate();
+                MaterialEditorPlugin.Logger.LogError("Failed to queue Material Editor siru synchronization: " + ex);
+            }
+        }
+
+        [HarmonyPrefix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateSiru), typeof(bool))]
+        private static void ChaControl_UpdateSiru_Prefix(ChaControl __instance, out MaterialEditorCharaController.SiruUpdateSnapshot __state)
+        {
+            __state = null;
+            var controller = MaterialEditorPlugin.GetCharaController(__instance);
+            if (controller == null)
+                return;
+
+            try
+            {
+                __state = controller.BeginSiruUpdate();
+            }
+            catch (Exception ex)
+            {
+                controller.CancelSiruUpdate();
+                MaterialEditorPlugin.Logger.LogError("Failed to prepare Material Editor siru synchronization: " + ex);
+            }
+        }
+
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateSiru), typeof(bool))]
+        private static void ChaControl_UpdateSiru_Postfix(ChaControl __instance, MaterialEditorCharaController.SiruUpdateSnapshot __state)
+        {
+            if (__state == null)
+                return;
+
+            var controller = MaterialEditorPlugin.GetCharaController(__instance);
+            if (controller == null)
+                return;
+
+            try
+            {
+                controller.CompleteSiruUpdate(__state);
+            }
+            catch (Exception ex)
+            {
+                controller.CancelSiruUpdate();
+                MaterialEditorPlugin.Logger.LogError("Failed to apply Material Editor siru synchronization: " + ex);
+            }
+        }
+    }
+}
+#endif

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -486,6 +486,65 @@ namespace KK_Plugins.MaterialEditor
             }
         }
 
+#if KK || KKS
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.SetSiruFlags), typeof(ChaFileDefine.SiruParts), typeof(byte))]
+        private static void ChaControl_SetSiruFlags_Postfix(ChaControl __instance, ChaFileDefine.SiruParts __0, byte __1)
+        {
+            var controller = MaterialEditorPlugin.GetCharaController(__instance);
+            if (controller == null)
+                return;
+
+            try
+            {
+                controller.QueueSiruWrite(__0, __1);
+            }
+            catch (Exception ex)
+            {
+                controller.CancelSiruUpdate();
+                MaterialEditorPlugin.Logger.LogError("Failed to queue Material Editor siru synchronization: " + ex);
+            }
+        }
+
+        [HarmonyPrefix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateSiru), typeof(bool))]
+        private static void ChaControl_UpdateSiru_Prefix(ChaControl __instance, out MaterialEditorCharaController.SiruUpdateSnapshot __state)
+        {
+            __state = null;
+            var controller = MaterialEditorPlugin.GetCharaController(__instance);
+            if (controller == null)
+                return;
+
+            try
+            {
+                __state = controller.BeginSiruUpdate();
+            }
+            catch (Exception ex)
+            {
+                controller.CancelSiruUpdate();
+                MaterialEditorPlugin.Logger.LogError("Failed to prepare Material Editor siru synchronization: " + ex);
+            }
+        }
+
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateSiru), typeof(bool))]
+        private static void ChaControl_UpdateSiru_Postfix(ChaControl __instance, MaterialEditorCharaController.SiruUpdateSnapshot __state)
+        {
+            if (__state == null)
+                return;
+
+            var controller = MaterialEditorPlugin.GetCharaController(__instance);
+            if (controller == null)
+                return;
+
+            try
+            {
+                controller.CompleteSiruUpdate(__state);
+            }
+            catch (Exception ex)
+            {
+                controller.CancelSiruUpdate();
+                MaterialEditorPlugin.Logger.LogError("Failed to apply Material Editor siru synchronization: " + ex);
+            }
+        }
+#else
         /// <summary>
         /// Apply juice to all material copies
         /// </summary>
@@ -513,6 +572,7 @@ namespace KK_Plugins.MaterialEditor
                 }
             }
         }
+#endif
 #endif
 #endif
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Hooks.cs
@@ -486,65 +486,7 @@ namespace KK_Plugins.MaterialEditor
             }
         }
 
-#if KK || KKS
-        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.SetSiruFlags), typeof(ChaFileDefine.SiruParts), typeof(byte))]
-        private static void ChaControl_SetSiruFlags_Postfix(ChaControl __instance, ChaFileDefine.SiruParts __0, byte __1)
-        {
-            var controller = MaterialEditorPlugin.GetCharaController(__instance);
-            if (controller == null)
-                return;
-
-            try
-            {
-                controller.QueueSiruWrite(__0, __1);
-            }
-            catch (Exception ex)
-            {
-                controller.CancelSiruUpdate();
-                MaterialEditorPlugin.Logger.LogError("Failed to queue Material Editor siru synchronization: " + ex);
-            }
-        }
-
-        [HarmonyPrefix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateSiru), typeof(bool))]
-        private static void ChaControl_UpdateSiru_Prefix(ChaControl __instance, out MaterialEditorCharaController.SiruUpdateSnapshot __state)
-        {
-            __state = null;
-            var controller = MaterialEditorPlugin.GetCharaController(__instance);
-            if (controller == null)
-                return;
-
-            try
-            {
-                __state = controller.BeginSiruUpdate();
-            }
-            catch (Exception ex)
-            {
-                controller.CancelSiruUpdate();
-                MaterialEditorPlugin.Logger.LogError("Failed to prepare Material Editor siru synchronization: " + ex);
-            }
-        }
-
-        [HarmonyPostfix, HarmonyPatch(typeof(ChaControl), nameof(ChaControl.UpdateSiru), typeof(bool))]
-        private static void ChaControl_UpdateSiru_Postfix(ChaControl __instance, MaterialEditorCharaController.SiruUpdateSnapshot __state)
-        {
-            if (__state == null)
-                return;
-
-            var controller = MaterialEditorPlugin.GetCharaController(__instance);
-            if (controller == null)
-                return;
-
-            try
-            {
-                controller.CompleteSiruUpdate(__state);
-            }
-            catch (Exception ex)
-            {
-                controller.CancelSiruUpdate();
-                MaterialEditorPlugin.Logger.LogError("Failed to apply Material Editor siru synchronization: " + ex);
-            }
-        }
-#else
+#if !KK && !KKS
         /// <summary>
         /// Apply juice to all material copies
         /// </summary>

--- a/src/MaterialEditor.Core/Core.MaterialEditor.SiruSyncPolicy.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.SiruSyncPolicy.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+
+namespace KK_Plugins.MaterialEditor
+{
+    internal sealed class SiruPendingWriteBuffer<TPart>
+    {
+        private readonly Dictionary<TPart, byte> _writes =
+            new Dictionary<TPart, byte>();
+
+        internal int Count => _writes.Count;
+
+        internal void Set(TPart part, byte value)
+        {
+            _writes[part] = value;
+        }
+
+        internal Dictionary<TPart, byte> CollectReadyWrites(
+            Func<TPart, bool> canApply)
+        {
+            var readyWrites = new Dictionary<TPart, byte>();
+            var writesToDiscard = new List<TPart>();
+            foreach (KeyValuePair<TPart, byte> pendingWrite in _writes)
+            {
+                if (canApply(pendingWrite.Key))
+                    readyWrites.Add(pendingWrite.Key, pendingWrite.Value);
+                else
+                    writesToDiscard.Add(pendingWrite.Key);
+            }
+
+            for (int i = 0; i < writesToDiscard.Count; i++)
+                _writes.Remove(writesToDiscard[i]);
+
+            return readyWrites;
+        }
+
+        internal void Complete(Dictionary<TPart, byte> appliedWrites)
+        {
+            foreach (KeyValuePair<TPart, byte> appliedWrite in appliedWrites)
+            {
+                byte pendingValue;
+                if (_writes.TryGetValue(appliedWrite.Key, out pendingValue)
+                    && pendingValue == appliedWrite.Value)
+                {
+                    _writes.Remove(appliedWrite.Key);
+                }
+            }
+        }
+
+        internal void Clear()
+        {
+            _writes.Clear();
+        }
+    }
+
+    internal static class SiruSyncPolicy
+    {
+        internal static bool CanApplyPendingWrite(
+            bool highPoly,
+            bool primaryMaterialAvailable)
+        {
+            return highPoly && primaryMaterialAvailable;
+        }
+
+        internal static bool MaterialNameMatchesFamily(
+            string materialName,
+            IEnumerable<string> familyNames,
+            string materialCopyPostfix)
+        {
+            if (string.IsNullOrEmpty(materialName) || familyNames == null)
+                return false;
+
+            foreach (string familyName in familyNames)
+            {
+                if (string.IsNullOrEmpty(familyName))
+                    continue;
+
+                if (string.Equals(materialName, familyName, StringComparison.Ordinal))
+                    return true;
+
+                if (!string.IsNullOrEmpty(materialCopyPostfix)
+                    && materialName.StartsWith(
+                        familyName + materialCopyPostfix,
+                        StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/MaterialEditor.Core/Core.MaterialEditor.projitems
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.projitems
@@ -25,6 +25,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.Assets.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.Tooltips.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.Hooks.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.Hooks.SiruSync.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SiruSyncPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.ObjectData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.TextureSaveHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LibAPNG\APNG.cs" />

--- a/src/MaterialEditor.Core/Core.MaterialEditor.projitems
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Edits.Properties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Edits.TextureShader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Persistence.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.SiruSync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Events.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Models.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.cs" />

--- a/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
+++ b/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
@@ -10,5 +10,7 @@
              Link="UI.ShaderUiMetadata.cs" />
     <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.TooltipPolicy.cs"
              Link="UI.TooltipPolicy.cs" />
+    <Compile Include="..\..\src\MaterialEditor.Core\Core.MaterialEditor.SiruSyncPolicy.cs"
+             Link="Core.MaterialEditor.SiruSyncPolicy.cs" />
   </ItemGroup>
 </Project>

--- a/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
+++ b/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
@@ -8,5 +8,7 @@
   <ItemGroup>
     <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.ShaderUiMetadata.cs"
              Link="UI.ShaderUiMetadata.cs" />
+    <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.TooltipPolicy.cs"
+             Link="UI.TooltipPolicy.cs" />
   </ItemGroup>
 </Project>

--- a/tests/MaterialEditor.MetadataTests/Program.cs
+++ b/tests/MaterialEditor.MetadataTests/Program.cs
@@ -10,6 +10,7 @@ internal static class Program
             ReferencesAndWhitespaceAreResolved();
             InvalidCatalogsAreRejected();
             ShaderHintDisplayPolicyIsIndependentOfStandardTooltips();
+            SiruSyncPolicyTests.Run();
             Console.WriteLine("Material Editor metadata regression tests passed.");
             return 0;
         }

--- a/tests/MaterialEditor.MetadataTests/Program.cs
+++ b/tests/MaterialEditor.MetadataTests/Program.cs
@@ -9,6 +9,7 @@ internal static class Program
             SharedDefaultsAndShaderOverridesMerge();
             ReferencesAndWhitespaceAreResolved();
             InvalidCatalogsAreRejected();
+            ShaderHintDisplayPolicyIsIndependentOfStandardTooltips();
             Console.WriteLine("Material Editor metadata regression tests passed.");
             return 0;
         }
@@ -90,6 +91,85 @@ internal static class Program
         Throws<ArgumentException>(
             () => ShaderTooltipCatalogParser.Parse(" "),
             "empty catalog");
+    }
+
+    private static void ShaderHintDisplayPolicyIsIndependentOfStandardTooltips()
+    {
+        Equal(
+            TooltipDisplayKind.ShaderHint,
+            ResolveTooltip(
+                standardTooltipsEnabled: false,
+                shaderHintsEnabled: true,
+                shiftPressed: true,
+                hasStandardText: true,
+                hasShaderHintText: true),
+            "Shift hint with standard tooltips disabled");
+        Equal(
+            TooltipDisplayKind.Standard,
+            ResolveTooltip(
+                standardTooltipsEnabled: true,
+                shaderHintsEnabled: true,
+                shiftPressed: false,
+                hasStandardText: true,
+                hasShaderHintText: true),
+            "standard tooltip without Shift");
+        Equal(
+            TooltipDisplayKind.None,
+            ResolveTooltip(
+                standardTooltipsEnabled: false,
+                shaderHintsEnabled: true,
+                shiftPressed: false,
+                hasStandardText: true,
+                hasShaderHintText: true),
+            "disabled standard tooltip without Shift");
+        Equal(
+            TooltipDisplayKind.Standard,
+            ResolveTooltip(
+                standardTooltipsEnabled: true,
+                shaderHintsEnabled: false,
+                shiftPressed: true,
+                hasStandardText: true,
+                hasShaderHintText: true),
+            "disabled shader hints fall back to standard tooltip");
+        Equal(
+            TooltipDisplayKind.None,
+            TooltipDisplayPolicy.Resolve(
+                hovered: true,
+                interactionSuppressed: true,
+                standardTooltipsEnabled: true,
+                shaderHintsEnabled: true,
+                shiftPressed: true,
+                hasStandardText: true,
+                hasShaderHintText: true),
+            "dragging suppresses all tooltips");
+        Equal(
+            TooltipDisplayKind.None,
+            TooltipDisplayPolicy.Resolve(
+                hovered: false,
+                interactionSuppressed: false,
+                standardTooltipsEnabled: true,
+                shaderHintsEnabled: true,
+                shiftPressed: true,
+                hasStandardText: true,
+                hasShaderHintText: true),
+            "non-hovered target");
+    }
+
+    private static TooltipDisplayKind ResolveTooltip(
+        bool standardTooltipsEnabled,
+        bool shaderHintsEnabled,
+        bool shiftPressed,
+        bool hasStandardText,
+        bool hasShaderHintText)
+    {
+        return TooltipDisplayPolicy.Resolve(
+            hovered: true,
+            interactionSuppressed: false,
+            standardTooltipsEnabled,
+            shaderHintsEnabled,
+            shiftPressed,
+            hasStandardText,
+            hasShaderHintText);
     }
 
     private static void Equal<T>(T expected, T actual, string name)

--- a/tests/MaterialEditor.MetadataTests/SiruSyncPolicyTests.cs
+++ b/tests/MaterialEditor.MetadataTests/SiruSyncPolicyTests.cs
@@ -1,0 +1,87 @@
+using KK_Plugins.MaterialEditor;
+
+internal static class SiruSyncPolicyTests
+{
+    internal static void Run()
+    {
+        PendingWriteLifecycleIsBounded();
+        MaterialFamiliesAreMatchedExactly();
+    }
+
+    private static void PendingWriteLifecycleIsBounded()
+    {
+        var pendingWrites = new SiruPendingWriteBuffer<string>();
+        pendingWrites.Set("face", 1);
+        pendingWrites.Set("body", 2);
+        Dictionary<string, byte> readyWrites =
+            pendingWrites.CollectReadyWrites(part => part == "face");
+
+        Equal(1, readyWrites.Count, "ready siru write count");
+        Equal(1, pendingWrites.Count, "unavailable siru write discarded");
+
+        pendingWrites.Set("face", 3);
+        pendingWrites.Complete(readyWrites);
+        Equal(
+            1,
+            pendingWrites.Count,
+            "newer siru write survives completion of an older batch");
+
+        readyWrites = pendingWrites.CollectReadyWrites(part => true);
+        pendingWrites.Complete(readyWrites);
+        Equal(0, pendingWrites.Count, "completed siru writes removed");
+
+        Equal(
+            true,
+            SiruSyncPolicy.CanApplyPendingWrite(
+                highPoly: true,
+                primaryMaterialAvailable: true),
+            "available siru target");
+        Equal(
+            false,
+            SiruSyncPolicy.CanApplyPendingWrite(
+                highPoly: false,
+                primaryMaterialAvailable: true),
+            "low-poly siru target");
+        Equal(
+            false,
+            SiruSyncPolicy.CanApplyPendingWrite(
+                highPoly: true,
+                primaryMaterialAvailable: false),
+            "missing siru material");
+    }
+
+    private static void MaterialFamiliesAreMatchedExactly()
+    {
+        var familyNames = new[] { "cf_m_body" };
+        Equal(
+            true,
+            SiruSyncPolicy.MaterialNameMatchesFamily(
+                "cf_m_body",
+                familyNames,
+                ".MECopy"),
+            "original material family");
+        Equal(
+            true,
+            SiruSyncPolicy.MaterialNameMatchesFamily(
+                "cf_m_body.MECopy2",
+                familyNames,
+                ".MECopy"),
+            "copied material family");
+        Equal(
+            false,
+            SiruSyncPolicy.MaterialNameMatchesFamily(
+                "cf_m_body_extra",
+                familyNames,
+                ".MECopy"),
+            "similarly-prefixed unrelated material");
+    }
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException(
+                $"{name}: expected '{expected}', got '{actual}'.");
+        }
+    }
+}


### PR DESCRIPTION
<!--- If your change only affects some games or only one plugin out of multiple,
      put this information in the title, e.g. "[ME][KK/KKS] Add a kitchen sink"-->

## Description

This PR contains two Material Editor improvements:

### Shift-activated shader hints

- Shader-authored property and category hints are now displayed only while either Shift key is held and the corresponding UI element is hovered.
- Properties and categories with authored hints receive a blue dashed underline while Shift is held, making available documentation discoverable without permanently obscuring the editor.
- Shader hints remain available when the existing `Show Tooltips` option is disabled.
- Added a separate `Enable Shader Hints` configuration option, enabled by default.
- Standard UI tooltips continue to follow the existing tooltip setting.
- Hints are suppressed during drag operations, and recycled property rows clear their previous hint state correctly.
- The category navigator uses the same hint behavior.
- No changes are required to existing shader tooltip XML catalogs.

### Siru synchronization

- Synchronizes KK/KKS siru state when Material Editor operations copy or propagate materials.
- Keeps the corresponding siru values consistent across supported material-copy operations.
- Adds the synchronization implementation to the shared Material Editor project.

## Motivation and Context

Shader-authored tooltips previously appeared through the ordinary tooltip system. This could obscure nearby controls and made shader documentation unavailable when users disabled standard UI tooltips.

Requiring Shift provides an explicit, unobtrusive way to request additional shader documentation. The dashed underline indicates which controls have authored hints before the user hovers them, while the separate configuration option keeps shader documentation independent from ordinary UI tooltips.

The siru synchronization change prevents copied materials and their associated character state from becoming inconsistent in KK/KKS.

## How Has This Been Tested?

- Built the complete solution in Release configuration:
  - 0 warnings
  - 0 errors
- Ran the Material Editor metadata regression test project successfully.
- Added regression coverage for the shader hint display policy, including:
  - standard tooltip behavior
  - Shift activation
  - disabled standard tooltips
  - independently disabled shader hints
  - drag suppression
- Verified that existing tooltip catalog formats remain compatible.

## Screenshots (if appropriate):
<img width="2880" height="2160" alt="IMG_6240" src="https://github.com/user-attachments/assets/74415f3a-b64e-459a-982b-b3f26a1c7f1f" />


<!-- Add screenshots showing:
1. Shader properties/categories without Shift held.
2. Blue dashed hint indicators while Shift is held.
3. A shader hint displayed while the standard Show Tooltips option is disabled.
-->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)