### PR TITLE
[ME] Add opt-in manifest schema 2 UI metadata

### DIFF
--- a/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
+++ b/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
@@ -22,7 +22,7 @@ Schema 2 adds optional attributes to `<Property>`:
 - `DisplayName`: label shown in Material Editor; defaults to `Name`.
 - `UiLevel`: `Basic` (the default) or `Advanced`. When a shader declares at
   least one Advanced property, its shader row shows a Basic/Advanced selector.
-  Advanced property labels are prefixed with `[A]` when visible. The selection
+  Advanced property rows show a vertical accent bar when visible. The selection
   is maintained independently for each shader during the current session.
 
 ## Float-backed controls

--- a/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
+++ b/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
@@ -20,28 +20,31 @@ example described here.
 Schema 2 adds optional attributes to `<Property>`:
 
 - `DisplayName`: label shown in Material Editor; defaults to `Name`.
-- `Order`: property order within its category. Explicit values appear first,
-  from lowest to highest; ties keep declaration order.
-- `CategoryOrder`: category order derived from its properties. Explicit values
-  appear first, from lowest to highest. Use the same value on every property in
-  a category; if values disagree, the first explicit value declared wins.
-- `UiLevel`: `Basic` (the default) or `Advanced`.
+- `UiLevel`: `Basic` (the default) or `Advanced`. When a shader declares at
+  least one Advanced property, its shader row shows a Basic/Advanced selector.
+  Advanced property labels are prefixed with `[A]` when visible. The selection
+  is maintained independently for each shader during the current session.
 
 ## Float-backed controls
 
-`Type="Toggle"` is an alias for a Float property using the toggle editor.
-`OffValue` and `OnValue` select the float values written for each state and
-default to `0` and `1`.
+`Type="Toggle"` is an alias for a Float property using the toggle editor. It
+writes `0` for off and `1` for on. Set `Invert="true"` to reverse the displayed
+toggle while keeping the stored values limited to `0` and `1`.
 
-`Type="Enum"` and `Type="Dropdown"` are equivalent aliases for a Float
-property using the enum editor. Declare choices as direct children:
+`Type="Enum"` is an alias for a Float property using the enum editor. Declare
+choices as alternating labels and numeric values in the `Enums` attribute,
+matching Unity's enum-property style:
 
 ```xml
-<Property Name="BlendMode" Type="Enum" DisplayName="Blend mode">
-  <Option Value="0" DisplayName="Opaque"/>
-  <Option Value="1" DisplayName="Cutout"/>
-</Property>
+<Property Name="BlendMode"
+          Type="Enum"
+          DisplayName="Blend mode"
+          Enums="Opaque,0,Cutout,1"/>
 ```
+
+Labels and values must appear in pairs. Labels cannot be empty, values must be
+finite invariant-culture numbers, and duplicate labels or values are ignored
+with a warning.
 
 The aliases are case-insensitive, but only recognized when
 `SchemaVersion="2"` is active.

--- a/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
+++ b/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
@@ -27,9 +27,11 @@ Schema 2 adds optional attributes to `<Property>`:
 
 ## Float-backed controls
 
-`Type="Toggle"` is an alias for a Float property using the toggle editor. It
-writes `0` for off and `1` for on. Set `Invert="true"` to reverse the displayed
-toggle while keeping the stored values limited to `0` and `1`.
+`Type="Boolean"` is a Float-backed Boolean control. It writes `0` for off and
+`1` for on. The optional `Invert="true"` attribute reverses the displayed state
+while keeping stored values limited to `0` and `1`; it defaults to `false`.
+`Type="Toggle"` remains accepted as a read-compatible alias, but new manifests
+should use `Boolean`.
 
 `Type="Enum"` is an alias for a Float property using the enum editor. Declare
 choices as alternating labels and numeric values in the `Enums` attribute,

--- a/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
+++ b/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
@@ -30,8 +30,6 @@ Schema 2 adds optional attributes to `<Property>`:
 `Type="Boolean"` is a Float-backed Boolean control. It writes `0` for off and
 `1` for on. The optional `Invert="true"` attribute reverses the displayed state
 while keeping stored values limited to `0` and `1`; it defaults to `false`.
-`Type="Toggle"` remains accepted as a read-compatible alias, but new manifests
-should use `Boolean`.
 
 `Type="Enum"` is an alias for a Float property using the enum editor. Declare
 choices as alternating labels and numeric values in the `Enums` attribute,

--- a/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
+++ b/Guides/Material Editor Guide/MANIFEST_SCHEMA_V2.md
@@ -1,0 +1,72 @@
+# Material Editor manifest schema 2
+
+Sideloader's outer `<manifest schema-ver="1">` remains unchanged. Opt in to
+Material Editor metadata on the inner element:
+
+```xml
+<MaterialEditor SchemaVersion="2">
+```
+
+An absent, invalid, or unsupported `SchemaVersion` uses legacy schema 1
+behavior. In that mode the metadata and type aliases below are not enabled.
+
+The existing `shader_manifest_template.xml` remains the complete legacy/general
+template, including game tags, tooltip catalogs, and the established property
+types. Use `shader_manifest_schema_v2_template.xml` for the focused schema 2
+example described here.
+
+## Property metadata
+
+Schema 2 adds optional attributes to `<Property>`:
+
+- `DisplayName`: label shown in Material Editor; defaults to `Name`.
+- `Order`: property order within its category. Explicit values appear first,
+  from lowest to highest; ties keep declaration order.
+- `CategoryOrder`: category order derived from its properties. Explicit values
+  appear first, from lowest to highest. Use the same value on every property in
+  a category; if values disagree, the first explicit value declared wins.
+- `UiLevel`: `Basic` (the default) or `Advanced`.
+
+## Float-backed controls
+
+`Type="Toggle"` is an alias for a Float property using the toggle editor.
+`OffValue` and `OnValue` select the float values written for each state and
+default to `0` and `1`.
+
+`Type="Enum"` and `Type="Dropdown"` are equivalent aliases for a Float
+property using the enum editor. Declare choices as direct children:
+
+```xml
+<Property Name="BlendMode" Type="Enum" DisplayName="Blend mode">
+  <Option Value="0" DisplayName="Opaque"/>
+  <Option Value="1" DisplayName="Cutout"/>
+</Property>
+```
+
+The aliases are case-insensitive, but only recognized when
+`SchemaVersion="2"` is active.
+
+## Conditional visibility
+
+`ShowIf` accepts these forms:
+
+```text
+Source
+!Source
+Source == value
+Source != value
+Source > value
+Source >= value
+Source < value
+Source <= value
+```
+
+`value` can be a number, `true`, or `false`; booleans map to `1` and `0`.
+The leading underscore in a source property name is optional. Only manifest
+properties of type `Float` or `Keyword` can be resolved as sources; this also
+includes properties marked `Hidden`. Conditions fail open: an absent or
+incompatible source, a resolver error, or an invalid condition leaves the
+dependent property visible.
+
+See `shader_manifest_schema_v2_template.xml` for a complete minimal schema 2
+example.

--- a/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
+++ b/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
@@ -25,40 +25,32 @@
                 DefaultValue="1"
                 DisplayName="Intensity"
                 Category="Surface"
-                CategoryOrder="10"
-                Order="10"
                 UiLevel="Basic"/>
 
       <!--
-        Toggle is a schema 2 alias for a Float property. OffValue and OnValue
-        are the float values written to the material; they default to 0 and 1.
+        Toggle is a schema 2 alias for a Float property. It writes 0 for off
+        and 1 for on. Invert reverses the displayed toggle state.
       -->
       <Property Name="DetailEnabled"
                 Type="Toggle"
                 DisplayName="Enable detail"
                 Category="Detail"
-                CategoryOrder="20"
-                Order="10"
                 UiLevel="Basic"
-                OffValue="0"
-                OnValue="1"/>
+                Invert="false"/>
 
       <!--
-        Enum is also Float-backed. Options must be direct child elements.
-        Type="Dropdown" is an equivalent schema 2 alias for Type="Enum".
+        Enum is also Float-backed. Enums contains alternating labels and
+        invariant-culture numeric values, matching Unity's enum style.
+        Advanced properties appear only when this shader's row is switched to
+        Advanced and are marked with an [A] prefix.
       -->
       <Property Name="DetailMode"
                 Type="Enum"
                 DisplayName="Detail mode"
                 Category="Detail"
-                CategoryOrder="20"
-                Order="20"
                 UiLevel="Advanced"
-                ShowIf="DetailEnabled != 0">
-        <Option Value="0" DisplayName="Soft"/>
-        <Option Value="1" DisplayName="Sharp"/>
-        <Option Value="2" DisplayName="Posterized"/>
-      </Property>
+                ShowIf="DetailEnabled != 0"
+                Enums="Soft,0,Sharp,1,Posterized,2"/>
 
       <!--
         ShowIf forms:
@@ -76,8 +68,6 @@
                 Range="0,1"
                 DisplayName="Detail strength"
                 Category="Detail"
-                CategoryOrder="20"
-                Order="30"
                 UiLevel="Advanced"
                 ShowIf="_DetailEnabled == true"/>
 

--- a/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
+++ b/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<manifest schema-ver="1">
+  <guid>{{Mod GUID}}</guid>
+  <name>{{Mod name}}</name>
+  <version>{{Mod version}}</version>
+  <author>{{Mod author}}</author>
+  <description>{{Mod description}}</description>
+  <website>{{Mod website}}</website>
+
+  <!--
+    schema-ver="1" above is Sideloader's manifest schema.
+    SchemaVersion="2" below enables Material Editor UI metadata.
+    If Material Editor's SchemaVersion is absent or unsupported, the block is
+    interpreted with legacy schema 1 behavior.
+  -->
+  <MaterialEditor SchemaVersion="2">
+    <Shader Name="{{ShaderName}}"
+            AssetBundle="{{asset_bundle_path.unity3d}}"
+            Asset="{{asset_name}}">
+
+      <!-- Existing Float properties remain valid in schema 2. -->
+      <Property Name="Intensity"
+                Type="Float"
+                Range="0,2"
+                DefaultValue="1"
+                DisplayName="Intensity"
+                Category="Surface"
+                CategoryOrder="10"
+                Order="10"
+                UiLevel="Basic"/>
+
+      <!--
+        Toggle is a schema 2 alias for a Float property. OffValue and OnValue
+        are the float values written to the material; they default to 0 and 1.
+      -->
+      <Property Name="DetailEnabled"
+                Type="Toggle"
+                DisplayName="Enable detail"
+                Category="Detail"
+                CategoryOrder="20"
+                Order="10"
+                UiLevel="Basic"
+                OffValue="0"
+                OnValue="1"/>
+
+      <!--
+        Enum is also Float-backed. Options must be direct child elements.
+        Type="Dropdown" is an equivalent schema 2 alias for Type="Enum".
+      -->
+      <Property Name="DetailMode"
+                Type="Enum"
+                DisplayName="Detail mode"
+                Category="Detail"
+                CategoryOrder="20"
+                Order="20"
+                UiLevel="Advanced"
+                ShowIf="DetailEnabled != 0">
+        <Option Value="0" DisplayName="Soft"/>
+        <Option Value="1" DisplayName="Sharp"/>
+        <Option Value="2" DisplayName="Posterized"/>
+      </Property>
+
+      <!--
+        ShowIf forms:
+          Source              source is non-zero
+          !Source             source is zero
+          Source == value     also !=, >, >=, < and <=
+        Numeric values and true/false are accepted. A leading underscore on
+        Source is optional. Only manifest Float or Keyword properties can be
+        resolved as sources, including Hidden properties. A missing or
+        incompatible source, a resolver error, or an invalid condition fails
+        open: the dependent property stays visible.
+      -->
+      <Property Name="DetailStrength"
+                Type="Float"
+                Range="0,1"
+                DisplayName="Detail strength"
+                Category="Detail"
+                CategoryOrder="20"
+                Order="30"
+                UiLevel="Advanced"
+                ShowIf="_DetailEnabled == true"/>
+
+      <!-- Legacy property attributes such as Hidden and the legacy types
+           Color, Texture and Keyword continue to work in schema 2. -->
+    </Shader>
+  </MaterialEditor>
+</manifest>

--- a/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
+++ b/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
@@ -42,7 +42,7 @@
         Enum is also Float-backed. Enums contains alternating labels and
         invariant-culture numeric values, matching Unity's enum style.
         Advanced properties appear only when this shader's row is switched to
-        Advanced and are marked with an [A] prefix.
+        Advanced and are marked with a vertical accent bar.
       -->
       <Property Name="DetailMode"
                 Type="Enum"

--- a/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
+++ b/Guides/Material Editor Guide/shader_manifest_schema_v2_template.xml
@@ -28,15 +28,14 @@
                 UiLevel="Basic"/>
 
       <!--
-        Toggle is a schema 2 alias for a Float property. It writes 0 for off
-        and 1 for on. Invert reverses the displayed toggle state.
+        Boolean is Float-backed and writes 0 for off and 1 for on. Invert is
+        optional, defaults to false, and reverses the displayed state.
       -->
       <Property Name="DetailEnabled"
-                Type="Toggle"
+                Type="Boolean"
                 DisplayName="Enable detail"
                 Category="Detail"
-                UiLevel="Basic"
-                Invert="false"/>
+                UiLevel="Basic"/>
 
       <!--
         Enum is also Float-backed. Enums contains alternating labels and

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Access the Material Editor by pressing the "Open Material Editor" button on clot
 
 For makers of shaders, see the [template](https://github.com/IllusionMods/KK_Plugins/blob/master/Guides/Material%20Editor%20Guide/shader_manifest_template.xml) for how to configure your shader zipmod for MaterialEditor compatibility.
 
+For the opt-in Material Editor manifest schema 2 metadata, see the [schema 2 guide](Guides/Material%20Editor%20Guide/MANIFEST_SCHEMA_V2.md) and its [focused template](Guides/Material%20Editor%20Guide/shader_manifest_schema_v2_template.xml).
+
 For plugin developers, see the [Material Editor public API compatibility policy](Guides/Material%20Editor%20Guide/Public%20API%20Compatibility.md), [extension API](Guides/Material%20Editor%20Guide/Extension%20API.md), and [label click API](Guides/Material%20Editor%20Guide/Label%20Click%20API.md).
 
 #### MaleJuice

--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.PropertyOrganizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.RepositoryContract.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ShaderUiMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.SessionState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.SelectionController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.StyleSystem.cs" />

--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Export.UV.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShaderPropertyFallbackPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.PropertyOrganizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.RepositoryContract.cs" />
@@ -36,6 +37,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.WindowView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.CategoryNavigator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.MaterialEditorPresenter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\UI.MaterialPropertyMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.MaterialSectionContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.MaterialSectionPresenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.Presentation.cs" />

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -4,6 +4,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Xml;
@@ -269,6 +270,12 @@ namespace MaterialEditorAPI
                         XmlDocument doc = new XmlDocument();
                         doc.Load(stream);
                         XmlElement materialEditorElement = doc.DocumentElement;
+                        Action<string> metadataWarning = message =>
+                            Logger?.LogWarning(
+                                "Material Editor default metadata: " + message);
+                        var schemaVersion = ShaderPropertyMetadataParser.ReadSchemaVersion(
+                            materialEditorElement,
+                            metadataWarning);
 
                         var shaderElements = materialEditorElement.GetElementsByTagName("Shader");
                         foreach (var shaderElementObj in shaderElements)
@@ -282,43 +289,26 @@ namespace MaterialEditorAPI
                                     XMLShaderProperties[shaderName] = new Dictionary<string, ShaderPropertyData>();
 
                                     var shaderPropertyElements = shaderElement.GetElementsByTagName("Property");
+                                    var declarationOrder = 0;
                                     foreach (var shaderPropertyElementObj in shaderPropertyElements)
                                     {
                                         if (shaderPropertyElementObj != null)
                                         {
                                             var shaderPropertyElement = (XmlElement)shaderPropertyElementObj;
                                             {
-                                                string propertyName = shaderPropertyElement.GetAttribute("Name");
-                                                ShaderPropertyType propertyType = (ShaderPropertyType)Enum.Parse(typeof(ShaderPropertyType), shaderPropertyElement.GetAttribute("Type"));
-                                                string defaultValue = shaderPropertyElement.GetAttribute("DefaultValue");
-                                                string defaultValueAB = shaderPropertyElement.GetAttribute("DefaultValueAssetBundle");
-                                                string anisoLevel = shaderPropertyElement.GetAttribute("AnisoLevel");
-                                                string filterMode = shaderPropertyElement.GetAttribute("FilterMode");
-                                                string wrapMode = shaderPropertyElement.GetAttribute("WrapMode");
-                                                string range = shaderPropertyElement.GetAttribute("Range");
-                                                string min = null;
-                                                string max = null;
-                                                if (!range.IsNullOrWhiteSpace())
+                                                ShaderPropertyData shaderPropertyData;
+                                                if (!ShaderPropertyData.TryParse(
+                                                        shaderPropertyElement,
+                                                        metadataWarning,
+                                                        out shaderPropertyData,
+                                                        schemaVersion))
                                                 {
-                                                    var rangeSplit = range.Split(',');
-                                                    if (rangeSplit.Length == 2)
-                                                    {
-                                                        min = rangeSplit[0];
-                                                        max = rangeSplit[1];
-                                                    }
+                                                    declarationOrder++;
+                                                    continue;
                                                 }
-                                                string hidden = shaderPropertyElement.GetAttribute("Hidden");
-                                                string category = shaderPropertyElement.GetAttribute("Category");
 
-                                                ShaderPropertyData shaderPropertyData = new ShaderPropertyData(
-                                                    propertyName, propertyType,
-                                                    defaultValue, defaultValueAB,
-                                                    anisoLevel, filterMode, wrapMode,
-                                                    min, max,
-                                                    hidden, category
-                                                );
-
-                                                XMLShaderProperties["default"][propertyName] = shaderPropertyData;
+                                                shaderPropertyData.DeclarationOrder = declarationOrder++;
+                                                XMLShaderProperties["default"][shaderPropertyData.Name] = shaderPropertyData;
                                             }
                                         }
                                     }
@@ -491,6 +481,16 @@ namespace MaterialEditorAPI
             /// Category of the shader property.
             /// </summary>
             public string Category;
+            internal int? CategoryOrder;
+            internal int DeclarationOrder;
+            internal string DisplayName;
+            internal int? Order;
+            internal string EditorId;
+            internal MaterialEditorPropertyUiLevel UiLevel;
+            internal MaterialEditorPropertyCondition ShowIf;
+            internal List<MaterialEditorEnumOption> EnumOptions;
+            internal float OffValue;
+            internal float OnValue;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ShaderPropertyData"/> class.
@@ -516,6 +516,11 @@ namespace MaterialEditorAPI
             {
                 Name = name;
                 Type = type;
+                DisplayName = name;
+                UiLevel = MaterialEditorPropertyUiLevel.Basic;
+                EnumOptions = new List<MaterialEditorEnumOption>();
+                OffValue = 0f;
+                OnValue = 1f;
                 DefaultValue = defaultValue.IsNullOrEmpty() ? null : defaultValue;
                 DefaultValueAssetBundle = defaultValueAB.IsNullOrEmpty() ? null : defaultValueAB;
 
@@ -539,7 +544,8 @@ namespace MaterialEditorAPI
 
                 if (!minValue.IsNullOrWhiteSpace() && !maxValue.IsNullOrWhiteSpace())
                 {
-                    if (float.TryParse(minValue, out float min) && float.TryParse(maxValue, out float max))
+                    if (TryParseManifestFloat(minValue, out float min)
+                        && TryParseManifestFloat(maxValue, out float max))
                     {
                         MinValue = min;
                         MaxValue = max;
@@ -548,6 +554,200 @@ namespace MaterialEditorAPI
 
                 Hidden = bool.TryParse(hidden, out bool result) && result;
                 Category = category;
+            }
+
+            internal static bool TryParse(
+                XmlElement propertyElement,
+                Action<string> warning,
+                out ShaderPropertyData propertyData,
+                int schemaVersion = 2)
+            {
+                propertyData = null;
+                if (propertyElement == null)
+                    return false;
+
+                var propertyName = propertyElement.GetAttribute("Name").Trim();
+                if (propertyName.Length == 0)
+                {
+                    warning?.Invoke("A shader Property without a Name was ignored.");
+                    return false;
+                }
+
+                var declaredPropertyType = propertyElement.GetAttribute("Type");
+                ShaderPropertyType propertyType;
+                string aliasEditorId;
+                if (!TryParsePropertyType(
+                        declaredPropertyType,
+                        schemaVersion,
+                        out propertyType,
+                        out aliasEditorId))
+                {
+                    warning?.Invoke(
+                        "Shader property '" + propertyName + "' has unknown Type '"
+                        + declaredPropertyType + "' and was ignored.");
+                    return false;
+                }
+
+                string min = null;
+                string max = null;
+                var range = propertyElement.GetAttribute("Range");
+                if (!range.IsNullOrWhiteSpace())
+                {
+                    var rangeSplit = range.Split(',');
+                    float parsedMinimum;
+                    float parsedMaximum;
+                    if (rangeSplit.Length == 2
+                        && TryParseManifestFloat(rangeSplit[0], out parsedMinimum)
+                        && TryParseManifestFloat(rangeSplit[1], out parsedMaximum))
+                    {
+                        min = parsedMinimum.ToString(CultureInfo.InvariantCulture);
+                        max = parsedMaximum.ToString(CultureInfo.InvariantCulture);
+                    }
+                    else
+                    {
+                        warning?.Invoke(
+                            "Shader property '" + propertyName + "' has invalid Range '"
+                            + range + "'; the default slider range will be used.");
+                    }
+                }
+
+                propertyData = new ShaderPropertyData(
+                    propertyName,
+                    propertyType,
+                    propertyElement.GetAttribute("DefaultValue"),
+                    propertyElement.GetAttribute("DefaultValueAssetBundle"),
+                    propertyElement.GetAttribute("AnisoLevel"),
+                    propertyElement.GetAttribute("FilterMode"),
+                    propertyElement.GetAttribute("WrapMode"),
+                    min,
+                    max,
+                    propertyElement.GetAttribute("Hidden"),
+                    propertyElement.GetAttribute("Category"));
+
+                if (schemaVersion != 2)
+                    return true;
+
+                var metadata = ShaderPropertyMetadataParser.Parse(
+                    propertyElement,
+                    warning);
+                var hasExplicitEditor =
+                    !propertyElement.GetAttribute("Editor").IsNullOrWhiteSpace();
+                if (!hasExplicitEditor
+                    && metadata.EditorId.IsNullOrEmpty()
+                    && !aliasEditorId.IsNullOrEmpty())
+                {
+                    metadata.EditorId = aliasEditorId;
+                }
+
+                if (!IsEditorCompatibleWithPropertyType(
+                        metadata.EditorId,
+                        propertyType))
+                {
+                    warning?.Invoke(
+                        "Shader property '" + propertyName + "' declares Editor '"
+                        + propertyElement.GetAttribute("Editor") + "' for Type '"
+                        + declaredPropertyType + "' (normalized backing Type '"
+                        + propertyType + "'); its type editor will be used.");
+                    metadata.EditorId = null;
+                }
+
+                if (metadata.EditorId == ShaderPropertyEditorIds.Enum
+                    && metadata.EnumOptions.Count == 0)
+                {
+                    warning?.Invoke(
+                        "Shader property '" + propertyName + "' declares Type '"
+                        + declaredPropertyType
+                        + "' as a dropdown without any valid Option elements; "
+                        + "the Float editor will be used.");
+                    metadata.EditorId = null;
+                }
+
+                propertyData.DisplayName = metadata.DisplayName.IsNullOrEmpty()
+                    ? propertyName
+                    : metadata.DisplayName;
+                propertyData.Order = metadata.Order;
+                propertyData.CategoryOrder = metadata.CategoryOrder;
+                propertyData.EditorId = metadata.EditorId;
+                propertyData.UiLevel = metadata.UiLevel;
+                propertyData.ShowIf = metadata.ShowIf;
+                propertyData.EnumOptions.AddRange(metadata.EnumOptions);
+                propertyData.OffValue = metadata.OffValue;
+                propertyData.OnValue = metadata.OnValue;
+                return true;
+            }
+
+            private static bool IsEditorCompatibleWithPropertyType(
+                string editorId,
+                ShaderPropertyType propertyType)
+            {
+                if (editorId.IsNullOrEmpty())
+                    return true;
+
+                return (editorId != ShaderPropertyEditorIds.Enum
+                        && editorId != ShaderPropertyEditorIds.Toggle)
+                       || propertyType == ShaderPropertyType.Float;
+            }
+
+            private static bool TryParsePropertyType(
+                string value,
+                int schemaVersion,
+                out ShaderPropertyType propertyType,
+                out string aliasEditorId)
+            {
+                propertyType = default(ShaderPropertyType);
+                aliasEditorId = null;
+                if (value.IsNullOrWhiteSpace())
+                    return false;
+
+                var normalizedType = value.Trim();
+                string aliasType;
+                if (ShaderPropertyMetadataParser.TryResolvePropertyTypeAlias(
+                        normalizedType,
+                        schemaVersion,
+                        out aliasType,
+                        out aliasEditorId))
+                {
+                    normalizedType = aliasType;
+                }
+
+                try
+                {
+                    var parsed = (ShaderPropertyType)Enum.Parse(
+                        typeof(ShaderPropertyType),
+                        normalizedType,
+                        true);
+                    if (!Enum.IsDefined(typeof(ShaderPropertyType), parsed))
+                        return false;
+
+                    propertyType = parsed;
+                    return true;
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+                catch (OverflowException)
+                {
+                    return false;
+                }
+            }
+
+            private static bool TryParseManifestFloat(string value, out float result)
+            {
+                if ((float.TryParse(
+                         value,
+                         NumberStyles.Float,
+                         CultureInfo.InvariantCulture,
+                         out result)
+                     || float.TryParse(value, out result))
+                    && !float.IsNaN(result)
+                    && !float.IsInfinity(result))
+                {
+                    return true;
+                }
+
+                result = 0f;
+                return false;
             }
         }
     }

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -676,7 +676,7 @@ namespace MaterialEditorAPI
                     return true;
 
                 return (editorId != ShaderPropertyEditorIds.Enum
-                        && editorId != ShaderPropertyEditorIds.Toggle)
+                        && editorId != ShaderPropertyEditorIds.Boolean)
                        || propertyType == ShaderPropertyType.Float;
             }
 

--- a/src/MaterialEditor.Base/PluginBase.cs
+++ b/src/MaterialEditor.Base/PluginBase.cs
@@ -481,16 +481,13 @@ namespace MaterialEditorAPI
             /// Category of the shader property.
             /// </summary>
             public string Category;
-            internal int? CategoryOrder;
             internal int DeclarationOrder;
             internal string DisplayName;
-            internal int? Order;
             internal string EditorId;
             internal MaterialEditorPropertyUiLevel UiLevel;
             internal MaterialEditorPropertyCondition ShowIf;
             internal List<MaterialEditorEnumOption> EnumOptions;
-            internal float OffValue;
-            internal float OnValue;
+            internal bool Invert;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ShaderPropertyData"/> class.
@@ -519,8 +516,6 @@ namespace MaterialEditorAPI
                 DisplayName = name;
                 UiLevel = MaterialEditorPropertyUiLevel.Basic;
                 EnumOptions = new List<MaterialEditorEnumOption>();
-                OffValue = 0f;
-                OnValue = 1f;
                 DefaultValue = defaultValue.IsNullOrEmpty() ? null : defaultValue;
                 DefaultValueAssetBundle = defaultValueAB.IsNullOrEmpty() ? null : defaultValueAB;
 
@@ -657,7 +652,7 @@ namespace MaterialEditorAPI
                     warning?.Invoke(
                         "Shader property '" + propertyName + "' declares Type '"
                         + declaredPropertyType
-                        + "' as a dropdown without any valid Option elements; "
+                        + "' as an enum without a valid Enums attribute; "
                         + "the Float editor will be used.");
                     metadata.EditorId = null;
                 }
@@ -665,14 +660,11 @@ namespace MaterialEditorAPI
                 propertyData.DisplayName = metadata.DisplayName.IsNullOrEmpty()
                     ? propertyName
                     : metadata.DisplayName;
-                propertyData.Order = metadata.Order;
-                propertyData.CategoryOrder = metadata.CategoryOrder;
                 propertyData.EditorId = metadata.EditorId;
                 propertyData.UiLevel = metadata.UiLevel;
                 propertyData.ShowIf = metadata.ShowIf;
                 propertyData.EnumOptions.AddRange(metadata.EnumOptions);
-                propertyData.OffValue = metadata.OffValue;
-                propertyData.OnValue = metadata.OnValue;
+                propertyData.Invert = metadata.Invert;
                 return true;
             }
 

--- a/src/MaterialEditor.Base/ShaderPropertyFallbackPolicy.cs
+++ b/src/MaterialEditor.Base/ShaderPropertyFallbackPolicy.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace MaterialEditorAPI
+{
+    internal static class ShaderPropertyFallbackPolicy
+    {
+        internal const string ReservedShaderName = "default";
+
+        internal static bool IsReservedShaderName(string shaderName)
+        {
+            return string.Equals(
+                shaderName,
+                ReservedShaderName,
+                StringComparison.Ordinal);
+        }
+
+        internal static MaterialEditorPluginBase.ShaderPropertyData Create(
+            MaterialEditorPluginBase.ShaderPropertyData shaderSpecific)
+        {
+            if (shaderSpecific == null)
+                throw new ArgumentNullException(nameof(shaderSpecific));
+
+            return new MaterialEditorPluginBase.ShaderPropertyData(
+                shaderSpecific.Name,
+                shaderSpecific.Type)
+            {
+                DefaultValue = shaderSpecific.DefaultValue,
+                DefaultValueAssetBundle = shaderSpecific.DefaultValueAssetBundle,
+                AnisoLevel = shaderSpecific.AnisoLevel,
+                FilterMode = shaderSpecific.FilterMode,
+                WrapMode = shaderSpecific.WrapMode,
+                MinValue = shaderSpecific.MinValue,
+                MaxValue = shaderSpecific.MaxValue,
+                Hidden = shaderSpecific.Hidden,
+                Category = shaderSpecific.Category,
+                CategoryOrder = null,
+                DeclarationOrder = 0,
+                DisplayName = shaderSpecific.Name,
+                Order = null,
+                EditorId = null,
+                UiLevel = MaterialEditorPropertyUiLevel.Basic,
+                ShowIf = null,
+                EnumOptions = new List<MaterialEditorEnumOption>(),
+                OffValue = 0f,
+                OnValue = 1f
+            };
+        }
+
+        internal static MaterialEditorPluginBase.ShaderPropertyData MergeInto(
+            IDictionary<string, MaterialEditorPluginBase.ShaderPropertyData>
+                fallbackProperties,
+            MaterialEditorPluginBase.ShaderPropertyData shaderSpecific)
+        {
+            if (fallbackProperties == null)
+                throw new ArgumentNullException(nameof(fallbackProperties));
+
+            var fallback = Create(shaderSpecific);
+            fallbackProperties[fallback.Name] = fallback;
+            return fallback;
+        }
+    }
+}

--- a/src/MaterialEditor.Base/ShaderPropertyFallbackPolicy.cs
+++ b/src/MaterialEditor.Base/ShaderPropertyFallbackPolicy.cs
@@ -34,16 +34,13 @@ namespace MaterialEditorAPI
                 MaxValue = shaderSpecific.MaxValue,
                 Hidden = shaderSpecific.Hidden,
                 Category = shaderSpecific.Category,
-                CategoryOrder = null,
                 DeclarationOrder = 0,
                 DisplayName = shaderSpecific.Name,
-                Order = null,
                 EditorId = null,
                 UiLevel = MaterialEditorPropertyUiLevel.Basic,
                 ShowIf = null,
                 EnumOptions = new List<MaterialEditorEnumOption>(),
-                OffValue = 0f,
-                OnValue = 1f
+                Invert = false
             };
         }
 

--- a/src/MaterialEditor.Base/UI/UI.MaterialEditorPresenter.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialEditorPresenter.cs
@@ -45,6 +45,7 @@ namespace MaterialEditorAPI
     {
         internal Action<GameObject, object, string> Refresh { get; set; }
         internal Action<GameObject, object, string> RefreshDeferred { get; set; }
+        internal Action<GameObject, object, string> RefreshConditionsDeferred { get; set; }
         internal Action<GameObject, object, IEnumerable<Renderer>> RefreshMaterialSelection { get; set; }
         internal Action<GameObject, Material, object> ShowRename { get; set; }
         internal Action<Renderer> ExportUv { get; set; }

--- a/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
@@ -640,7 +640,7 @@ namespace MaterialEditorAPI
                         continue;
                     }
 
-                    if (!Approximately(firstValue, value))
+                    if (firstValue != value)
                     {
                         return new MaterialEditorEnumValueSelection(
                             MaterialEditorEnumValueState.Mixed,
@@ -654,7 +654,7 @@ namespace MaterialEditorAPI
             {
                 for (var index = 0; index < options.Count; index++)
                 {
-                    if (Approximately(options[index].Value, firstValue))
+                    if (options[index].Value == firstValue)
                     {
                         return new MaterialEditorEnumValueSelection(
                             MaterialEditorEnumValueState.Matched,
@@ -672,7 +672,7 @@ namespace MaterialEditorAPI
 
         internal static bool GetBooleanDisplayValue(float storedValue, bool invert)
         {
-            var enabled = !Approximately(storedValue, 0f);
+            var enabled = storedValue != 0f;
             return invert ? !enabled : enabled;
         }
 
@@ -686,7 +686,7 @@ namespace MaterialEditorAPI
             float selectedValue,
             float originalValue)
         {
-            return !wasMixed && Approximately(selectedValue, originalValue);
+            return !wasMixed && selectedValue == originalValue;
         }
 
         internal static void PersistExplicitEnumSelection(
@@ -706,15 +706,6 @@ namespace MaterialEditorAPI
             setOverride(selectedValue);
         }
 
-        internal static bool Approximately(float left, float right)
-        {
-            if (left == right)
-                return true;
-
-            var difference = Math.Abs(left - right);
-            var largest = Math.Max(Math.Abs(left), Math.Abs(right));
-            return difference <= Math.Max(0.000001f * largest, float.Epsilon * 8f);
-        }
     }
 
     internal static class MaterialEditorConditionPolicy

--- a/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
@@ -204,7 +204,8 @@ namespace MaterialEditorAPI
             }
 
             var value = declaredType.Trim();
-            if (string.Equals(value, "Toggle", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(value, "Boolean", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "Toggle", StringComparison.OrdinalIgnoreCase))
             {
                 normalizedType = "Float";
                 editorId = ShaderPropertyEditorIds.Toggle;
@@ -324,6 +325,7 @@ namespace MaterialEditorAPI
                 return ShaderPropertyEditorIds.Enum;
             if (EqualsAny(
                     raw,
+                    "Boolean",
                     "Toggle",
                     "ToggleFloat",
                     ShaderPropertyEditorIds.Toggle))
@@ -592,6 +594,126 @@ namespace MaterialEditorAPI
         private static void Warn(Action<string> warning, string message)
         {
             warning?.Invoke(message);
+        }
+    }
+
+    internal enum MaterialEditorEnumValueState
+    {
+        Matched,
+        Unmatched,
+        Mixed
+    }
+
+    internal sealed class MaterialEditorEnumValueSelection
+    {
+        internal MaterialEditorEnumValueSelection(
+            MaterialEditorEnumValueState state,
+            int optionIndex,
+            float currentValue)
+        {
+            State = state;
+            OptionIndex = optionIndex;
+            CurrentValue = currentValue;
+        }
+
+        internal MaterialEditorEnumValueState State { get; }
+        internal int OptionIndex { get; }
+        internal float CurrentValue { get; }
+    }
+
+    internal static class MaterialEditorFloatBackedValuePolicy
+    {
+        internal static MaterialEditorEnumValueSelection ResolveEnumSelection(
+            IList<MaterialEditorEnumOption> options,
+            IEnumerable<float> currentValues)
+        {
+            var hasValue = false;
+            var firstValue = 0f;
+            if (currentValues != null)
+            {
+                foreach (var value in currentValues)
+                {
+                    if (!hasValue)
+                    {
+                        firstValue = value;
+                        hasValue = true;
+                        continue;
+                    }
+
+                    if (!Approximately(firstValue, value))
+                    {
+                        return new MaterialEditorEnumValueSelection(
+                            MaterialEditorEnumValueState.Mixed,
+                            -1,
+                            firstValue);
+                    }
+                }
+            }
+
+            if (hasValue && options != null)
+            {
+                for (var index = 0; index < options.Count; index++)
+                {
+                    if (Approximately(options[index].Value, firstValue))
+                    {
+                        return new MaterialEditorEnumValueSelection(
+                            MaterialEditorEnumValueState.Matched,
+                            index,
+                            firstValue);
+                    }
+                }
+            }
+
+            return new MaterialEditorEnumValueSelection(
+                MaterialEditorEnumValueState.Unmatched,
+                -1,
+                firstValue);
+        }
+
+        internal static bool GetBooleanDisplayValue(float storedValue, bool invert)
+        {
+            var enabled = !Approximately(storedValue, 0f);
+            return invert ? !enabled : enabled;
+        }
+
+        internal static float GetBooleanStoredValue(bool displayValue, bool invert)
+        {
+            return displayValue != invert ? 1f : 0f;
+        }
+
+        internal static bool ShouldRemoveEnumOverride(
+            bool wasMixed,
+            float selectedValue,
+            float originalValue)
+        {
+            return !wasMixed && Approximately(selectedValue, originalValue);
+        }
+
+        internal static void PersistExplicitEnumSelection(
+            Action removeOverride,
+            Action<float> setOverride,
+            float selectedValue)
+        {
+            if (removeOverride == null)
+                throw new ArgumentNullException(nameof(removeOverride));
+            if (setOverride == null)
+                throw new ArgumentNullException(nameof(setOverride));
+
+            // The legacy backends remove an existing float override when its
+            // value matches ValueOriginal. Removing first makes the following
+            // set create a fresh persisted entry even for that value.
+            removeOverride();
+            setOverride(selectedValue);
+        }
+
+        internal static bool Approximately(float left, float right)
+        {
+            if (left == right)
+                return true;
+
+            var difference = Math.Abs(left - right);
+            var largest = Math.Max(Math.Abs(left), Math.Abs(right));
+            return difference <= Math.Max(0.000001f * largest, float.Epsilon * 8f);
         }
     }
 

--- a/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
@@ -1,0 +1,648 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+
+namespace MaterialEditorAPI
+{
+    internal enum MaterialEditorPropertyUiLevel
+    {
+        Basic,
+        Advanced
+    }
+
+    internal enum MaterialEditorConditionComparison
+    {
+        Equal,
+        NotEqual,
+        GreaterThan,
+        GreaterThanOrEqual,
+        LessThan,
+        LessThanOrEqual
+    }
+
+    internal sealed class MaterialEditorPropertyCondition
+    {
+        internal MaterialEditorPropertyCondition(
+            string propertyName,
+            MaterialEditorConditionComparison comparison,
+            float value)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+                throw new ArgumentException("A condition property name is required.", nameof(propertyName));
+
+            PropertyName = NormalizePropertyName(propertyName);
+            Comparison = comparison;
+            Value = value;
+        }
+
+        internal string PropertyName { get; }
+        internal MaterialEditorConditionComparison Comparison { get; }
+        internal float Value { get; }
+
+        internal bool Evaluate(float currentValue)
+        {
+            switch (Comparison)
+            {
+                case MaterialEditorConditionComparison.Equal:
+                    return currentValue == Value;
+                case MaterialEditorConditionComparison.NotEqual:
+                    return currentValue != Value;
+                case MaterialEditorConditionComparison.GreaterThan:
+                    return currentValue > Value;
+                case MaterialEditorConditionComparison.GreaterThanOrEqual:
+                    return currentValue >= Value;
+                case MaterialEditorConditionComparison.LessThan:
+                    return currentValue < Value;
+                case MaterialEditorConditionComparison.LessThanOrEqual:
+                    return currentValue <= Value;
+                default:
+                    return true;
+            }
+        }
+
+        private static string NormalizePropertyName(string propertyName)
+        {
+            var normalized = propertyName.Trim();
+            while (normalized.StartsWith("_", StringComparison.Ordinal))
+                normalized = normalized.Substring(1);
+            if (normalized.Length == 0)
+                throw new ArgumentException("A condition property name is required.", nameof(propertyName));
+
+            foreach (var character in normalized)
+            {
+                if (!char.IsLetterOrDigit(character)
+                    && character != '_'
+                    && character != '.')
+                {
+                    throw new ArgumentException(
+                        "A condition property name contains unsupported characters.",
+                        nameof(propertyName));
+                }
+            }
+
+            return normalized;
+        }
+    }
+
+    internal sealed class MaterialEditorEnumOption
+    {
+        internal MaterialEditorEnumOption(float value, string displayName)
+        {
+            Value = value;
+            DisplayName = string.IsNullOrEmpty(displayName)
+                ? value.ToString(CultureInfo.InvariantCulture)
+                : displayName;
+        }
+
+        internal float Value { get; }
+        internal string DisplayName { get; }
+    }
+
+    internal static class ShaderPropertyEditorIds
+    {
+        internal const string Enum = "materialeditor.enum";
+        internal const string Toggle = "materialeditor.toggle";
+    }
+
+    internal sealed class ShaderPropertyUiMetadata
+    {
+        internal string DisplayName;
+        internal int? Order;
+        internal int? CategoryOrder;
+        internal string EditorId;
+        internal MaterialEditorPropertyUiLevel UiLevel = MaterialEditorPropertyUiLevel.Basic;
+        internal MaterialEditorPropertyCondition ShowIf;
+        internal readonly List<MaterialEditorEnumOption> EnumOptions =
+            new List<MaterialEditorEnumOption>();
+        internal float OffValue;
+        internal float OnValue = 1f;
+    }
+
+    internal static class ShaderPropertyMetadataParser
+    {
+        private const int CurrentSchemaVersion = 2;
+
+        internal static int ReadSchemaVersion(
+            XmlElement materialEditorElement,
+            Action<string> warning = null)
+        {
+            if (materialEditorElement == null)
+                return 1;
+
+            var raw = ReadAttribute(materialEditorElement, "SchemaVersion");
+            if (string.IsNullOrEmpty(raw))
+                return 1;
+
+            int version;
+            if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out version)
+                || version < 1
+                || version > CurrentSchemaVersion)
+            {
+                Warn(
+                    warning,
+                    "Unknown MaterialEditor SchemaVersion '" + raw
+                    + "'; using schema 1 compatibility mode.");
+                return 1;
+            }
+
+            return version;
+        }
+
+        internal static ShaderPropertyUiMetadata Parse(
+            XmlElement propertyElement,
+            Action<string> warning = null)
+        {
+            if (propertyElement == null)
+                throw new ArgumentNullException(nameof(propertyElement));
+
+            var metadata = new ShaderPropertyUiMetadata
+            {
+                DisplayName = ReadAttribute(propertyElement, "DisplayName")
+            };
+            var context = GetPropertyContext(propertyElement);
+
+            ParseOrder(propertyElement, metadata, context, warning);
+            ParseCategoryOrder(propertyElement, metadata, context, warning);
+            ParseUiLevel(propertyElement, metadata, context, warning);
+            metadata.EditorId = ParseEditor(propertyElement, context, warning);
+            metadata.ShowIf = ParseConditionAttribute(
+                propertyElement,
+                "ShowIf",
+                context,
+                warning);
+            metadata.OffValue = ParseFloatAttribute(
+                propertyElement,
+                "OffValue",
+                0f,
+                context,
+                warning);
+            metadata.OnValue = ParseFloatAttribute(
+                propertyElement,
+                "OnValue",
+                1f,
+                context,
+                warning);
+            ParseEnumOptions(propertyElement, metadata, context, warning);
+
+            if (metadata.EditorId == ShaderPropertyEditorIds.Enum
+                && metadata.EnumOptions.Count == 0)
+            {
+                Warn(
+                    warning,
+                    context
+                    + " declares the Enum editor without any valid Option elements; "
+                    + "using its type editor instead.");
+                metadata.EditorId = null;
+            }
+
+            return metadata;
+        }
+
+        internal static bool TryResolvePropertyTypeAlias(
+            string declaredType,
+            int schemaVersion,
+            out string normalizedType,
+            out string editorId)
+        {
+            normalizedType = null;
+            editorId = null;
+            if (schemaVersion != CurrentSchemaVersion
+                || string.IsNullOrEmpty(declaredType)
+                || declaredType.Trim().Length == 0)
+            {
+                return false;
+            }
+
+            var value = declaredType.Trim();
+            if (string.Equals(value, "Toggle", StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedType = "Float";
+                editorId = ShaderPropertyEditorIds.Toggle;
+                return true;
+            }
+
+            if (string.Equals(value, "Dropdown", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "Enum", StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedType = "Float";
+                editorId = ShaderPropertyEditorIds.Enum;
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool TryParseCondition(
+            string expression,
+            out MaterialEditorPropertyCondition condition,
+            Action<string> warning = null)
+        {
+            condition = null;
+            if (string.IsNullOrEmpty(expression)
+                || expression.Trim().Length == 0)
+            {
+                Warn(warning, "Condition is empty.");
+                return false;
+            }
+
+            var text = expression.Trim();
+            if (text[0] == '!')
+            {
+                return TryCreateCondition(
+                    text.Substring(1).Trim(),
+                    MaterialEditorConditionComparison.Equal,
+                    0f,
+                    out condition,
+                    warning);
+            }
+
+            string operatorText;
+            int operatorIndex;
+            if (!TryFindOperator(text, out operatorText, out operatorIndex))
+            {
+                return TryCreateCondition(
+                    text,
+                    MaterialEditorConditionComparison.NotEqual,
+                    0f,
+                    out condition,
+                    warning);
+            }
+
+            var propertyName = text.Substring(0, operatorIndex).Trim();
+            var expectedText = text.Substring(operatorIndex + operatorText.Length).Trim();
+            float expected;
+            if (!TryParseConditionValue(expectedText, out expected))
+            {
+                Warn(
+                    warning,
+                    "Condition '" + expression + "' has an invalid expected value.");
+                return false;
+            }
+
+            MaterialEditorConditionComparison comparison;
+            if (!TryMapComparison(operatorText, out comparison))
+            {
+                Warn(
+                    warning,
+                    "Condition '" + expression + "' has an unsupported comparison.");
+                return false;
+            }
+
+            return TryCreateCondition(
+                propertyName,
+                comparison,
+                expected,
+                out condition,
+                warning);
+        }
+
+        private static void ParseOrder(
+            XmlElement element,
+            ShaderPropertyUiMetadata metadata,
+            string context,
+            Action<string> warning)
+        {
+            var raw = ReadAttribute(element, "Order");
+            if (string.IsNullOrEmpty(raw))
+                return;
+
+            int value;
+            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+                metadata.Order = value;
+            else
+                Warn(warning, context + " has invalid Order '" + raw + "'; declaration order will be used.");
+        }
+
+        private static void ParseCategoryOrder(
+            XmlElement element,
+            ShaderPropertyUiMetadata metadata,
+            string context,
+            Action<string> warning)
+        {
+            var raw = ReadAttribute(element, "CategoryOrder");
+            if (string.IsNullOrEmpty(raw))
+                return;
+
+            int value;
+            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+                metadata.CategoryOrder = value;
+            else
+                Warn(
+                    warning,
+                    context + " has invalid CategoryOrder '" + raw
+                    + "'; category declaration order will be used.");
+        }
+
+        private static void ParseUiLevel(
+            XmlElement element,
+            ShaderPropertyUiMetadata metadata,
+            string context,
+            Action<string> warning)
+        {
+            var raw = ReadAttribute(element, "UiLevel");
+            if (string.IsNullOrEmpty(raw)
+                || string.Equals(raw, "Basic", StringComparison.OrdinalIgnoreCase))
+            {
+                metadata.UiLevel = MaterialEditorPropertyUiLevel.Basic;
+                return;
+            }
+
+            if (string.Equals(raw, "Advanced", StringComparison.OrdinalIgnoreCase))
+            {
+                metadata.UiLevel = MaterialEditorPropertyUiLevel.Advanced;
+                return;
+            }
+
+            Warn(
+                warning,
+                context + " has unknown UiLevel '" + raw + "'; Basic will be used.");
+            metadata.UiLevel = MaterialEditorPropertyUiLevel.Basic;
+        }
+
+        private static string ParseEditor(
+            XmlElement element,
+            string context,
+            Action<string> warning)
+        {
+            var raw = ReadAttribute(element, "Editor");
+            if (string.IsNullOrEmpty(raw))
+                return null;
+
+            if (EqualsAny(raw, "Enum", ShaderPropertyEditorIds.Enum))
+                return ShaderPropertyEditorIds.Enum;
+            if (EqualsAny(
+                    raw,
+                    "Toggle",
+                    "ToggleFloat",
+                    ShaderPropertyEditorIds.Toggle))
+            {
+                return ShaderPropertyEditorIds.Toggle;
+            }
+
+            Warn(
+                warning,
+                context + " has unknown Editor '" + raw
+                + "'; its type editor will be used.");
+            return null;
+        }
+
+        private static MaterialEditorPropertyCondition ParseConditionAttribute(
+            XmlElement element,
+            string attributeName,
+            string context,
+            Action<string> warning)
+        {
+            var raw = ReadAttribute(element, attributeName);
+            if (string.IsNullOrEmpty(raw))
+                return null;
+
+            MaterialEditorPropertyCondition condition;
+            if (TryParseCondition(
+                    raw,
+                    out condition,
+                    message => Warn(
+                        warning,
+                        context + " has invalid " + attributeName + ": " + message)))
+            {
+                return condition;
+            }
+
+            return null;
+        }
+
+        private static float ParseFloatAttribute(
+            XmlElement element,
+            string attributeName,
+            float fallback,
+            string context,
+            Action<string> warning)
+        {
+            var raw = ReadAttribute(element, attributeName);
+            if (string.IsNullOrEmpty(raw))
+                return fallback;
+
+            float value;
+            if (TryParseFiniteFloat(raw, out value))
+                return value;
+
+            Warn(
+                warning,
+                context + " has invalid " + attributeName + " '" + raw + "'; "
+                + fallback.ToString(CultureInfo.InvariantCulture) + " will be used.");
+            return fallback;
+        }
+
+        private static void ParseEnumOptions(
+            XmlElement element,
+            ShaderPropertyUiMetadata metadata,
+            string context,
+            Action<string> warning)
+        {
+            var values = new HashSet<float>();
+            foreach (XmlNode child in element.ChildNodes)
+            {
+                var optionElement = child as XmlElement;
+                if (optionElement == null || optionElement.Name != "Option")
+                    continue;
+
+                var rawValue = ReadAttribute(optionElement, "Value");
+                float value;
+                if (!TryParseFiniteFloat(rawValue, out value))
+                {
+                    Warn(
+                        warning,
+                        context + " contains an Option with invalid Value '"
+                        + rawValue + "'; it was ignored.");
+                    continue;
+                }
+
+                if (!values.Add(value))
+                {
+                    Warn(
+                        warning,
+                        context + " contains duplicate enum option value '"
+                        + rawValue + "'; the duplicate was ignored.");
+                    continue;
+                }
+
+                var displayName = ReadAttribute(optionElement, "DisplayName");
+                if (string.IsNullOrEmpty(displayName))
+                    displayName = ReadAttribute(optionElement, "Label");
+                if (string.IsNullOrEmpty(displayName))
+                    displayName = ReadAttribute(optionElement, "Name");
+                if (string.IsNullOrEmpty(displayName))
+                    displayName = (optionElement.InnerText ?? string.Empty).Trim();
+
+                metadata.EnumOptions.Add(
+                    new MaterialEditorEnumOption(value, displayName));
+            }
+        }
+
+        private static bool TryFindOperator(
+            string expression,
+            out string operatorText,
+            out int operatorIndex)
+        {
+            var operators = new[] { ">=", "<=", "!=", "==", ">", "<" };
+            foreach (var candidate in operators)
+            {
+                var index = expression.IndexOf(candidate, StringComparison.Ordinal);
+                if (index > 0)
+                {
+                    operatorText = candidate;
+                    operatorIndex = index;
+                    return true;
+                }
+            }
+
+            operatorText = null;
+            operatorIndex = -1;
+            return false;
+        }
+
+        private static bool TryMapComparison(
+            string operatorText,
+            out MaterialEditorConditionComparison comparison)
+        {
+            switch (operatorText)
+            {
+                case "==":
+                    comparison = MaterialEditorConditionComparison.Equal;
+                    return true;
+                case "!=":
+                    comparison = MaterialEditorConditionComparison.NotEqual;
+                    return true;
+                case ">":
+                    comparison = MaterialEditorConditionComparison.GreaterThan;
+                    return true;
+                case ">=":
+                    comparison = MaterialEditorConditionComparison.GreaterThanOrEqual;
+                    return true;
+                case "<":
+                    comparison = MaterialEditorConditionComparison.LessThan;
+                    return true;
+                case "<=":
+                    comparison = MaterialEditorConditionComparison.LessThanOrEqual;
+                    return true;
+                default:
+                    comparison = MaterialEditorConditionComparison.Equal;
+                    return false;
+            }
+        }
+
+        private static bool TryCreateCondition(
+            string propertyName,
+            MaterialEditorConditionComparison comparison,
+            float expected,
+            out MaterialEditorPropertyCondition condition,
+            Action<string> warning)
+        {
+            condition = null;
+            try
+            {
+                condition = new MaterialEditorPropertyCondition(
+                    propertyName,
+                    comparison,
+                    expected);
+                return true;
+            }
+            catch (ArgumentException exception)
+            {
+                Warn(warning, exception.Message);
+                return false;
+            }
+        }
+
+        private static bool TryParseConditionValue(string value, out float parsed)
+        {
+            if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                parsed = 1f;
+                return true;
+            }
+
+            if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase))
+            {
+                parsed = 0f;
+                return true;
+            }
+
+            return TryParseFiniteFloat(value, out parsed);
+        }
+
+        private static bool TryParseFiniteFloat(string value, out float parsed)
+        {
+            if (float.TryParse(
+                    value,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out parsed)
+                && !float.IsNaN(parsed)
+                && !float.IsInfinity(parsed))
+            {
+                return true;
+            }
+
+            parsed = 0f;
+            return false;
+        }
+
+        private static bool EqualsAny(string value, params string[] candidates)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (string.Equals(value, candidate, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static string ReadAttribute(XmlElement element, string attributeName)
+        {
+            if (element == null || !element.HasAttribute(attributeName))
+                return null;
+
+            var value = element.GetAttribute(attributeName);
+            return string.IsNullOrEmpty(value) ? null : value.Trim();
+        }
+
+        private static string GetPropertyContext(XmlElement element)
+        {
+            var name = ReadAttribute(element, "Name");
+            return string.IsNullOrEmpty(name)
+                ? "Shader property"
+                : "Shader property '" + name + "'";
+        }
+
+        private static void Warn(Action<string> warning, string message)
+        {
+            warning?.Invoke(message);
+        }
+    }
+
+    internal static class MaterialEditorConditionPolicy
+    {
+        internal static bool Evaluate(
+            MaterialEditorPropertyCondition condition,
+            Func<string, float?> resolveValue,
+            bool fallback = true)
+        {
+            if (condition == null)
+                return true;
+            if (resolveValue == null)
+                return fallback;
+
+            try
+            {
+                var value = resolveValue(condition.PropertyName);
+                return value.HasValue ? condition.Evaluate(value.Value) : fallback;
+            }
+            catch
+            {
+                return fallback;
+            }
+        }
+    }
+}

--- a/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
@@ -102,7 +102,7 @@ namespace MaterialEditorAPI
     internal static class ShaderPropertyEditorIds
     {
         internal const string Enum = "materialeditor.enum";
-        internal const string Toggle = "materialeditor.toggle";
+        internal const string Boolean = "materialeditor.boolean";
     }
 
     internal sealed class ShaderPropertyUiMetadata
@@ -204,11 +204,10 @@ namespace MaterialEditorAPI
             }
 
             var value = declaredType.Trim();
-            if (string.Equals(value, "Boolean", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(value, "Toggle", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(value, "Boolean", StringComparison.OrdinalIgnoreCase))
             {
                 normalizedType = "Float";
-                editorId = ShaderPropertyEditorIds.Toggle;
+                editorId = ShaderPropertyEditorIds.Boolean;
                 return true;
             }
 
@@ -323,14 +322,9 @@ namespace MaterialEditorAPI
 
             if (EqualsAny(raw, "Enum", ShaderPropertyEditorIds.Enum))
                 return ShaderPropertyEditorIds.Enum;
-            if (EqualsAny(
-                    raw,
-                    "Boolean",
-                    "Toggle",
-                    "ToggleFloat",
-                    ShaderPropertyEditorIds.Toggle))
+            if (EqualsAny(raw, "Boolean", ShaderPropertyEditorIds.Boolean))
             {
-                return ShaderPropertyEditorIds.Toggle;
+                return ShaderPropertyEditorIds.Boolean;
             }
 
             Warn(

--- a/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialPropertyMetadata.cs
@@ -108,15 +108,12 @@ namespace MaterialEditorAPI
     internal sealed class ShaderPropertyUiMetadata
     {
         internal string DisplayName;
-        internal int? Order;
-        internal int? CategoryOrder;
         internal string EditorId;
         internal MaterialEditorPropertyUiLevel UiLevel = MaterialEditorPropertyUiLevel.Basic;
         internal MaterialEditorPropertyCondition ShowIf;
         internal readonly List<MaterialEditorEnumOption> EnumOptions =
             new List<MaterialEditorEnumOption>();
-        internal float OffValue;
-        internal float OnValue = 1f;
+        internal bool Invert;
     }
 
     internal static class ShaderPropertyMetadataParser
@@ -162,8 +159,6 @@ namespace MaterialEditorAPI
             };
             var context = GetPropertyContext(propertyElement);
 
-            ParseOrder(propertyElement, metadata, context, warning);
-            ParseCategoryOrder(propertyElement, metadata, context, warning);
             ParseUiLevel(propertyElement, metadata, context, warning);
             metadata.EditorId = ParseEditor(propertyElement, context, warning);
             metadata.ShowIf = ParseConditionAttribute(
@@ -171,16 +166,10 @@ namespace MaterialEditorAPI
                 "ShowIf",
                 context,
                 warning);
-            metadata.OffValue = ParseFloatAttribute(
+            metadata.Invert = ParseBooleanAttribute(
                 propertyElement,
-                "OffValue",
-                0f,
-                context,
-                warning);
-            metadata.OnValue = ParseFloatAttribute(
-                propertyElement,
-                "OnValue",
-                1f,
+                "Invert",
+                false,
                 context,
                 warning);
             ParseEnumOptions(propertyElement, metadata, context, warning);
@@ -191,7 +180,7 @@ namespace MaterialEditorAPI
                 Warn(
                     warning,
                     context
-                    + " declares the Enum editor without any valid Option elements; "
+                    + " declares the Enum editor without a valid Enums attribute; "
                     + "using its type editor instead.");
                 metadata.EditorId = null;
             }
@@ -222,8 +211,7 @@ namespace MaterialEditorAPI
                 return true;
             }
 
-            if (string.Equals(value, "Dropdown", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(value, "Enum", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(value, "Enum", StringComparison.OrdinalIgnoreCase))
             {
                 normalizedType = "Float";
                 editorId = ShaderPropertyEditorIds.Enum;
@@ -295,43 +283,6 @@ namespace MaterialEditorAPI
                 expected,
                 out condition,
                 warning);
-        }
-
-        private static void ParseOrder(
-            XmlElement element,
-            ShaderPropertyUiMetadata metadata,
-            string context,
-            Action<string> warning)
-        {
-            var raw = ReadAttribute(element, "Order");
-            if (string.IsNullOrEmpty(raw))
-                return;
-
-            int value;
-            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
-                metadata.Order = value;
-            else
-                Warn(warning, context + " has invalid Order '" + raw + "'; declaration order will be used.");
-        }
-
-        private static void ParseCategoryOrder(
-            XmlElement element,
-            ShaderPropertyUiMetadata metadata,
-            string context,
-            Action<string> warning)
-        {
-            var raw = ReadAttribute(element, "CategoryOrder");
-            if (string.IsNullOrEmpty(raw))
-                return;
-
-            int value;
-            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
-                metadata.CategoryOrder = value;
-            else
-                Warn(
-                    warning,
-                    context + " has invalid CategoryOrder '" + raw
-                    + "'; category declaration order will be used.");
         }
 
         private static void ParseUiLevel(
@@ -411,10 +362,10 @@ namespace MaterialEditorAPI
             return null;
         }
 
-        private static float ParseFloatAttribute(
+        private static bool ParseBooleanAttribute(
             XmlElement element,
             string attributeName,
-            float fallback,
+            bool fallback,
             string context,
             Action<string> warning)
         {
@@ -422,14 +373,14 @@ namespace MaterialEditorAPI
             if (string.IsNullOrEmpty(raw))
                 return fallback;
 
-            float value;
-            if (TryParseFiniteFloat(raw, out value))
+            bool value;
+            if (bool.TryParse(raw, out value))
                 return value;
 
             Warn(
                 warning,
                 context + " has invalid " + attributeName + " '" + raw + "'; "
-                + fallback.ToString(CultureInfo.InvariantCulture) + " will be used.");
+                + fallback.ToString() + " will be used.");
             return fallback;
         }
 
@@ -439,20 +390,40 @@ namespace MaterialEditorAPI
             string context,
             Action<string> warning)
         {
-            var values = new HashSet<float>();
-            foreach (XmlNode child in element.ChildNodes)
-            {
-                var optionElement = child as XmlElement;
-                if (optionElement == null || optionElement.Name != "Option")
-                    continue;
+            var raw = ReadAttribute(element, "Enums");
+            if (string.IsNullOrEmpty(raw))
+                return;
 
-                var rawValue = ReadAttribute(optionElement, "Value");
+            var tokens = raw.Split(',');
+            if (tokens.Length % 2 != 0)
+            {
+                Warn(
+                    warning,
+                    context + " has an invalid Enums list; labels and values "
+                    + "must be declared in pairs. The unmatched final token was ignored.");
+            }
+
+            var values = new HashSet<float>();
+            var labels = new HashSet<string>(StringComparer.Ordinal);
+            for (var index = 0; index + 1 < tokens.Length; index += 2)
+            {
+                var displayName = tokens[index].Trim();
+                var rawValue = tokens[index + 1].Trim();
+                if (displayName.Length == 0)
+                {
+                    Warn(
+                        warning,
+                        context + " contains an enum option with an empty label; "
+                        + "the option was ignored.");
+                    continue;
+                }
+
                 float value;
                 if (!TryParseFiniteFloat(rawValue, out value))
                 {
                     Warn(
                         warning,
-                        context + " contains an Option with invalid Value '"
+                        context + " contains an enum option with invalid value '"
                         + rawValue + "'; it was ignored.");
                     continue;
                 }
@@ -466,13 +437,15 @@ namespace MaterialEditorAPI
                     continue;
                 }
 
-                var displayName = ReadAttribute(optionElement, "DisplayName");
-                if (string.IsNullOrEmpty(displayName))
-                    displayName = ReadAttribute(optionElement, "Label");
-                if (string.IsNullOrEmpty(displayName))
-                    displayName = ReadAttribute(optionElement, "Name");
-                if (string.IsNullOrEmpty(displayName))
-                    displayName = (optionElement.InnerText ?? string.Empty).Trim();
+                if (!labels.Add(displayName))
+                {
+                    values.Remove(value);
+                    Warn(
+                        warning,
+                        context + " contains duplicate enum option label '"
+                        + displayName + "'; the duplicate was ignored.");
+                    continue;
+                }
 
                 metadata.EnumOptions.Add(
                     new MaterialEditorEnumOption(value, displayName));

--- a/src/MaterialEditor.Base/UI/UI.MaterialSectionPresenter.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialSectionPresenter.cs
@@ -127,6 +127,8 @@ namespace MaterialEditorAPI
                 context.Material);
             if (originalShaderName.IsNullOrEmpty())
                 originalShaderName = context.ShaderName;
+            var hasAdvancedProperties = HasAdvancedProperties(context);
+            var uiMode = _session.ShaderUiModes.GetMode(context.ShaderName);
             var shaderItem = new ShaderRowModel()
             {
                 GameObject = context.GameObject,
@@ -137,6 +139,8 @@ namespace MaterialEditorAPI
                 OriginalShaderName = originalShaderName,
                 TooltipText = ShaderUiMetadataRegistry.GetShaderTooltip(
                     context.ShaderName),
+                HasAdvancedProperties = hasAdvancedProperties,
+                UiMode = uiMode,
                 Collapsed = collapsed,
                 CollapsedOnChange = value =>
                 {
@@ -172,6 +176,11 @@ namespace MaterialEditorAPI
                         string.Empty,
                         string.Empty)
             };
+            shaderItem.UiModeOnChange = value =>
+            {
+                if (_session.ShaderUiModes.SetMode(shaderItem.ShaderName, value))
+                    _actions.Refresh(context.GameObject, context.Data, context.Filter);
+            };
             context.Rows.Add(shaderItem);
 
             if (collapsed)
@@ -196,6 +205,20 @@ namespace MaterialEditorAPI
                     context.Edits.ResetRenderQueue(context.Material)
             });
             return shaderItem;
+        }
+
+        private bool HasAdvancedProperties(MaterialSectionContext context)
+        {
+            var shaderKey = XMLShaderProperties.ContainsKey(context.ShaderName)
+                ? context.ShaderName
+                : "default";
+            return XMLShaderProperties[shaderKey].Values.Any(property =>
+                property.UiLevel == MaterialEditorPropertyUiLevel.Advanced
+                && (property.Type == ShaderPropertyType.Keyword
+                    || context.Material.HasProperty($"_{property.Name}"))
+                && !_actions.IsPropertyBlacklisted(
+                    context.MaterialName,
+                    property.Name));
         }
 
         private void AddPropertyRows(
@@ -233,7 +256,8 @@ namespace MaterialEditorAPI
                         || context.Material.HasProperty($"_{property.Name}"))
                     .Where(property =>
                         property.UiLevel == MaterialEditorPropertyUiLevel.Basic
-                        || _session.UiMode == MaterialEditorUiMode.Advanced)
+                        || _session.ShaderUiModes.GetMode(context.ShaderName)
+                        == MaterialEditorUiMode.Advanced)
                     .Where(property =>
                         MaterialEditorConditionPolicy.Evaluate(
                             property.ShowIf,

--- a/src/MaterialEditor.Base/UI/UI.MaterialSectionPresenter.cs
+++ b/src/MaterialEditor.Base/UI/UI.MaterialSectionPresenter.cs
@@ -203,17 +203,44 @@ namespace MaterialEditorAPI
             MaterialSectionPresentation section,
             bool includeRows)
         {
-            var categories = PropertyOrganizer.PropertyOrganization[
-                XMLShaderProperties.ContainsKey(context.ShaderName)
-                    ? context.ShaderName
-                    : "default"];
+            var shaderKey = XMLShaderProperties.ContainsKey(context.ShaderName)
+                ? context.ShaderName
+                : "default";
+            var categories = PropertyOrganizer.PropertyOrganization[shaderKey];
+            // Conditions may intentionally reference a hidden control property,
+            // so source resolution must use the raw manifest rather than the
+            // visible-only organizer output.
+            var manifestDefinitions = XMLShaderProperties[shaderKey]
+                .Values
+                .ToList();
+            var definitionsByName = manifestDefinitions
+                .GroupBy(definition => definition.Name)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.First(),
+                    StringComparer.Ordinal);
+            var conditionSources = new HashSet<string>(
+                manifestDefinitions
+                    .Where(definition => definition.ShowIf != null)
+                    .Select(definition => definition.ShowIf.PropertyName),
+                StringComparer.Ordinal);
 
             foreach (var category in categories)
             {
-                var definitions = category.Value
+                var definitions = category.Properties
                     .Where(property =>
                         property.Type == ShaderPropertyType.Keyword
                         || context.Material.HasProperty($"_{property.Name}"))
+                    .Where(property =>
+                        property.UiLevel == MaterialEditorPropertyUiLevel.Basic
+                        || _session.UiMode == MaterialEditorUiMode.Advanced)
+                    .Where(property =>
+                        MaterialEditorConditionPolicy.Evaluate(
+                            property.ShowIf,
+                            sourceName => ResolveConditionValue(
+                                context.Material,
+                                definitionsByName,
+                                sourceName)))
                     .Where(property =>
                         !_actions.IsPropertyBlacklisted(
                             context.MaterialName,
@@ -221,19 +248,22 @@ namespace MaterialEditorAPI
                     .Where(property =>
                         context.PropertyFilter.Count == 0
                         || context.PropertyFilter.Any(word =>
-                            MaterialEditorFilter.Matches(property.Name, word)))
+                            MaterialEditorFilter.Matches(property.Name, word)
+                            || MaterialEditorFilter.Matches(
+                                property.DisplayName,
+                                word)))
                     .ToList();
                 if (definitions.Count == 0)
                     continue;
 
                 var namedCategory =
                     categories.Count > 1
-                    || category.Key != PropertyOrganizer.UncategorizedName;
+                    || category.Name != PropertyOrganizer.UncategorizedName;
                 var categorySection = _categories.Add(
                     context,
                     section,
                     "manifest",
-                    category.Key,
+                    category.Name,
                     namedCategory,
                     includeRows);
                 if (!includeRows || categorySection.RowsCollapsed)
@@ -249,13 +279,44 @@ namespace MaterialEditorAPI
                         context.Projector,
                         context.MaterialName,
                         definition,
-                        category.Key);
+                        category.Name);
+                    if (conditionSources.Contains(definition.Name))
+                    {
+                        descriptor.PresentationRefresh = () =>
+                            _actions.RefreshConditionsDeferred(
+                                context.GameObject,
+                                context.Data,
+                                context.Filter);
+                    }
                     foreach (var row in _propertyRows.Create(descriptor))
                         context.Rows.Add(row);
                 }
             }
 
             AddExtensionPropertyRows(context, section, includeRows);
+        }
+
+        private static float? ResolveConditionValue(
+            Material material,
+            IDictionary<string, ShaderPropertyData> definitionsByName,
+            string propertyName)
+        {
+            ShaderPropertyData definition;
+            if (material == null
+                || definitionsByName == null
+                || string.IsNullOrEmpty(propertyName)
+                || !definitionsByName.TryGetValue(propertyName, out definition))
+                return null;
+
+            if (definition.Type == ShaderPropertyType.Keyword)
+                return material.IsKeywordEnabled($"_{propertyName}") ? 1f : 0f;
+            if (definition.Type != ShaderPropertyType.Float)
+                return null;
+
+            var materialPropertyName = $"_{propertyName}";
+            return material.HasProperty(materialPropertyName)
+                ? material.GetFloat(materialPropertyName)
+                : (float?)null;
         }
 
         private void AddExtensionPropertyRows(

--- a/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
@@ -210,9 +210,6 @@ namespace MaterialEditorAPI
             foreach (var row in rows)
             {
                 row.IsAdvanced = isAdvanced;
-                row.LabelText = MaterialEditorAdvancedPropertyPresentation.FormatLabel(
-                    row.LabelText,
-                    isAdvanced);
                 row.TooltipText = tooltipText;
                 yield return row;
             }

--- a/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
@@ -374,6 +374,7 @@ namespace MaterialEditorAPI
                 Value = value,
                 OriginalValue = original,
                 Options = descriptor.EnumOptions,
+                CurrentValues = GetFloatValues(descriptor),
                 SelectInterpolable = () =>
                     _actions.SelectInterpolable(
                         gameObject,
@@ -396,6 +397,41 @@ namespace MaterialEditorAPI
                         gameObject),
                 PresentationRefresh = descriptor.PresentationRefresh
             };
+        }
+
+        private static IList<float> GetFloatValues(PropertyDescriptor descriptor)
+        {
+            var values = new List<float>();
+            var materialPropertyName = "_" + descriptor.Name;
+            if (descriptor.Projector != null)
+            {
+                if (descriptor.Material.HasProperty(materialPropertyName))
+                    values.Add(descriptor.Material.GetFloat(materialPropertyName));
+                return values;
+            }
+
+            var visited = new HashSet<Material>();
+            foreach (var renderer in GetRendererList(descriptor.GameObject))
+            {
+                foreach (var material in GetMaterials(descriptor.GameObject, renderer))
+                {
+                    if (!visited.Add(material)
+                        || material.NameFormatted() != descriptor.MaterialName
+                        || !material.HasProperty(materialPropertyName))
+                    {
+                        continue;
+                    }
+
+                    values.Add(material.GetFloat(materialPropertyName));
+                }
+            }
+
+            if (values.Count == 0
+                && descriptor.Material.HasProperty(materialPropertyName))
+            {
+                values.Add(descriptor.Material.GetFloat(materialPropertyName));
+            }
+            return values;
         }
 
         private FloatTogglePropertyRowModel CreateFloatToggleRow(

--- a/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
@@ -33,8 +33,7 @@ namespace MaterialEditorAPI
                 : definition.EditorId;
             EnumOptions = definition.EnumOptions
                           ?? new List<MaterialEditorEnumOption>();
-            OffValue = definition.OffValue;
-            OnValue = definition.OnValue;
+            Invert = definition.Invert;
             PublicDescriptor = new MaterialEditorPropertyDescriptor(
                 definition.Name,
                 DisplayName,
@@ -75,8 +74,7 @@ namespace MaterialEditorAPI
             MaxValue = descriptor.Maximum;
             EditorId = descriptor.EditorId;
             EnumOptions = new List<MaterialEditorEnumOption>();
-            OffValue = 0f;
-            OnValue = 1f;
+            Invert = false;
             PublicDescriptor = descriptor;
         }
 
@@ -92,8 +90,7 @@ namespace MaterialEditorAPI
         internal float? MaxValue { get; }
         internal string EditorId { get; }
         internal IList<MaterialEditorEnumOption> EnumOptions { get; }
-        internal float OffValue { get; }
-        internal float OnValue { get; }
+        internal bool Invert { get; }
         internal System.Action PresentationRefresh { get; set; }
         internal MaterialEditorPropertyDescriptor PublicDescriptor { get; }
 
@@ -419,8 +416,7 @@ namespace MaterialEditorAPI
                 PublicDescriptor = descriptor.PublicDescriptor,
                 Value = value,
                 OriginalValue = original,
-                OffValue = descriptor.OffValue,
-                OnValue = descriptor.OnValue,
+                Invert = descriptor.Invert,
                 SelectInterpolable = () =>
                     _actions.SelectInterpolable(
                         gameObject,

--- a/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
@@ -22,14 +22,23 @@ namespace MaterialEditorAPI
             Projector = projector;
             MaterialName = materialName;
             Name = definition.Name;
-            DisplayName = definition.Name;
+            DisplayName = string.IsNullOrEmpty(definition.DisplayName)
+                ? definition.Name
+                : definition.DisplayName;
             Type = definition.Type;
             MinValue = definition.MinValue;
             MaxValue = definition.MaxValue;
+            EditorId = string.IsNullOrEmpty(definition.EditorId)
+                ? GetEditorId(definition.Type)
+                : definition.EditorId;
+            EnumOptions = definition.EnumOptions
+                          ?? new List<MaterialEditorEnumOption>();
+            OffValue = definition.OffValue;
+            OnValue = definition.OnValue;
             PublicDescriptor = new MaterialEditorPropertyDescriptor(
                 definition.Name,
-                definition.Name,
-                GetEditorId(definition.Type))
+                DisplayName,
+                EditorId)
             {
                 PropertyName = definition.Name,
                 Category = category ?? string.Empty,
@@ -64,6 +73,10 @@ namespace MaterialEditorAPI
             Type = type;
             MinValue = descriptor.Minimum;
             MaxValue = descriptor.Maximum;
+            EditorId = descriptor.EditorId;
+            EnumOptions = new List<MaterialEditorEnumOption>();
+            OffValue = 0f;
+            OnValue = 1f;
             PublicDescriptor = descriptor;
         }
 
@@ -77,6 +90,11 @@ namespace MaterialEditorAPI
         internal ShaderPropertyType Type { get; }
         internal float? MinValue { get; }
         internal float? MaxValue { get; }
+        internal string EditorId { get; }
+        internal IList<MaterialEditorEnumOption> EnumOptions { get; }
+        internal float OffValue { get; }
+        internal float OnValue { get; }
+        internal System.Action PresentationRefresh { get; set; }
         internal MaterialEditorPropertyDescriptor PublicDescriptor { get; }
 
         private static string GetEditorId(ShaderPropertyType type)
@@ -122,7 +140,13 @@ namespace MaterialEditorAPI
                     rows = new[] { CreateColorRow(descriptor) };
                     break;
                 case ShaderPropertyType.Float:
-                    rows = new[] { CreateFloatRow(descriptor) };
+                    if (descriptor.EditorId == ShaderPropertyEditorIds.Enum
+                        && descriptor.EnumOptions.Count > 0)
+                        rows = new[] { CreateEnumRow(descriptor) };
+                    else if (descriptor.EditorId == ShaderPropertyEditorIds.Toggle)
+                        rows = new[] { CreateFloatToggleRow(descriptor) };
+                    else
+                        rows = new[] { CreateFloatRow(descriptor) };
                     break;
                 case ShaderPropertyType.Keyword:
                     rows = new[] { CreateKeywordRow(descriptor) };
@@ -319,6 +343,108 @@ namespace MaterialEditorAPI
                 () => _editService.RemoveMaterialFloatProperty(data, material, propertyName, gameObject));
         }
 
+        private EnumPropertyRowModel CreateEnumRow(PropertyDescriptor descriptor)
+        {
+            var gameObject = descriptor.GameObject;
+            var data = descriptor.Data;
+            var material = descriptor.Material;
+            var propertyName = descriptor.Name;
+            var value = material.GetFloat($"_{propertyName}");
+            var original =
+                _editService.GetMaterialFloatPropertyValueOriginal(
+                    data,
+                    material,
+                    propertyName,
+                    gameObject)
+                ?? value;
+
+            return new EnumPropertyRowModel(descriptor.DisplayName)
+            {
+                GameObject = gameObject,
+                Data = data,
+                Material = material,
+                Projector = descriptor.Projector,
+                PropertyName = propertyName,
+                PublicDescriptor = descriptor.PublicDescriptor,
+                Value = value,
+                OriginalValue = original,
+                Options = descriptor.EnumOptions,
+                SelectInterpolable = () =>
+                    _actions.SelectInterpolable(
+                        gameObject,
+                        RowModel.RowItemType.FloatProperty,
+                        descriptor.MaterialName,
+                        propertyName,
+                        string.Empty),
+                ValueOnChange = newValue =>
+                    _editService.SetMaterialFloatProperty(
+                        data,
+                        material,
+                        propertyName,
+                        newValue,
+                        gameObject),
+                ValueOnReset = () =>
+                    _editService.RemoveMaterialFloatProperty(
+                        data,
+                        material,
+                        propertyName,
+                        gameObject),
+                PresentationRefresh = descriptor.PresentationRefresh
+            };
+        }
+
+        private FloatTogglePropertyRowModel CreateFloatToggleRow(
+            PropertyDescriptor descriptor)
+        {
+            var gameObject = descriptor.GameObject;
+            var data = descriptor.Data;
+            var material = descriptor.Material;
+            var propertyName = descriptor.Name;
+            var value = material.GetFloat($"_{propertyName}");
+            var original =
+                _editService.GetMaterialFloatPropertyValueOriginal(
+                    data,
+                    material,
+                    propertyName,
+                    gameObject)
+                ?? value;
+
+            return new FloatTogglePropertyRowModel(descriptor.DisplayName)
+            {
+                GameObject = gameObject,
+                Data = data,
+                Material = material,
+                Projector = descriptor.Projector,
+                PropertyName = propertyName,
+                PublicDescriptor = descriptor.PublicDescriptor,
+                Value = value,
+                OriginalValue = original,
+                OffValue = descriptor.OffValue,
+                OnValue = descriptor.OnValue,
+                SelectInterpolable = () =>
+                    _actions.SelectInterpolable(
+                        gameObject,
+                        RowModel.RowItemType.FloatProperty,
+                        descriptor.MaterialName,
+                        propertyName,
+                        string.Empty),
+                ValueOnChange = newValue =>
+                    _editService.SetMaterialFloatProperty(
+                        data,
+                        material,
+                        propertyName,
+                        newValue,
+                        gameObject),
+                ValueOnReset = () =>
+                    _editService.RemoveMaterialFloatProperty(
+                        data,
+                        material,
+                        propertyName,
+                        gameObject),
+                PresentationRefresh = descriptor.PresentationRefresh
+            };
+        }
+
         internal static FloatPropertyRowModel CreateFloatRow(
             PropertyDescriptor descriptor,
             float value,
@@ -341,7 +467,8 @@ namespace MaterialEditorAPI
                 OriginalValue = original,
                 SelectInterpolable = selectInterpolable,
                 ValueOnChange = changeValue,
-                ValueOnReset = resetValue
+                ValueOnReset = resetValue,
+                PresentationRefresh = descriptor.PresentationRefresh
             };
             if (minValue != null)
                 item.SliderMinimum = minValue.Value;
@@ -374,7 +501,8 @@ namespace MaterialEditorAPI
                 ValueOnChange = newValue =>
                     _editService.SetMaterialKeywordProperty(data, material, propertyName, newValue, gameObject),
                 ValueOnReset = () =>
-                    _editService.RemoveMaterialKeywordProperty(data, material, propertyName, gameObject)
+                    _editService.RemoveMaterialKeywordProperty(data, material, propertyName, gameObject),
+                PresentationRefresh = descriptor.PresentationRefresh
             };
         }
 

--- a/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
@@ -142,7 +142,7 @@ namespace MaterialEditorAPI
                     if (descriptor.EditorId == ShaderPropertyEditorIds.Enum
                         && descriptor.EnumOptions.Count > 0)
                         rows = new[] { CreateEnumRow(descriptor) };
-                    else if (descriptor.EditorId == ShaderPropertyEditorIds.Toggle)
+                    else if (descriptor.EditorId == ShaderPropertyEditorIds.Boolean)
                         rows = new[] { CreateFloatToggleRow(descriptor) };
                     else
                         rows = new[] { CreateFloatRow(descriptor) };

--- a/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyDescriptor.cs
@@ -28,6 +28,7 @@ namespace MaterialEditorAPI
             Type = definition.Type;
             MinValue = definition.MinValue;
             MaxValue = definition.MaxValue;
+            IsAdvanced = definition.UiLevel == MaterialEditorPropertyUiLevel.Advanced;
             EditorId = string.IsNullOrEmpty(definition.EditorId)
                 ? GetEditorId(definition.Type)
                 : definition.EditorId;
@@ -88,6 +89,7 @@ namespace MaterialEditorAPI
         internal ShaderPropertyType Type { get; }
         internal float? MinValue { get; }
         internal float? MaxValue { get; }
+        internal bool IsAdvanced { get; }
         internal string EditorId { get; }
         internal IList<MaterialEditorEnumOption> EnumOptions { get; }
         internal bool Invert { get; }
@@ -152,7 +154,10 @@ namespace MaterialEditorAPI
                     rows = new RowModel[0];
                     break;
             }
-            return WithTooltip(rows, descriptor.PublicDescriptor?.TooltipText);
+            return WithMetadata(
+                rows,
+                descriptor.PublicDescriptor?.TooltipText,
+                descriptor.IsAdvanced);
         }
 
         internal IEnumerable<RowModel> CreateExtension(
@@ -165,9 +170,10 @@ namespace MaterialEditorAPI
             if (editor == null)
                 return new RowModel[0];
 
-            return WithTooltip(
+            return WithMetadata(
                 CreateExtensionRows(context, descriptor, editor),
-                descriptor.TooltipText);
+                descriptor.TooltipText,
+                false);
         }
 
         private IEnumerable<RowModel> CreateExtensionRows(
@@ -196,12 +202,17 @@ namespace MaterialEditorAPI
             return new RowModel[0];
         }
 
-        private static IEnumerable<RowModel> WithTooltip(
+        private static IEnumerable<RowModel> WithMetadata(
             IEnumerable<RowModel> rows,
-            string tooltipText)
+            string tooltipText,
+            bool isAdvanced)
         {
             foreach (var row in rows)
             {
+                row.IsAdvanced = isAdvanced;
+                row.LabelText = MaterialEditorAdvancedPropertyPresentation.FormatLabel(
+                    row.LabelText,
+                    isAdvanced);
                 row.TooltipText = tooltipText;
                 yield return row;
             }

--- a/src/MaterialEditor.Base/UI/UI.PropertyOrganizer.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyOrganizer.cs
@@ -1,43 +1,129 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using static MaterialEditorAPI.MaterialEditorPluginBase;
 
 namespace MaterialEditorAPI
 {
+    internal sealed class OrganizedPropertyCategory
+    {
+        internal OrganizedPropertyCategory(
+            string name,
+            IList<ShaderPropertyData> properties)
+        {
+            Name = name;
+            Properties = properties;
+        }
+
+        internal string Name { get; }
+        internal IList<ShaderPropertyData> Properties { get; }
+    }
+
     internal class PropertyOrganizer
     {
-        // Shader, category, property
-        internal static Dictionary<string, Dictionary<string, List<ShaderPropertyData>>> PropertyOrganization = new Dictionary<string, Dictionary<string, List<ShaderPropertyData>>>();
+        private sealed class DeclaredProperty
+        {
+            internal ShaderPropertyData Definition;
+            internal int FallbackOrder;
+        }
+
+        private sealed class DeclaredCategory
+        {
+            internal string Name;
+            internal int? Order;
+            internal int DeclarationOrder;
+            internal List<DeclaredProperty> Properties;
+        }
+
+        // Shader -> ordered categories -> ordered properties.
+        internal static readonly Dictionary<string, List<OrganizedPropertyCategory>>
+            PropertyOrganization =
+                new Dictionary<string, List<OrganizedPropertyCategory>>();
+
         internal static string UncategorizedName = "Uncategorized";
-        internal static void Refresh() {
+
+        internal static void Refresh()
+        {
+            PropertyOrganization.Clear();
             foreach (var shader in XMLShaderProperties)
             {
-                PropertyOrganization[shader.Key] = shader.Value
-                    .Where(kv => !kv.Value.Hidden)
-                    .GroupBy(kv => (string.IsNullOrEmpty(kv.Value.Category) || !SortPropertiesByCategory.Value) ? UncategorizedName : char.ToUpper(kv.Value.Category[0]) + kv.Value.Category.Substring(1))
-                    .OrderBy(g => g.Key == UncategorizedName ? 1 : 0)  // Ensure "Uncategorized" goes to the end
-                    .ToDictionary(
-                        g => g.Key,
-                        g =>
-                        {
-                            var kvs = g.AsEnumerable();
-                            if (SortPropertiesByType.Value && SortPropertiesByName.Value)
-                            {
-                                kvs = kvs.OrderBy(kv => kv.Value.Type).ThenBy(kv => kv.Value.Name);
-                            }
-                            else if (SortPropertiesByType.Value)
-                            {
-                                kvs = kvs.OrderBy(kv => kv.Value.Type);
-                            }
-                            else if (SortPropertiesByName.Value)
-                            {
-                                kvs = kvs.OrderBy(kv => kv.Value.Name);
-                            }
-                            return kvs.Select(kv=>kv.Value).ToList();
-                        }
-                );
+                var declared = shader.Value
+                    .Select((item, index) => new DeclaredProperty
+                    {
+                        Definition = item.Value,
+                        FallbackOrder = index
+                    })
+                    .Where(item => !item.Definition.Hidden)
+                    .ToList();
 
+                var categories = declared
+                    .GroupBy(item => GetCategoryName(item.Definition))
+                    .Select(group => new DeclaredCategory
+                    {
+                        Name = group.Key,
+                        // A manifest should use one CategoryOrder per category.
+                        // If it does not, the first explicitly declared value wins.
+                        Order = group
+                            .Where(item => item.Definition.CategoryOrder.HasValue)
+                            .OrderBy(item => item.Definition.DeclarationOrder)
+                            .ThenBy(item => item.FallbackOrder)
+                            .Select(item => item.Definition.CategoryOrder)
+                            .FirstOrDefault(),
+                        DeclarationOrder = group.Min(
+                            item => item.Definition.DeclarationOrder),
+                        Properties = group.ToList()
+                    })
+                    .OrderBy(category =>
+                        category.Name == UncategorizedName ? 1 : 0)
+                    .ThenBy(category => category.Order.HasValue ? 0 : 1)
+                    .ThenBy(category => category.Order ?? 0)
+                    .ThenBy(category => category.DeclarationOrder)
+                    .ThenBy(category => category.Name)
+                    .Select(category => new OrganizedPropertyCategory(
+                        category.Name,
+                        SortProperties(category.Properties)))
+                    .ToList();
+
+                PropertyOrganization[shader.Key] = categories;
             }
+        }
+
+        private static string GetCategoryName(ShaderPropertyData definition)
+        {
+            if (string.IsNullOrEmpty(definition.Category)
+                || !SortPropertiesByCategory.Value)
+                return UncategorizedName;
+
+            return char.ToUpper(definition.Category[0])
+                   + definition.Category.Substring(1);
+        }
+
+        private static IList<ShaderPropertyData> SortProperties(
+            IEnumerable<DeclaredProperty> source)
+        {
+            var items = source.ToList();
+            var explicitlyOrdered = items
+                .Where(item => item.Definition.Order.HasValue)
+                .OrderBy(item => item.Definition.Order.Value)
+                .ThenBy(item => item.Definition.DeclarationOrder)
+                .ThenBy(item => item.FallbackOrder);
+
+            IOrderedEnumerable<DeclaredProperty> legacyOrdered = items
+                .Where(item => !item.Definition.Order.HasValue)
+                .OrderBy(item => 0);
+
+            // Properties without schema-v2 Order continue to use the existing
+            // sort settings. Explicit Order ties retain declaration order.
+            if (SortPropertiesByType.Value)
+                legacyOrdered = legacyOrdered.ThenBy(item => item.Definition.Type);
+            if (SortPropertiesByName.Value)
+                legacyOrdered = legacyOrdered.ThenBy(item => item.Definition.Name);
+
+            return explicitlyOrdered
+                .Concat(legacyOrdered
+                    .ThenBy(item => item.Definition.DeclarationOrder)
+                    .ThenBy(item => item.FallbackOrder))
+                .Select(item => item.Definition)
+                .ToList();
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.PropertyOrganizer.cs
+++ b/src/MaterialEditor.Base/UI/UI.PropertyOrganizer.cs
@@ -29,7 +29,6 @@ namespace MaterialEditorAPI
         private sealed class DeclaredCategory
         {
             internal string Name;
-            internal int? Order;
             internal int DeclarationOrder;
             internal List<DeclaredProperty> Properties;
         }
@@ -60,22 +59,12 @@ namespace MaterialEditorAPI
                     .Select(group => new DeclaredCategory
                     {
                         Name = group.Key,
-                        // A manifest should use one CategoryOrder per category.
-                        // If it does not, the first explicitly declared value wins.
-                        Order = group
-                            .Where(item => item.Definition.CategoryOrder.HasValue)
-                            .OrderBy(item => item.Definition.DeclarationOrder)
-                            .ThenBy(item => item.FallbackOrder)
-                            .Select(item => item.Definition.CategoryOrder)
-                            .FirstOrDefault(),
                         DeclarationOrder = group.Min(
                             item => item.Definition.DeclarationOrder),
                         Properties = group.ToList()
                     })
                     .OrderBy(category =>
                         category.Name == UncategorizedName ? 1 : 0)
-                    .ThenBy(category => category.Order.HasValue ? 0 : 1)
-                    .ThenBy(category => category.Order ?? 0)
                     .ThenBy(category => category.DeclarationOrder)
                     .ThenBy(category => category.Name)
                     .Select(category => new OrganizedPropertyCategory(
@@ -101,27 +90,20 @@ namespace MaterialEditorAPI
             IEnumerable<DeclaredProperty> source)
         {
             var items = source.ToList();
-            var explicitlyOrdered = items
-                .Where(item => item.Definition.Order.HasValue)
-                .OrderBy(item => item.Definition.Order.Value)
-                .ThenBy(item => item.Definition.DeclarationOrder)
-                .ThenBy(item => item.FallbackOrder);
+            IOrderedEnumerable<DeclaredProperty> legacyOrdered =
+                items.OrderBy(item => 0);
 
-            IOrderedEnumerable<DeclaredProperty> legacyOrdered = items
-                .Where(item => !item.Definition.Order.HasValue)
-                .OrderBy(item => 0);
-
-            // Properties without schema-v2 Order continue to use the existing
-            // sort settings. Explicit Order ties retain declaration order.
+            // Preserve the legacy sort settings. Declaration order provides a
+            // deterministic fallback when the configured sort keys tie or are
+            // disabled.
             if (SortPropertiesByType.Value)
                 legacyOrdered = legacyOrdered.ThenBy(item => item.Definition.Type);
             if (SortPropertiesByName.Value)
                 legacyOrdered = legacyOrdered.ThenBy(item => item.Definition.Name);
 
-            return explicitlyOrdered
-                .Concat(legacyOrdered
-                    .ThenBy(item => item.Definition.DeclarationOrder)
-                    .ThenBy(item => item.FallbackOrder))
+            return legacyOrdered
+                .ThenBy(item => item.Definition.DeclarationOrder)
+                .ThenBy(item => item.FallbackOrder)
                 .Select(item => item.Definition)
                 .ToList();
         }

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
@@ -216,7 +216,7 @@ namespace MaterialEditorAPI
             Action refresh = () =>
             {
                 controls.Toggle.Set(
-                    Mathf.Approximately(item.Value, item.OnValue),
+                    Mathf.Approximately(item.Value, item.Invert ? 0f : 1f),
                     false);
                 ChangedStateBinding.Apply(
                     controls.Label,
@@ -229,7 +229,7 @@ namespace MaterialEditorAPI
             refresh();
             listeners.Listen(controls.Toggle, enabled =>
             {
-                var value = enabled ? item.OnValue : item.OffValue;
+                var value = enabled != item.Invert ? 1f : 0f;
                 if (Mathf.Approximately(value, item.Value))
                     return;
 

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
@@ -124,18 +124,40 @@ namespace MaterialEditorAPI
             TooltipBinding.Bind(controls.Label.gameObject, item.TooltipText);
 
             List<float> optionValues = null;
+            var mixedIndex = -1;
+            var isMixed = false;
             Action rebuild = () =>
             {
                 controls.Dropdown.options.Clear();
                 optionValues = new List<float>();
                 var selectedIndex = -1;
+                mixedIndex = -1;
+                var selection =
+                    MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                        item.Options,
+                        item.CurrentValues ?? new[] { item.Value });
+                isMixed = selection.State == MaterialEditorEnumValueState.Mixed;
+
+                if (isMixed)
+                {
+                    mixedIndex = optionValues.Count;
+                    selectedIndex = mixedIndex;
+                    optionValues.Add(item.Value);
+                    controls.Dropdown.options.Add(new Dropdown.OptionData("Mixed"));
+                }
 
                 if (item.Options != null)
                 {
-                    foreach (var option in item.Options)
+                    for (var optionIndex = 0;
+                         optionIndex < item.Options.Count;
+                         optionIndex++)
                     {
-                        if (Mathf.Approximately(option.Value, item.Value))
+                        var option = item.Options[optionIndex];
+                        if (selection.State == MaterialEditorEnumValueState.Matched
+                            && selection.OptionIndex == optionIndex)
+                        {
                             selectedIndex = optionValues.Count;
+                        }
                         optionValues.Add(option.Value);
                         controls.Dropdown.options.Add(
                             new Dropdown.OptionData(option.DisplayName));
@@ -143,14 +165,15 @@ namespace MaterialEditorAPI
                 }
 
                 // Preserve values authored outside the declared option set.
-                if (selectedIndex < 0)
+                if (selection.State == MaterialEditorEnumValueState.Unmatched)
                 {
                     selectedIndex = optionValues.Count;
-                    optionValues.Add(item.Value);
+                    optionValues.Add(selection.CurrentValue);
                     controls.Dropdown.options.Add(
                         new Dropdown.OptionData(
                             "Current ("
-                            + item.Value.ToString(CultureInfo.InvariantCulture)
+                            + selection.CurrentValue.ToString(
+                                CultureInfo.InvariantCulture)
                             + ")"));
                 }
 
@@ -159,7 +182,7 @@ namespace MaterialEditorAPI
             Action refresh = () =>
                 ChangedStateBinding.Apply(
                     controls.Label,
-                    item.LabelText,
+                    isMixed ? item.LabelText + " (Mixed)" : item.LabelText,
                     item.Value != item.OriginalValue,
                     controls.ResetButton,
                     controls.Panel);
@@ -170,15 +193,34 @@ namespace MaterialEditorAPI
             {
                 if (optionValues == null
                     || index < 0
-                    || index >= optionValues.Count)
+                    || index >= optionValues.Count
+                    || index == mixedIndex)
                     return;
 
                 var value = optionValues[index];
-                if (Mathf.Approximately(value, item.Value))
+                if (!isMixed
+                    && MaterialEditorFloatBackedValuePolicy.Approximately(
+                        value,
+                        item.Value))
                     return;
 
+                var wasMixed = isMixed;
                 item.Value = value;
-                if (item.Value == item.OriginalValue)
+                item.CurrentValues = new[] { value };
+                if (wasMixed)
+                {
+                    // An explicit choice must be applied to every same-named
+                    // material and remain persisted even when it equals the
+                    // representative material's original value.
+                    MaterialEditorFloatBackedValuePolicy.PersistExplicitEnumSelection(
+                        item.ValueOnReset,
+                        item.ValueOnChange,
+                        item.Value);
+                }
+                else if (MaterialEditorFloatBackedValuePolicy.ShouldRemoveEnumOverride(
+                             wasMixed,
+                             item.Value,
+                             item.OriginalValue))
                     item.ValueOnReset();
                 else
                     item.ValueOnChange(item.Value);
@@ -189,6 +231,7 @@ namespace MaterialEditorAPI
             listeners.Listen(controls.ResetButton, () =>
             {
                 item.Value = item.OriginalValue;
+                item.CurrentValues = new[] { item.OriginalValue };
                 item.ValueOnReset();
                 rebuild();
                 refresh();
@@ -216,7 +259,9 @@ namespace MaterialEditorAPI
             Action refresh = () =>
             {
                 controls.Toggle.Set(
-                    Mathf.Approximately(item.Value, item.Invert ? 0f : 1f),
+                    MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(
+                        item.Value,
+                        item.Invert),
                     false);
                 ChangedStateBinding.Apply(
                     controls.Label,
@@ -229,8 +274,13 @@ namespace MaterialEditorAPI
             refresh();
             listeners.Listen(controls.Toggle, enabled =>
             {
-                var value = enabled != item.Invert ? 1f : 0f;
-                if (Mathf.Approximately(value, item.Value))
+                var value =
+                    MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(
+                        enabled,
+                        item.Invert);
+                if (MaterialEditorFloatBackedValuePolicy.Approximately(
+                        value,
+                        item.Value))
                     return;
 
                 item.Value = value;

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
@@ -198,10 +198,7 @@ namespace MaterialEditorAPI
                     return;
 
                 var value = optionValues[index];
-                if (!isMixed
-                    && MaterialEditorFloatBackedValuePolicy.Approximately(
-                        value,
-                        item.Value))
+                if (!isMixed && value == item.Value)
                     return;
 
                 var wasMixed = isMixed;
@@ -278,9 +275,7 @@ namespace MaterialEditorAPI
                     MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(
                         enabled,
                         item.Invert);
-                if (MaterialEditorFloatBackedValuePolicy.Approximately(
-                        value,
-                        item.Value))
+                if (value == item.Value)
                     return;
 
                 item.Value = value;

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.FloatKeyword.cs
@@ -1,4 +1,9 @@
-﻿using static UILib.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+using UnityEngine.UI;
+using static UILib.Extensions;
 
 namespace MaterialEditorAPI
 {
@@ -21,6 +26,12 @@ namespace MaterialEditorAPI
                 case RowModel.RowItemType.KeywordProperty:
                     BindKeyword((KeywordPropertyRowModel)item, listeners);
                     break;
+                case RowModel.RowItemType.EnumProperty:
+                    BindEnum((EnumPropertyRowModel)item, listeners);
+                    break;
+                case RowModel.RowItemType.FloatToggleProperty:
+                    BindFloatToggle((FloatTogglePropertyRowModel)item, listeners);
+                    break;
             }
         }
 
@@ -30,14 +41,14 @@ namespace MaterialEditorAPI
             controls.SetVisible(true);
             TooltipBinding.Bind(controls.Label.gameObject, item.TooltipText);
 
-            System.Action refresh = () =>
+            Action refresh = () =>
                 ChangedStateBinding.Apply(
                     controls.Label,
                     item.LabelText,
                     item.Value != item.OriginalValue,
                     controls.ResetButton,
                     controls.Panel);
-            System.Action<float> applyValue = value =>
+            Action<float> applyValue = value =>
             {
                 item.Value = value;
                 controls.Slider.Set(item.Value, false);
@@ -47,6 +58,7 @@ namespace MaterialEditorAPI
                 else
                     item.ValueOnChange(item.Value);
                 refresh();
+                item.PresentationRefresh?.Invoke();
             };
 
             InputFieldBinding.BindFloat(
@@ -70,6 +82,7 @@ namespace MaterialEditorAPI
                 controls.Input.SetValue(item.Value);
                 item.ValueOnReset();
                 refresh();
+                item.PresentationRefresh?.Invoke();
             });
             listeners.Listen(
                 controls.SelectInterpolableButton,
@@ -101,6 +114,148 @@ namespace MaterialEditorAPI
                 controls.LabelClickTrigger,
                 item,
                 MaterialEditorLabelType.KeywordProperty,
+                () => item.PropertyName);
+        }
+
+        private void BindEnum(EnumPropertyRowModel item, ListenerScope listeners)
+        {
+            var controls = _controls.Enum;
+            controls.SetVisible(true);
+            TooltipBinding.Bind(controls.Label.gameObject, item.TooltipText);
+
+            List<float> optionValues = null;
+            Action rebuild = () =>
+            {
+                controls.Dropdown.options.Clear();
+                optionValues = new List<float>();
+                var selectedIndex = -1;
+
+                if (item.Options != null)
+                {
+                    foreach (var option in item.Options)
+                    {
+                        if (Mathf.Approximately(option.Value, item.Value))
+                            selectedIndex = optionValues.Count;
+                        optionValues.Add(option.Value);
+                        controls.Dropdown.options.Add(
+                            new Dropdown.OptionData(option.DisplayName));
+                    }
+                }
+
+                // Preserve values authored outside the declared option set.
+                if (selectedIndex < 0)
+                {
+                    selectedIndex = optionValues.Count;
+                    optionValues.Add(item.Value);
+                    controls.Dropdown.options.Add(
+                        new Dropdown.OptionData(
+                            "Current ("
+                            + item.Value.ToString(CultureInfo.InvariantCulture)
+                            + ")"));
+                }
+
+                controls.Dropdown.Set(selectedIndex);
+            };
+            Action refresh = () =>
+                ChangedStateBinding.Apply(
+                    controls.Label,
+                    item.LabelText,
+                    item.Value != item.OriginalValue,
+                    controls.ResetButton,
+                    controls.Panel);
+
+            rebuild();
+            refresh();
+            listeners.Listen(controls.Dropdown, index =>
+            {
+                if (optionValues == null
+                    || index < 0
+                    || index >= optionValues.Count)
+                    return;
+
+                var value = optionValues[index];
+                if (Mathf.Approximately(value, item.Value))
+                    return;
+
+                item.Value = value;
+                if (item.Value == item.OriginalValue)
+                    item.ValueOnReset();
+                else
+                    item.ValueOnChange(item.Value);
+                rebuild();
+                refresh();
+                item.PresentationRefresh?.Invoke();
+            });
+            listeners.Listen(controls.ResetButton, () =>
+            {
+                item.Value = item.OriginalValue;
+                item.ValueOnReset();
+                rebuild();
+                refresh();
+                item.PresentationRefresh?.Invoke();
+            });
+            listeners.Listen(
+                controls.SelectInterpolableButton,
+                () => item.SelectInterpolable());
+            LabelClickBinding.Bind(
+                listeners,
+                controls.LabelClickTrigger,
+                item,
+                MaterialEditorLabelType.FloatProperty,
+                () => item.PropertyName);
+        }
+
+        private void BindFloatToggle(
+            FloatTogglePropertyRowModel item,
+            ListenerScope listeners)
+        {
+            var controls = _controls.FloatToggle;
+            controls.SetVisible(true);
+            TooltipBinding.Bind(controls.Label.gameObject, item.TooltipText);
+
+            Action refresh = () =>
+            {
+                controls.Toggle.Set(
+                    Mathf.Approximately(item.Value, item.OnValue),
+                    false);
+                ChangedStateBinding.Apply(
+                    controls.Label,
+                    item.LabelText,
+                    item.Value != item.OriginalValue,
+                    controls.ResetButton,
+                    controls.Panel);
+            };
+
+            refresh();
+            listeners.Listen(controls.Toggle, enabled =>
+            {
+                var value = enabled ? item.OnValue : item.OffValue;
+                if (Mathf.Approximately(value, item.Value))
+                    return;
+
+                item.Value = value;
+                if (item.Value == item.OriginalValue)
+                    item.ValueOnReset();
+                else
+                    item.ValueOnChange(item.Value);
+                refresh();
+                item.PresentationRefresh?.Invoke();
+            });
+            listeners.Listen(controls.ResetButton, () =>
+            {
+                item.Value = item.OriginalValue;
+                item.ValueOnReset();
+                refresh();
+                item.PresentationRefresh?.Invoke();
+            });
+            listeners.Listen(
+                controls.SelectInterpolableButton,
+                () => item.SelectInterpolable());
+            LabelClickBinding.Bind(
+                listeners,
+                controls.LabelClickTrigger,
+                item,
+                MaterialEditorLabelType.FloatProperty,
                 () => item.PropertyName);
         }
     }

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.MaterialShader.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.MaterialShader.cs
@@ -93,6 +93,21 @@ namespace MaterialEditorAPI
                     controls.CategoriesCollapseButton,
                     () => item.CategoriesCollapsedOnChange(!item.AllCategoriesCollapsed));
 
+            controls.UiModeButton.gameObject.SetActive(item.HasAdvancedProperties);
+            if (item.HasAdvancedProperties)
+            {
+                controls.UiModeButton.GetComponentInChildren<Text>().text =
+                    item.UiMode == MaterialEditorUiMode.Advanced
+                        ? "Advanced"
+                        : "Basic";
+                listeners.Listen(
+                    controls.UiModeButton,
+                    () => item.UiModeOnChange(
+                        item.UiMode == MaterialEditorUiMode.Advanced
+                            ? MaterialEditorUiMode.Basic
+                            : MaterialEditorUiMode.Advanced));
+            }
+
             System.Action refresh = () =>
                 ChangedStateBinding.Apply(
                     controls.Label,

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.cs
@@ -57,7 +57,9 @@ namespace MaterialEditorAPI
             _registry.Register(
                 floatKeyword,
                 RowModel.RowItemType.FloatProperty,
-                RowModel.RowItemType.KeywordProperty);
+                RowModel.RowItemType.KeywordProperty,
+                RowModel.RowItemType.EnumProperty,
+                RowModel.RowItemType.FloatToggleProperty);
         }
 
         internal void Bind(RowModel item, bool force)

--- a/src/MaterialEditor.Base/UI/UI.RowBinder.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinder.cs
@@ -80,6 +80,7 @@ namespace MaterialEditorAPI
             IRowTypeBinder handler;
             if (_registry.TryGet(item.ItemType, out handler))
                 handler.Bind(item, _listeners);
+            _controls.SetAdvancedPropertyAccent(item.IsAdvanced);
         }
 
         public void SetVisible(bool visible)

--- a/src/MaterialEditor.Base/UI/UI.RowBinding.Common.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowBinding.Common.cs
@@ -167,6 +167,7 @@ namespace MaterialEditorAPI
                 else
                     changeValue(getValue());
                 refresh();
+                item.PresentationRefresh?.Invoke();
             });
 
             listeners.Listen(controls.ResetButton, () =>
@@ -175,6 +176,7 @@ namespace MaterialEditorAPI
                 controls.Toggle.Set(getValue(), false);
                 resetValue();
                 refresh();
+                item.PresentationRefresh?.Invoke();
             });
         }
     }

--- a/src/MaterialEditor.Base/UI/UI.RowControls.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowControls.cs
@@ -287,9 +287,14 @@ namespace MaterialEditorAPI
     internal sealed class RowControlSet
     {
         private readonly List<RowControls> _rows;
+        private readonly CanvasGroup _advancedPropertyAccentCanvasGroup;
 
         private RowControlSet(RowBinder owner)
         {
+            AdvancedPropertyAccent =
+                owner.GetUIComponent<Image>("AdvancedPropertyAccent");
+            _advancedPropertyAccentCanvasGroup =
+                AdvancedPropertyAccent.GetComponent<CanvasGroup>();
             Renderer = new RendererRowControls(owner);
             RendererEnabled = CreateToggle(owner, "RendererEnabled");
             RendererShadowCastingMode = new DropdownRowControls(
@@ -344,6 +349,7 @@ namespace MaterialEditorAPI
         }
 
         internal RendererRowControls Renderer { get; }
+        internal Image AdvancedPropertyAccent { get; }
         internal ToggleRowControls RendererEnabled { get; }
         internal DropdownRowControls RendererShadowCastingMode { get; }
         internal ToggleRowControls RendererReceiveShadows { get; }
@@ -370,6 +376,14 @@ namespace MaterialEditorAPI
         {
             foreach (var row in _rows)
                 row.SetVisible(false);
+            SetAdvancedPropertyAccent(false);
+        }
+
+        internal void SetAdvancedPropertyAccent(bool visible)
+        {
+            _advancedPropertyAccentCanvasGroup.alpha = 1f;
+            if (AdvancedPropertyAccent.gameObject.activeSelf != visible)
+                AdvancedPropertyAccent.gameObject.SetActive(visible);
         }
 
         private static ToggleRowControls CreateToggle(

--- a/src/MaterialEditor.Base/UI/UI.RowControls.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowControls.cs
@@ -120,6 +120,7 @@ namespace MaterialEditorAPI
             Label = owner.GetUIComponent<Text>("ShaderLabel");
             LabelClickTrigger = owner.GetUIComponent<LabelClickTrigger>("ShaderLabel");
             Dropdown = owner.GetUIComponent<Dropdown>("ShaderDropdown");
+            UiModeButton = owner.GetUIComponent<Button>("ShaderUiModeButton");
             SelectInterpolableButton = owner.GetUIComponent<Button>("SelectInterpolableShaderButton");
             ResetButton = owner.GetUIComponent<Button>("ShaderResetButton");
         }
@@ -129,6 +130,7 @@ namespace MaterialEditorAPI
         internal Text Label { get; }
         internal LabelClickTrigger LabelClickTrigger { get; }
         internal Dropdown Dropdown { get; }
+        internal Button UiModeButton { get; }
         internal Button SelectInterpolableButton { get; }
         internal Button ResetButton { get; }
     }

--- a/src/MaterialEditor.Base/UI/UI.RowControls.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowControls.cs
@@ -27,19 +27,22 @@ namespace MaterialEditorAPI
             Text label,
             Toggle toggle,
             Button resetButton,
-            LabelClickTrigger labelClickTrigger = null)
+            LabelClickTrigger labelClickTrigger = null,
+            Button selectInterpolableButton = null)
             : base(panel)
         {
             Label = label;
             Toggle = toggle;
             ResetButton = resetButton;
             LabelClickTrigger = labelClickTrigger;
+            SelectInterpolableButton = selectInterpolableButton;
         }
 
         internal Text Label { get; }
         internal Toggle Toggle { get; }
         internal Button ResetButton { get; }
         internal LabelClickTrigger LabelClickTrigger { get; }
+        internal Button SelectInterpolableButton { get; }
     }
 
     internal sealed class RendererRowControls : RowControls
@@ -259,6 +262,26 @@ namespace MaterialEditorAPI
         internal Button ResetButton { get; }
     }
 
+    internal sealed class EnumRowControls : RowControls
+    {
+        internal EnumRowControls(RowBinder owner)
+            : base(owner.GetUIComponent<CanvasGroup>("EnumPanel"))
+        {
+            Label = owner.GetUIComponent<Text>("EnumLabel");
+            LabelClickTrigger = owner.GetUIComponent<LabelClickTrigger>("EnumLabel");
+            SelectInterpolableButton = owner.GetUIComponent<Button>(
+                "SelectInterpolableEnumButton");
+            Dropdown = owner.GetUIComponent<Dropdown>("EnumDropdown");
+            ResetButton = owner.GetUIComponent<Button>("EnumResetButton");
+        }
+
+        internal Text Label { get; }
+        internal LabelClickTrigger LabelClickTrigger { get; }
+        internal Button SelectInterpolableButton { get; }
+        internal Dropdown Dropdown { get; }
+        internal Button ResetButton { get; }
+    }
+
     internal sealed class RowControlSet
     {
         private readonly List<RowControls> _rows;
@@ -289,6 +312,12 @@ namespace MaterialEditorAPI
             Color = new ColorRowControls(owner);
             Float = new FloatRowControls(owner);
             Keyword = CreateToggle(owner, "Keyword", "KeywordLabel");
+            Enum = new EnumRowControls(owner);
+            FloatToggle = CreateToggle(
+                owner,
+                "FloatToggle",
+                "FloatToggleLabel",
+                "SelectInterpolableFloatToggleButton");
 
             _rows = new List<RowControls>
             {
@@ -306,7 +335,9 @@ namespace MaterialEditorAPI
                 OffsetScale,
                 Color,
                 Float,
-                Keyword
+                Keyword,
+                Enum,
+                FloatToggle
             };
         }
 
@@ -325,6 +356,8 @@ namespace MaterialEditorAPI
         internal ColorRowControls Color { get; }
         internal FloatRowControls Float { get; }
         internal ToggleRowControls Keyword { get; }
+        internal EnumRowControls Enum { get; }
+        internal ToggleRowControls FloatToggle { get; }
 
         internal static RowControlSet Create(RowBinder owner)
         {
@@ -340,7 +373,8 @@ namespace MaterialEditorAPI
         private static ToggleRowControls CreateToggle(
             RowBinder owner,
             string prefix,
-            string labelClickObjectName = null)
+            string labelClickObjectName = null,
+            string selectInterpolableObjectName = null)
         {
             return new ToggleRowControls(
                 owner.GetUIComponent<CanvasGroup>($"{prefix}Panel"),
@@ -349,7 +383,10 @@ namespace MaterialEditorAPI
                 owner.GetUIComponent<Button>($"{prefix}ResetButton"),
                 labelClickObjectName == null
                     ? null
-                    : owner.GetUIComponent<LabelClickTrigger>(labelClickObjectName));
+                    : owner.GetUIComponent<LabelClickTrigger>(labelClickObjectName),
+                selectInterpolableObjectName == null
+                    ? null
+                    : owner.GetUIComponent<Button>(selectInterpolableObjectName));
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.RowModel.MaterialShader.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowModel.MaterialShader.cs
@@ -32,6 +32,9 @@ namespace MaterialEditorAPI
         internal bool HasCategories { get; set; }
         internal bool AllCategoriesCollapsed { get; set; }
         internal Action<bool> CategoriesCollapsedOnChange { get; set; }
+        internal bool HasAdvancedProperties { get; set; }
+        internal MaterialEditorUiMode UiMode { get; set; }
+        internal Action<MaterialEditorUiMode> UiModeOnChange { get; set; }
         internal Action SelectInterpolable { get; set; }
         internal Action<string> ShaderNameOnChange { get; set; }
         internal Action ShaderNameOnReset { get; set; }

--- a/src/MaterialEditor.Base/UI/UI.RowModel.Properties.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowModel.Properties.cs
@@ -68,8 +68,7 @@ namespace MaterialEditorAPI
 
         internal float Value { get; set; }
         internal float OriginalValue { get; set; }
-        internal float OffValue { get; set; }
-        internal float OnValue { get; set; } = 1f;
+        internal bool Invert { get; set; }
         internal Action SelectInterpolable { get; set; }
         internal Action<float> ValueOnChange { get; set; }
         internal Action ValueOnReset { get; set; }

--- a/src/MaterialEditor.Base/UI/UI.RowModel.Properties.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowModel.Properties.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace MaterialEditorAPI
@@ -41,5 +42,36 @@ namespace MaterialEditorAPI
             : base(RowItemType.KeywordProperty, labelText)
         {
         }
+    }
+
+    internal sealed class EnumPropertyRowModel : RowModel
+    {
+        internal EnumPropertyRowModel(string labelText)
+            : base(RowItemType.EnumProperty, labelText)
+        {
+        }
+
+        internal float Value { get; set; }
+        internal float OriginalValue { get; set; }
+        internal IList<MaterialEditorEnumOption> Options { get; set; }
+        internal Action SelectInterpolable { get; set; }
+        internal Action<float> ValueOnChange { get; set; }
+        internal Action ValueOnReset { get; set; }
+    }
+
+    internal sealed class FloatTogglePropertyRowModel : RowModel
+    {
+        internal FloatTogglePropertyRowModel(string labelText)
+            : base(RowItemType.FloatToggleProperty, labelText)
+        {
+        }
+
+        internal float Value { get; set; }
+        internal float OriginalValue { get; set; }
+        internal float OffValue { get; set; }
+        internal float OnValue { get; set; } = 1f;
+        internal Action SelectInterpolable { get; set; }
+        internal Action<float> ValueOnChange { get; set; }
+        internal Action ValueOnReset { get; set; }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.RowModel.Properties.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowModel.Properties.cs
@@ -54,6 +54,7 @@ namespace MaterialEditorAPI
         internal float Value { get; set; }
         internal float OriginalValue { get; set; }
         internal IList<MaterialEditorEnumOption> Options { get; set; }
+        internal IList<float> CurrentValues { get; set; }
         internal Action SelectInterpolable { get; set; }
         internal Action<float> ValueOnChange { get; set; }
         internal Action ValueOnReset { get; set; }

--- a/src/MaterialEditor.Base/UI/UI.RowModel.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowModel.cs
@@ -14,6 +14,7 @@ namespace MaterialEditorAPI
 
         internal RowItemType ItemType { get; }
         internal string LabelText { get; set; }
+        internal bool IsAdvanced { get; set; }
         internal string TooltipText { get; set; }
         internal GameObject GameObject { get; set; }
         internal object Data { get; set; }

--- a/src/MaterialEditor.Base/UI/UI.RowModel.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowModel.cs
@@ -21,6 +21,7 @@ namespace MaterialEditorAPI
         internal Material Material { get; set; }
         internal Projector Projector { get; set; }
         internal string PropertyName { get; set; }
+        internal Action PresentationRefresh { get; set; }
         internal MaterialEditorPropertyDescriptor PublicDescriptor { get; set; }
 
         internal enum RowItemType
@@ -39,7 +40,9 @@ namespace MaterialEditorAPI
             TextureOffsetScale,
             ColorProperty,
             FloatProperty,
-            KeywordProperty
+            KeywordProperty,
+            EnumProperty,
+            FloatToggleProperty
         }
     }
 

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.FloatKeyword.cs
@@ -10,6 +10,8 @@ namespace MaterialEditorAPI
         {
             CreateFloatRow(parent);
             CreateKeywordRow(parent);
+            CreateEnumRow(parent);
+            CreateFloatToggleRow(parent);
         }
 
         private static void CreateFloatRow(Transform parent)
@@ -83,6 +85,79 @@ namespace MaterialEditorAPI
 
             var reset = MaterialEditorControlFactory.CreateButton(
                 "KeywordResetButton",
+                panel.transform,
+                "Reset");
+            RowViewFactorySupport.SetWidth(reset, ResetButtonWidth);
+            TooltipManager.AddTooltip(
+                reset.gameObject,
+                "Reset the selected property to its original value");
+        }
+
+        private static void CreateEnumRow(Transform parent)
+        {
+            var panel = RowViewFactorySupport.CreatePanel(
+                "EnumPanel",
+                parent,
+                ItemColor,
+                true);
+
+            var label = RowViewFactorySupport.CreateLabel(
+                "EnumLabel",
+                panel.transform,
+                string.Empty,
+                LabelWidth,
+                1f);
+            label.gameObject.AddComponent<LabelClickTrigger>();
+
+            RowViewFactorySupport.CreateInterpolableButton(
+                "SelectInterpolableEnumButton",
+                panel.transform,
+                "Select currently selected enum property as interpolable in timeline");
+
+            var dropdown = MaterialEditorControlFactory.CreateDropdown(
+                "EnumDropdown",
+                panel.transform);
+            RowViewFactorySupport.SetWidth(dropdown, ContentFullWidth);
+
+            var reset = MaterialEditorControlFactory.CreateButton(
+                "EnumResetButton",
+                panel.transform,
+                "Reset");
+            RowViewFactorySupport.SetWidth(reset, ResetButtonWidth);
+            TooltipManager.AddTooltip(
+                reset.gameObject,
+                "Reset the selected property to its original value");
+        }
+
+        private static void CreateFloatToggleRow(Transform parent)
+        {
+            var panel = RowViewFactorySupport.CreatePanel(
+                "FloatTogglePanel",
+                parent,
+                ItemColor,
+                true);
+
+            var label = RowViewFactorySupport.CreateLabel(
+                "FloatToggleLabel",
+                panel.transform,
+                string.Empty,
+                LabelWidth,
+                1f);
+            label.gameObject.AddComponent<LabelClickTrigger>();
+
+            RowViewFactorySupport.CreateInterpolableButton(
+                "SelectInterpolableFloatToggleButton",
+                panel.transform,
+                "Select currently selected toggle property as interpolable in timeline");
+
+            var toggle = MaterialEditorControlFactory.CreateToggle(
+                "FloatToggleToggle",
+                panel.transform,
+                string.Empty);
+            RowViewFactorySupport.SetWidth(toggle, KeywordToggleWidth);
+
+            var reset = MaterialEditorControlFactory.CreateButton(
+                "FloatToggleResetButton",
                 panel.transform,
                 "Reset");
             RowViewFactorySupport.SetWidth(reset, ResetButtonWidth);

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.FloatKeyword.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.FloatKeyword.cs
@@ -148,7 +148,7 @@ namespace MaterialEditorAPI
             RowViewFactorySupport.CreateInterpolableButton(
                 "SelectInterpolableFloatToggleButton",
                 panel.transform,
-                "Select currently selected toggle property as interpolable in timeline");
+                "Select currently selected Boolean property as interpolable in timeline");
 
             var toggle = MaterialEditorControlFactory.CreateToggle(
                 "FloatToggleToggle",

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.MaterialShader.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.MaterialShader.cs
@@ -100,6 +100,17 @@ namespace MaterialEditorAPI
                 panel.transform,
                 "Select the currently selected shader property and its render queue as interpolables in timeline");
 
+            var uiMode = MaterialEditorControlFactory.CreateButton(
+                "ShaderUiModeButton",
+                panel.transform,
+                "Basic");
+            RowViewFactorySupport.SetWidth(
+                uiMode,
+                MaterialEditorLayout.ShaderModeButtonWidth);
+            TooltipManager.AddTooltip(
+                uiMode.gameObject,
+                "Switch Basic/Advanced properties for this shader only");
+
             var dropdown = MaterialEditorControlFactory.CreateDropdown(
                 "ShaderDropdown",
                 panel.transform);

--- a/src/MaterialEditor.Base/UI/UI.RowViewFactory.cs
+++ b/src/MaterialEditor.Base/UI/UI.RowViewFactory.cs
@@ -1,3 +1,4 @@
+using UILib;
 using UnityEngine;
 using UnityEngine.UI;
 using static MaterialEditorAPI.MaterialEditorUI;
@@ -21,7 +22,32 @@ namespace MaterialEditorAPI
 
             RowStyle.Apply(contentList.gameObject);
             RowLayoutCatalog.Apply(contentList.gameObject);
+            CreateAdvancedPropertyAccent(contentList.transform);
             return contentList.gameObject;
+        }
+
+        private static void CreateAdvancedPropertyAccent(Transform parent)
+        {
+            var accent = MaterialEditorControlFactory.CreatePanel(
+                "AdvancedPropertyAccent",
+                parent);
+            accent.color = MaterialEditorStyles.AdvancedPropertyAccentColor;
+            accent.raycastTarget = false;
+            accent.transform.SetRect(
+                0f,
+                0f,
+                0f,
+                1f,
+                0f,
+                MaterialEditorLayout.AdvancedPropertyAccentVerticalInset,
+                MaterialEditorLayout.AdvancedPropertyAccentWidth,
+                -MaterialEditorLayout.AdvancedPropertyAccentVerticalInset);
+
+            var canvasGroup = accent.gameObject.AddComponent<CanvasGroup>();
+            canvasGroup.interactable = false;
+            canvasGroup.blocksRaycasts = false;
+            accent.transform.SetAsLastSibling();
+            accent.gameObject.SetActive(false);
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/UI.SessionState.cs
+++ b/src/MaterialEditor.Base/UI/UI.SessionState.cs
@@ -3,12 +3,6 @@ using UnityEngine;
 
 namespace MaterialEditorAPI
 {
-    internal enum MaterialEditorUiMode
-    {
-        Basic,
-        Advanced
-    }
-
     internal sealed class MaterialEditorSessionState
     {
         internal GameObject CurrentGameObject;
@@ -21,10 +15,11 @@ namespace MaterialEditorAPI
         internal readonly Dictionary<string, bool> CollapsedPropertyCategories = new Dictionary<string, bool>();
         internal readonly Dictionary<string, bool> CollapsedMaterialSections = new Dictionary<string, bool>();
         internal readonly Dictionary<string, bool> CollapsedShaderSections = new Dictionary<string, bool>();
+        internal readonly MaterialEditorShaderUiModeState ShaderUiModes =
+            new MaterialEditorShaderUiModeState();
 
         internal bool ListsVisible;
         internal bool RenameListVisible;
-        internal MaterialEditorUiMode UiMode = MaterialEditorUiMode.Basic;
 
         private bool _objExportPending;
         private Renderer _objRenderer;

--- a/src/MaterialEditor.Base/UI/UI.SessionState.cs
+++ b/src/MaterialEditor.Base/UI/UI.SessionState.cs
@@ -3,6 +3,12 @@ using UnityEngine;
 
 namespace MaterialEditorAPI
 {
+    internal enum MaterialEditorUiMode
+    {
+        Basic,
+        Advanced
+    }
+
     internal sealed class MaterialEditorSessionState
     {
         internal GameObject CurrentGameObject;
@@ -18,6 +24,7 @@ namespace MaterialEditorAPI
 
         internal bool ListsVisible;
         internal bool RenameListVisible;
+        internal MaterialEditorUiMode UiMode = MaterialEditorUiMode.Basic;
 
         private bool _objExportPending;
         private Renderer _objRenderer;

--- a/src/MaterialEditor.Base/UI/UI.ShaderUiMode.cs
+++ b/src/MaterialEditor.Base/UI/UI.ShaderUiMode.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace MaterialEditorAPI
+{
+    internal enum MaterialEditorUiMode
+    {
+        Basic,
+        Advanced
+    }
+
+    /// <summary>
+    /// Keeps the unpersisted Basic/Advanced preference independent for each
+    /// shader. Basic is represented by absence so the state stays compact.
+    /// </summary>
+    internal sealed class MaterialEditorShaderUiModeState
+    {
+        private readonly HashSet<string> _advancedShaders =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        internal MaterialEditorUiMode GetMode(string shaderName)
+        {
+            return !string.IsNullOrEmpty(shaderName)
+                   && _advancedShaders.Contains(shaderName)
+                ? MaterialEditorUiMode.Advanced
+                : MaterialEditorUiMode.Basic;
+        }
+
+        internal bool SetMode(string shaderName, MaterialEditorUiMode mode)
+        {
+            if (string.IsNullOrEmpty(shaderName))
+                return false;
+
+            return mode == MaterialEditorUiMode.Advanced
+                ? _advancedShaders.Add(shaderName)
+                : _advancedShaders.Remove(shaderName);
+        }
+    }
+
+    internal static class MaterialEditorAdvancedPropertyPresentation
+    {
+        internal const string Marker = "[A] ";
+
+        internal static string FormatLabel(string label, bool advanced)
+        {
+            var text = label ?? string.Empty;
+            return advanced ? Marker + text : text;
+        }
+    }
+}

--- a/src/MaterialEditor.Base/UI/UI.ShaderUiMode.cs
+++ b/src/MaterialEditor.Base/UI/UI.ShaderUiMode.cs
@@ -37,14 +37,4 @@ namespace MaterialEditorAPI
         }
     }
 
-    internal static class MaterialEditorAdvancedPropertyPresentation
-    {
-        internal const string Marker = "[A] ";
-
-        internal static string FormatLabel(string label, bool advanced)
-        {
-            var text = label ?? string.Empty;
-            return advanced ? Marker + text : text;
-        }
-    }
 }

--- a/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
+++ b/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
@@ -25,6 +25,7 @@ namespace MaterialEditorAPI
         internal const float RendererDropdownWidth = 94f;
         internal const float MaterialButtonWidth = ButtonWidth * 0.75f;
         internal const float MaterialRenameButtonWidth = SmallButtonWidth;
+        internal const float ShaderModeButtonWidth = 70f;
         internal const float ShaderDropdownWidth = ContentWidth;
         internal const float RenderQueueInputWidth = 94f;
         internal const float OffsetScaleLabelXWidth = 48f;

--- a/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
+++ b/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
@@ -36,6 +36,9 @@ namespace MaterialEditorAPI
         internal const float FloatSliderWidth = ContentWidth - 94f;
         internal const float FloatInputWidth = 94f;
         internal const float KeywordToggleWidth = ContentWidth;
+        internal const int DropdownFontSize = 16;
+        internal const int DropdownMinimumFontSize = 12;
+        internal const float DropdownTextVerticalInset = 1f;
 
         internal static readonly RectOffset RowPadding = new RectOffset(1, 1, 1, 1);
     }
@@ -201,10 +204,33 @@ namespace MaterialEditorAPI
             if (dropdown == null)
                 return;
 
-            ApplyText(dropdown.captionText, MaterialEditorTextRole.Input);
-            if (dropdown.itemText != null)
-                ApplyText(dropdown.itemText, MaterialEditorTextRole.Input);
+            ApplyDropdownText(dropdown.captionText);
+            ApplyDropdownText(dropdown.itemText);
             ApplyTypography(dropdown.gameObject);
+        }
+
+        private static void ApplyDropdownText(Text text)
+        {
+            if (text == null)
+                return;
+
+            ApplyText(text, MaterialEditorTextRole.Input);
+            text.fontSize = MaterialEditorLayout.DropdownFontSize;
+            text.resizeTextForBestFit = true;
+            text.resizeTextMinSize =
+                MaterialEditorLayout.DropdownMinimumFontSize;
+            text.resizeTextMaxSize = MaterialEditorLayout.DropdownFontSize;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+            text.verticalOverflow = VerticalWrapMode.Truncate;
+
+            var rect = text.rectTransform;
+            rect.offsetMin = new Vector2(
+                rect.offsetMin.x,
+                MaterialEditorLayout.DropdownTextVerticalInset);
+            rect.offsetMax = new Vector2(
+                rect.offsetMax.x,
+                -MaterialEditorLayout.DropdownTextVerticalInset);
+            text.SetVerticesDirty();
         }
 
         internal static void ApplyScrollView(ScrollRect scrollRect)

--- a/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
+++ b/src/MaterialEditor.Base/UI/UI.StyleSystem.cs
@@ -19,6 +19,8 @@ namespace MaterialEditorAPI
         internal const float ResetButtonWidth = SmallButtonWidth * 2f;
         internal const float InterpolableButtonWidth = SmallButtonWidth;
         internal const float ContentWidth = 316f;
+        internal const float AdvancedPropertyAccentWidth = 5f;
+        internal const float AdvancedPropertyAccentVerticalInset = 2f;
 
         internal const float RendererButtonWidth = ButtonWidth;
         internal const float RendererToggleWidth = 20f;
@@ -83,6 +85,8 @@ namespace MaterialEditorAPI
         internal static readonly Color ScrollbarColor = new Color(1f, 1f, 1f, 0.6f);
         internal static readonly Color ShaderHintUnderlineColor =
             new Color(0.05f, 0.45f, 1f, 1f);
+        internal static readonly Color AdvancedPropertyAccentColor =
+            new Color32(0x4A, 0xA3, 0xFF, 0xFF);
 
         internal static void ApplyPanel(Image panel, MaterialEditorPanelRole role)
         {

--- a/src/MaterialEditor.Base/UI/UI.WindowView.cs
+++ b/src/MaterialEditor.Base/UI/UI.WindowView.cs
@@ -11,12 +11,15 @@ namespace MaterialEditorAPI
         internal Canvas Window { get; private set; }
         internal Image MainPanel { get; private set; }
         internal Image HeaderPanel { get; private set; }
+        internal Image ModePanel { get; private set; }
         internal Text HeaderTitle { get; private set; }
         internal ScrollRect ScrollableUI { get; private set; }
         internal InputField FilterInputField { get; private set; }
         internal Button CategoryNavigatorButton { get; private set; }
         internal Button CollapseAllCategoriesButton { get; private set; }
         internal Button ViewListButton { get; private set; }
+        internal Button BasicModeButton { get; private set; }
+        internal Button AdvancedModeButton { get; private set; }
 
         internal SelectListPanel RendererList { get; private set; }
         internal SelectListPanel MaterialList { get; private set; }
@@ -34,12 +37,14 @@ namespace MaterialEditorAPI
             Action close,
             Action toggleSidePanels,
             Action toggleAllCategories,
+            Action<MaterialEditorUiMode> changeUiMode,
             Action<CategoryNavigationTarget> navigateToCategory,
             Action<CategoryNavigationTarget> toggleCategory)
         {
             Build(
                 owner, filter, refresh, close, toggleSidePanels,
-                toggleAllCategories, navigateToCategory, toggleCategory);
+                toggleAllCategories, changeUiMode,
+                navigateToCategory, toggleCategory);
         }
 
         internal void PrepareForDisplay(string filter)
@@ -117,6 +122,7 @@ namespace MaterialEditorAPI
             Action close,
             Action toggleSidePanels,
             Action toggleAllCategories,
+            Action<MaterialEditorUiMode> changeUiMode,
             Action<CategoryNavigationTarget> navigateToCategory,
             Action<CategoryNavigationTarget> toggleCategory)
         {
@@ -210,6 +216,44 @@ namespace MaterialEditorAPI
 
             MaterialEditorStyles.ApplyTypography(HeaderPanel.gameObject);
 
+            ModePanel = MaterialEditorControlFactory.CreatePanel(
+                "MaterialEditorModePanel",
+                MainPanel.transform,
+                MaterialEditorPanelRole.Header);
+            ModePanel.transform.SetRect(
+                0f, 1f, 1f, 1f,
+                0f,
+                -MaterialEditorLayout.HeaderHeight * 2f,
+                0f,
+                -MaterialEditorLayout.HeaderHeight);
+
+            BasicModeButton = MaterialEditorControlFactory.CreateButton(
+                "MaterialEditorBasicModeButton",
+                ModePanel.transform,
+                "Basic");
+            BasicModeButton.transform.SetRect(
+                0f, 0f, 0f, 1f,
+                1f, 1f, 66f, -1f);
+            BasicModeButton.onClick.AddListener(
+                () => changeUiMode(MaterialEditorUiMode.Basic));
+            TooltipManager.AddTooltip(
+                BasicModeButton.gameObject,
+                "Show commonly used material properties.");
+
+            AdvancedModeButton = MaterialEditorControlFactory.CreateButton(
+                "MaterialEditorAdvancedModeButton",
+                ModePanel.transform,
+                "Advanced");
+            AdvancedModeButton.transform.SetRect(
+                0f, 0f, 0f, 1f,
+                67f, 1f, 147f, -1f);
+            AdvancedModeButton.onClick.AddListener(
+                () => changeUiMode(MaterialEditorUiMode.Advanced));
+            TooltipManager.AddTooltip(
+                AdvancedModeButton.gameObject,
+                "Show all material properties.");
+            MaterialEditorStyles.ApplyTypography(ModePanel.gameObject);
+
             ScrollableUI = MaterialEditorControlFactory.CreateScrollView("MaterialEditorWindow", MainPanel.transform);
             ScrollableUI.transform.SetRect(
                 0f,
@@ -219,7 +263,8 @@ namespace MaterialEditorAPI
                 MaterialEditorLayout.Margin,
                 MaterialEditorLayout.Margin,
                 -MaterialEditorLayout.Margin,
-                -MaterialEditorLayout.HeaderHeight - MaterialEditorLayout.Margin / 2f);
+                -MaterialEditorLayout.HeaderHeight * 2f
+                - MaterialEditorLayout.Margin / 2f);
             ScrollableUI.gameObject.AddComponent<Mask>();
             ScrollableUI.content.gameObject.AddComponent<VerticalLayoutGroup>();
             ScrollableUI.content.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
@@ -253,6 +298,14 @@ namespace MaterialEditorAPI
                 presentation != null && presentation.AllCategoriesCollapsed
                     ? FoldGlyphs.AllExpanded
                     : FoldGlyphs.AllCollapsed;
+        }
+
+        internal void SetUiMode(MaterialEditorUiMode mode)
+        {
+            if (BasicModeButton != null)
+                BasicModeButton.interactable = mode != MaterialEditorUiMode.Basic;
+            if (AdvancedModeButton != null)
+                AdvancedModeButton.interactable = mode != MaterialEditorUiMode.Advanced;
         }
 
         private void ToggleCategoryNavigator()

--- a/src/MaterialEditor.Base/UI/UI.WindowView.cs
+++ b/src/MaterialEditor.Base/UI/UI.WindowView.cs
@@ -11,15 +11,12 @@ namespace MaterialEditorAPI
         internal Canvas Window { get; private set; }
         internal Image MainPanel { get; private set; }
         internal Image HeaderPanel { get; private set; }
-        internal Image ModePanel { get; private set; }
         internal Text HeaderTitle { get; private set; }
         internal ScrollRect ScrollableUI { get; private set; }
         internal InputField FilterInputField { get; private set; }
         internal Button CategoryNavigatorButton { get; private set; }
         internal Button CollapseAllCategoriesButton { get; private set; }
         internal Button ViewListButton { get; private set; }
-        internal Button BasicModeButton { get; private set; }
-        internal Button AdvancedModeButton { get; private set; }
 
         internal SelectListPanel RendererList { get; private set; }
         internal SelectListPanel MaterialList { get; private set; }
@@ -37,13 +34,12 @@ namespace MaterialEditorAPI
             Action close,
             Action toggleSidePanels,
             Action toggleAllCategories,
-            Action<MaterialEditorUiMode> changeUiMode,
             Action<CategoryNavigationTarget> navigateToCategory,
             Action<CategoryNavigationTarget> toggleCategory)
         {
             Build(
                 owner, filter, refresh, close, toggleSidePanels,
-                toggleAllCategories, changeUiMode,
+                toggleAllCategories,
                 navigateToCategory, toggleCategory);
         }
 
@@ -122,7 +118,6 @@ namespace MaterialEditorAPI
             Action close,
             Action toggleSidePanels,
             Action toggleAllCategories,
-            Action<MaterialEditorUiMode> changeUiMode,
             Action<CategoryNavigationTarget> navigateToCategory,
             Action<CategoryNavigationTarget> toggleCategory)
         {
@@ -216,44 +211,6 @@ namespace MaterialEditorAPI
 
             MaterialEditorStyles.ApplyTypography(HeaderPanel.gameObject);
 
-            ModePanel = MaterialEditorControlFactory.CreatePanel(
-                "MaterialEditorModePanel",
-                MainPanel.transform,
-                MaterialEditorPanelRole.Header);
-            ModePanel.transform.SetRect(
-                0f, 1f, 1f, 1f,
-                0f,
-                -MaterialEditorLayout.HeaderHeight * 2f,
-                0f,
-                -MaterialEditorLayout.HeaderHeight);
-
-            BasicModeButton = MaterialEditorControlFactory.CreateButton(
-                "MaterialEditorBasicModeButton",
-                ModePanel.transform,
-                "Basic");
-            BasicModeButton.transform.SetRect(
-                0f, 0f, 0f, 1f,
-                1f, 1f, 66f, -1f);
-            BasicModeButton.onClick.AddListener(
-                () => changeUiMode(MaterialEditorUiMode.Basic));
-            TooltipManager.AddTooltip(
-                BasicModeButton.gameObject,
-                "Show commonly used material properties.");
-
-            AdvancedModeButton = MaterialEditorControlFactory.CreateButton(
-                "MaterialEditorAdvancedModeButton",
-                ModePanel.transform,
-                "Advanced");
-            AdvancedModeButton.transform.SetRect(
-                0f, 0f, 0f, 1f,
-                67f, 1f, 147f, -1f);
-            AdvancedModeButton.onClick.AddListener(
-                () => changeUiMode(MaterialEditorUiMode.Advanced));
-            TooltipManager.AddTooltip(
-                AdvancedModeButton.gameObject,
-                "Show all material properties.");
-            MaterialEditorStyles.ApplyTypography(ModePanel.gameObject);
-
             ScrollableUI = MaterialEditorControlFactory.CreateScrollView("MaterialEditorWindow", MainPanel.transform);
             ScrollableUI.transform.SetRect(
                 0f,
@@ -263,7 +220,7 @@ namespace MaterialEditorAPI
                 MaterialEditorLayout.Margin,
                 MaterialEditorLayout.Margin,
                 -MaterialEditorLayout.Margin,
-                -MaterialEditorLayout.HeaderHeight * 2f
+                -MaterialEditorLayout.HeaderHeight
                 - MaterialEditorLayout.Margin / 2f);
             ScrollableUI.gameObject.AddComponent<Mask>();
             ScrollableUI.content.gameObject.AddComponent<VerticalLayoutGroup>();
@@ -298,14 +255,6 @@ namespace MaterialEditorAPI
                 presentation != null && presentation.AllCategoriesCollapsed
                     ? FoldGlyphs.AllExpanded
                     : FoldGlyphs.AllCollapsed;
-        }
-
-        internal void SetUiMode(MaterialEditorUiMode mode)
-        {
-            if (BasicModeButton != null)
-                BasicModeButton.interactable = mode != MaterialEditorUiMode.Basic;
-            if (AdvancedModeButton != null)
-                AdvancedModeButton.interactable = mode != MaterialEditorUiMode.Advanced;
         }
 
         private void ToggleCategoryNavigator()

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -32,11 +32,17 @@ namespace MaterialEditorAPI
         public static Image DragPanel;
         private static readonly MaterialEditorSessionState Session = new MaterialEditorSessionState();
         private static MaterialEditorWindowView ActiveView;
+        private static MaterialEditorUI ActiveUi;
 
         private MaterialEditorWindowView _windowView;
         private MaterialEditorSelectionController _selectionController;
         private MaterialEditorPresenter _presenter;
         private MaterialEditorPresentation _presentation;
+        private Coroutine _conditionRefreshCoroutine;
+        private int _conditionRefreshVersion;
+        private GameObject _conditionRefreshGameObject;
+        private object _conditionRefreshData;
+        private string _conditionRefreshFilter;
 
         private static readonly List<Action<MaterialEditorLabelClickEventArgs>> LabelClickHandlers = new List<Action<MaterialEditorLabelClickEventArgs>>();
 
@@ -169,6 +175,7 @@ namespace MaterialEditorAPI
         /// </summary>
         protected void InitUI()
         {
+            ActiveUi = this;
             MaterialEditorExtensionRegistry.SetActiveEditService(EditService);
             _windowView = new MaterialEditorWindowView(
                 transform,
@@ -177,8 +184,10 @@ namespace MaterialEditorAPI
                 () => Visible = false,
                 () => _selectionController.ToggleSidePanels(),
                 ToggleAllCategories,
+                ChangeUiMode,
                 NavigateToCategory,
                 ToggleCategory);
+            _windowView.SetUiMode(Session.UiMode);
             _selectionController = new MaterialEditorSelectionController(
                 Session,
                 _windowView,
@@ -192,6 +201,7 @@ namespace MaterialEditorAPI
                     Refresh = PopulateList,
                     RefreshDeferred = (go, data, filter) =>
                         StartCoroutine(PopulateListCoroutine(go, data, filter)),
+                    RefreshConditionsDeferred = ScheduleConditionRefresh,
                     RefreshMaterialSelection = PopulateMaterialList,
                     ShowRename = PopulateRenameList,
                     ExportUv = Export.ExportUVMaps,
@@ -245,7 +255,10 @@ namespace MaterialEditorAPI
                 if (MaterialEditorWindow != null)
                     MaterialEditorWindow.gameObject.SetActive(value);
                 if (!value)
+                {
+                    ActiveUi?.CancelConditionRefresh();
                     TexChangeWatcher?.Dispose();
+                }
             }
         }
 
@@ -306,6 +319,7 @@ namespace MaterialEditorAPI
         /// <param name="filter">Comma separated list of text to filter the results</param>
         protected void PopulateList(GameObject go, object data, string filter = null)
         {
+            CancelConditionRefresh();
             _selectionController.CloseRenamePanel();
 
             if (filter == null)
@@ -326,6 +340,76 @@ namespace MaterialEditorAPI
             _presentation = _presenter.BuildRows(go, data, filter, renderers, projectors);
             VirtualList.SetList(_presentation.Rows);
             _windowView.SetPresentation(_presentation);
+        }
+
+        private void ScheduleConditionRefresh(
+            GameObject go,
+            object data,
+            string filter)
+        {
+            if (!IsCurrentConditionRefreshContext(go, data, filter))
+                return;
+
+            _conditionRefreshGameObject = go;
+            _conditionRefreshData = data;
+            _conditionRefreshFilter = filter;
+            _conditionRefreshVersion++;
+
+            if (_conditionRefreshCoroutine != null)
+                return;
+            _conditionRefreshCoroutine =
+                StartCoroutine(ConditionRefreshWorker());
+        }
+
+        private IEnumerator ConditionRefreshWorker()
+        {
+            int scheduledVersion;
+            do
+            {
+                scheduledVersion = _conditionRefreshVersion;
+                yield return null;
+            }
+            while (scheduledVersion != _conditionRefreshVersion);
+
+            var go = _conditionRefreshGameObject;
+            var data = _conditionRefreshData;
+            var filter = _conditionRefreshFilter;
+            _conditionRefreshCoroutine = null;
+            _conditionRefreshGameObject = null;
+            _conditionRefreshData = null;
+            _conditionRefreshFilter = null;
+
+            if (!IsCurrentConditionRefreshContext(go, data, filter))
+                yield break;
+            PopulateList(go, data, filter);
+        }
+
+        private bool IsCurrentConditionRefreshContext(
+            GameObject go,
+            object data,
+            string filter)
+        {
+            return Visible
+                   && go != null
+                   && ReferenceEquals(go, CurrentGameObject)
+                   && ReferenceEquals(data, CurrentData)
+                   && string.Equals(
+                       filter,
+                       CurrentFilter,
+                       StringComparison.Ordinal);
+        }
+
+        private void CancelConditionRefresh()
+        {
+            _conditionRefreshVersion++;
+            _conditionRefreshGameObject = null;
+            _conditionRefreshData = null;
+            _conditionRefreshFilter = null;
+
+            var coroutine = _conditionRefreshCoroutine;
+            _conditionRefreshCoroutine = null;
+            if (coroutine != null)
+                StopCoroutine(coroutine);
         }
 
         private void NavigateToCategory(CategoryNavigationTarget target)
@@ -352,6 +436,16 @@ namespace MaterialEditorAPI
 
             _presentation.SetAllCategoriesCollapsed(
                 !_presentation.AllCategoriesCollapsed);
+            PopulateList(CurrentGameObject, CurrentData, CurrentFilter);
+        }
+
+        private void ChangeUiMode(MaterialEditorUiMode mode)
+        {
+            if (Session.UiMode == mode)
+                return;
+
+            Session.UiMode = mode;
+            _windowView.SetUiMode(mode);
             PopulateList(CurrentGameObject, CurrentData, CurrentFilter);
         }
 

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -184,10 +184,8 @@ namespace MaterialEditorAPI
                 () => Visible = false,
                 () => _selectionController.ToggleSidePanels(),
                 ToggleAllCategories,
-                ChangeUiMode,
                 NavigateToCategory,
                 ToggleCategory);
-            _windowView.SetUiMode(Session.UiMode);
             _selectionController = new MaterialEditorSelectionController(
                 Session,
                 _windowView,
@@ -436,16 +434,6 @@ namespace MaterialEditorAPI
 
             _presentation.SetAllCategoriesCollapsed(
                 !_presentation.AllCategoriesCollapsed);
-            PopulateList(CurrentGameObject, CurrentData, CurrentFilter);
-        }
-
-        private void ChangeUiMode(MaterialEditorUiMode mode)
-        {
-            if (Session.UiMode == mode)
-                return;
-
-            Session.UiMode = mode;
-            _windowView.SetUiMode(mode);
             PopulateList(CurrentGameObject, CurrentData, CurrentFilter);
         }
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.Shaders.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.Shaders.cs
@@ -98,6 +98,14 @@ namespace KK_Plugins.MaterialEditor
             string sourceId)
         {
             if (materialEditorElement == null) return;
+            Action<string> metadataWarning = message => Logger.LogWarning(
+                "Material Editor metadata in '"
+                + (sourceId ?? "unknown source")
+                + "': "
+                + message);
+            var schemaVersion = ShaderPropertyMetadataParser.ReadSchemaVersion(
+                materialEditorElement,
+                metadataWarning);
             var tooltipCatalog = LoadTooltipCatalogs(
                 materialEditorElement,
                 sourceId ?? "unknown source");
@@ -108,65 +116,80 @@ namespace KK_Plugins.MaterialEditor
                 {
                     var shaderElement = (XmlElement)shaderElementObj;
                     string shaderName = shaderElement.GetAttribute("Name");
-                    var shaderMetadata = tooltipCatalog.ResolveShader(shaderName);
-                    ShaderUiMetadataRegistry.SetShader(shaderName, shaderMetadata);
-
-                    if (LoadedShaders.ContainsKey(shaderName))
+                    var isReservedDefault =
+                        ShaderPropertyFallbackPolicy.IsReservedShaderName(shaderName);
+                    Shader shader = null;
+                    if (isReservedDefault)
                     {
-                        Destroy(LoadedShaders[shaderName].Shader);
-                        LoadedShaders.Remove(shaderName);
+                        metadataWarning(
+                            "Shader Name 'default' is reserved; its properties "
+                            + "will be merged into the global legacy fallback "
+                            + "without shader-specific metadata.");
                     }
-                    var shader = LoadShader(shaderName, shaderElement.GetAttribute("AssetBundle"), shaderElement.GetAttribute("Asset"));
-                    LoadedShaders[shaderName] = new ShaderData(shader, shaderName, shaderElement.GetAttribute("RenderQueue"), shaderElement.GetAttribute("ShaderOptimization"));
-
-                    XMLShaderProperties[shaderName] = new Dictionary<string, ShaderPropertyData>();
-                    if (shader != null && shader.name != shaderName)
+                    else
                     {
-                        XMLShaderProperties[shader.name] = new Dictionary<string, ShaderPropertyData>();
-                        ShaderUiMetadataRegistry.SetShader(shader.name, shaderMetadata);
+                        var shaderMetadata = tooltipCatalog.ResolveShader(shaderName);
+                        ShaderUiMetadataRegistry.SetShader(shaderName, shaderMetadata);
+
+                        if (LoadedShaders.ContainsKey(shaderName))
+                        {
+                            Destroy(LoadedShaders[shaderName].Shader);
+                            LoadedShaders.Remove(shaderName);
+                        }
+                        shader = LoadShader(
+                            shaderName,
+                            shaderElement.GetAttribute("AssetBundle"),
+                            shaderElement.GetAttribute("Asset"));
+                        LoadedShaders[shaderName] = new ShaderData(
+                            shader,
+                            shaderName,
+                            shaderElement.GetAttribute("RenderQueue"),
+                            shaderElement.GetAttribute("ShaderOptimization"));
+
+                        XMLShaderProperties[shaderName] =
+                            new Dictionary<string, ShaderPropertyData>();
+                        if (shader != null && shader.name != shaderName)
+                        {
+                            XMLShaderProperties[shader.name] =
+                                new Dictionary<string, ShaderPropertyData>();
+                            ShaderUiMetadataRegistry.SetShader(
+                                shader.name,
+                                shaderMetadata);
+                        }
                     }
 
                     var shaderPropertyElements = shaderElement.GetElementsByTagName("Property");
+                    var declarationOrder = 0;
                     foreach (var shaderPropertyElementObj in shaderPropertyElements)
                     {
                         if (shaderPropertyElementObj != null)
                         {
                             var shaderPropertyElement = (XmlElement)shaderPropertyElementObj;
-
-                            string propertyName = shaderPropertyElement.GetAttribute("Name");
-                            ShaderPropertyType propertyType = (ShaderPropertyType)Enum.Parse(typeof(ShaderPropertyType), shaderPropertyElement.GetAttribute("Type"));
-                            string defaultValue = shaderPropertyElement.GetAttribute("DefaultValue");
-                            string defaultValueAB = shaderPropertyElement.GetAttribute("DefaultValueAssetBundle");
-                            string anisoLevel = shaderPropertyElement.GetAttribute("AnisoLevel");
-                            string filterMode = shaderPropertyElement.GetAttribute("FilterMode");
-                            string wrapMode = shaderPropertyElement.GetAttribute("WrapMode");
-                            string range = shaderPropertyElement.GetAttribute("Range");
-                            string min = null;
-                            string max = null;
-                            if (!range.IsNullOrWhiteSpace())
+                            ShaderPropertyData shaderPropertyData;
+                            if (!ShaderPropertyData.TryParse(
+                                    shaderPropertyElement,
+                                    metadataWarning,
+                                    out shaderPropertyData,
+                                    schemaVersion))
                             {
-                                var rangeSplit = range.Split(',');
-                                if (rangeSplit.Length == 2)
+                                declarationOrder++;
+                                continue;
+                            }
+
+                            shaderPropertyData.DeclarationOrder = declarationOrder++;
+                            ShaderPropertyFallbackPolicy.MergeInto(
+                                XMLShaderProperties["default"],
+                                shaderPropertyData);
+                            if (!isReservedDefault)
+                            {
+                                XMLShaderProperties[shaderName][shaderPropertyData.Name] =
+                                    shaderPropertyData;
+                                if (shader != null && shader.name != shaderName)
                                 {
-                                    min = rangeSplit[0];
-                                    max = rangeSplit[1];
+                                    XMLShaderProperties[shader.name][shaderPropertyData.Name] =
+                                        shaderPropertyData;
                                 }
                             }
-                            string hidden = shaderPropertyElement.GetAttribute("Hidden");
-                            string category = shaderPropertyElement.GetAttribute("Category");
-
-                            ShaderPropertyData shaderPropertyData = new ShaderPropertyData(
-                                propertyName, propertyType,
-                                defaultValue, defaultValueAB,
-                                anisoLevel, filterMode, wrapMode,
-                                min, max,
-                                hidden, category
-                            );
-
-                            XMLShaderProperties["default"][propertyName] = shaderPropertyData;
-                            XMLShaderProperties[shaderName][propertyName] = shaderPropertyData;
-                            if (shader != null && shader.name != shaderName)
-                                XMLShaderProperties[shader.name][propertyName] = shaderPropertyData;
                         }
                     }
                 }

--- a/tests/MaterialEditor.MetadataTests/ConditionDeferredRefreshTests.cs
+++ b/tests/MaterialEditor.MetadataTests/ConditionDeferredRefreshTests.cs
@@ -1,0 +1,191 @@
+internal static class ConditionDeferredRefreshTests
+{
+    internal static void Run()
+    {
+        var root = FindRepositoryRoot();
+        var uiSource = ReadSource(root, "src", "MaterialEditor.Base", "UI", "UI.cs");
+        var actionsSource = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.MaterialEditorPresenter.cs");
+        var materialSource = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.MaterialSectionPresenter.cs");
+
+        Contains(
+            actionsSource,
+            "RefreshConditionsDeferred",
+            "condition refresh has a dedicated internal action");
+        Contains(
+            uiSource,
+            "RefreshDeferred = (go, data, filter) =>\n                        StartCoroutine(PopulateListCoroutine(go, data, filter))",
+            "shader refresh retains the protected ten-frame coroutine");
+        Contains(
+            uiSource,
+            "RefreshConditionsDeferred = ScheduleConditionRefresh",
+            "ShowIf refresh uses the coalescing coordinator");
+        Equal(
+            2,
+            CountOccurrences(materialSource, "_actions.RefreshDeferred("),
+            "only shader change/reset use the legacy deferred refresh");
+        Equal(
+            1,
+            CountOccurrences(
+                materialSource,
+                "_actions.RefreshConditionsDeferred("),
+            "condition sources use only the dedicated refresh action");
+
+        var schedule = ExtractMethod(
+            uiSource,
+            "private void ScheduleConditionRefresh(");
+        Contains(
+            schedule,
+            "if (!IsCurrentConditionRefreshContext(go, data, filter))",
+            "stale targets are rejected before scheduling");
+        var latestAssignment = schedule.IndexOf(
+            "_conditionRefreshGameObject = go;",
+            StringComparison.Ordinal);
+        var workerGuard = schedule.IndexOf(
+            "if (_conditionRefreshCoroutine != null)",
+            StringComparison.Ordinal);
+        Equal(
+            true,
+            latestAssignment >= 0 && workerGuard > latestAssignment,
+            "latest request replaces pending data before the single-worker guard");
+        Equal(
+            1,
+            CountOccurrences(uiSource, "StartCoroutine(ConditionRefreshWorker())"),
+            "condition refresh has one worker start site");
+
+        var worker = ExtractMethod(
+            uiSource,
+            "private IEnumerator ConditionRefreshWorker(");
+        Contains(
+            worker,
+            "while (scheduledVersion != _conditionRefreshVersion);",
+            "worker waits for one stable frame and coalesces newer requests");
+        Contains(
+            worker,
+            "if (!IsCurrentConditionRefreshContext(go, data, filter))",
+            "worker revalidates target/data/filter before applying");
+        Contains(
+            worker,
+            "_conditionRefreshCoroutine = null;",
+            "worker releases its gate before synchronous population");
+
+        var contextGuard = ExtractMethod(
+            uiSource,
+            "private bool IsCurrentConditionRefreshContext(");
+        Contains(contextGuard, "return Visible", "closed UI rejects refresh");
+        Contains(contextGuard, "go != null", "destroyed target rejects refresh");
+        Contains(
+            contextGuard,
+            "ReferenceEquals(go, CurrentGameObject)",
+            "refresh requires the exact current GameObject");
+        Contains(
+            contextGuard,
+            "ReferenceEquals(data, CurrentData)",
+            "refresh requires the exact current data context");
+        Contains(
+            contextGuard,
+            "CurrentFilter,\n                       StringComparison.Ordinal",
+            "refresh requires the current filter context");
+
+        var populate = ExtractMethod(
+            uiSource,
+            "protected void PopulateList(");
+        Contains(
+            populate,
+            "CancelConditionRefresh();",
+            "synchronous population cancels pending condition refresh");
+        Contains(
+            uiSource,
+            "ActiveUi?.CancelConditionRefresh();",
+            "closing the Material Editor cancels pending condition refresh");
+
+        var legacyCoroutine = ExtractMethod(
+            uiSource,
+            "protected IEnumerator PopulateListCoroutine(");
+        Equal(
+            10,
+            CountOccurrences(legacyCoroutine, "yield return null;"),
+            "protected shader dropdown delay remains ten frames");
+        Contains(
+            legacyCoroutine,
+            "PopulateList(go, data, filter);",
+            "protected deferred API retains its existing population behavior");
+    }
+
+    private static string ReadSource(string root, params string[] parts)
+    {
+        var path = parts.Aggregate(root, Path.Combine);
+        return File.ReadAllText(path).Replace("\r\n", "\n");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (var start in new[]
+                 {
+                     Directory.GetCurrentDirectory(),
+                     AppContext.BaseDirectory
+                 })
+        {
+            var directory = new DirectoryInfo(start);
+            while (directory != null)
+            {
+                if (File.Exists(Path.Combine(
+                        directory.FullName,
+                        "tests",
+                        "MaterialEditor.MetadataTests",
+                        "MaterialEditor.MetadataTests.csproj")))
+                    return directory.FullName;
+                directory = directory.Parent;
+            }
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root.");
+    }
+
+    private static string ExtractMethod(string source, string signature)
+    {
+        var signatureIndex = source.IndexOf(signature, StringComparison.Ordinal);
+        if (signatureIndex < 0)
+            throw new InvalidOperationException("Method not found: " + signature);
+        var openingBrace = source.IndexOf('{', signatureIndex);
+        var depth = 0;
+        for (var index = openingBrace; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+                depth++;
+            else if (source[index] == '}' && --depth == 0)
+                return source.Substring(openingBrace, index - openingBrace + 1);
+        }
+        throw new InvalidOperationException("Unterminated method: " + signature);
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
+
+    private static void Contains(string source, string value, string name) =>
+        Equal(true, source.Contains(value, StringComparison.Ordinal), name);
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            throw new InvalidOperationException(
+                name + ": expected '" + expected + "', got '" + actual + "'.");
+    }
+}

--- a/tests/MaterialEditor.MetadataTests/ConditionDeferredRefreshTests.cs
+++ b/tests/MaterialEditor.MetadataTests/ConditionDeferredRefreshTests.cs
@@ -23,7 +23,7 @@ internal static class ConditionDeferredRefreshTests
             "condition refresh has a dedicated internal action");
         Contains(
             uiSource,
-            "RefreshDeferred = (go, data, filter) =>\n                        StartCoroutine(PopulateListCoroutine(go, data, filter))",
+            "StartCoroutine(PopulateListCoroutine(go, data, filter))",
             "shader refresh retains the protected ten-frame coroutine");
         Contains(
             uiSource,

--- a/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
+++ b/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
@@ -13,6 +13,7 @@ internal static class ManifestSchemaV2Tests
         EnumSelectionUsesDeclaredValuesAndPreservesSpecialStates();
         ExplicitMixedEnumSelectionRecreatesThePersistedOverride();
         BooleanValuesRoundTripAsFloatZeroOrOne();
+        BindingDoesNotWriteWhileOpeningOrRefreshing();
         ShowIfSupportsTheDocumentedFormsAndFailsOpen();
     }
 
@@ -258,6 +259,40 @@ internal static class ManifestSchemaV2Tests
         Equal(0.25f, declared[decimalSelection.OptionIndex].Value,
             "dropdown writes the declared numeric value, not its index");
 
+        var declaredNegativeSelection =
+            MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                declared,
+                new[] { -3f });
+        Equal(
+            MaterialEditorEnumValueState.Matched,
+            declaredNegativeSelection.State,
+            "declared negative enum value matches directly");
+        Equal(0, declaredNegativeSelection.OptionIndex,
+            "declared negative enum option index");
+
+        const float nearButDifferent = 0.25000003f;
+        var nearSelection =
+            MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                declared,
+                new[] { nearButDifferent });
+        Equal(
+            MaterialEditorEnumValueState.Unmatched,
+            nearSelection.State,
+            "nearby float is not an exact enum match");
+        Equal(-1, nearSelection.OptionIndex,
+            "nearby float has no enum option index");
+        Equal(nearButDifferent, nearSelection.CurrentValue,
+            "nearby float remains unchanged");
+
+        var nearMixed =
+            MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                declared,
+                new[] { 0.25f, nearButDifferent });
+        Equal(
+            MaterialEditorEnumValueState.Mixed,
+            nearMixed.State,
+            "nearby values on different materials remain distinct");
+
         var unmatched =
             MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
                 declared,
@@ -269,6 +304,22 @@ internal static class ManifestSchemaV2Tests
         Equal(-1, unmatched.OptionIndex, "unmatched enum has no option index");
         Equal(0.75f, unmatched.CurrentValue,
             "unmatched enum preserves the current float");
+
+        foreach (var unknown in new[] { -99f, 99f })
+        {
+            var unknownSelection =
+                MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                    declared,
+                    new[] { unknown });
+            Equal(
+                MaterialEditorEnumValueState.Unmatched,
+                unknownSelection.State,
+                "unknown enum value remains unmatched " + unknown);
+            Equal(-1, unknownSelection.OptionIndex,
+                "unknown enum value has no option index " + unknown);
+            Equal(unknown, unknownSelection.CurrentValue,
+                "unknown enum value remains intact " + unknown);
+        }
 
         var mixed = MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
             declared,
@@ -307,8 +358,7 @@ internal static class ManifestSchemaV2Tests
         Action<float> legacySetOverride = value =>
         {
             calls.Add("set");
-            if (overrideExists &&
-                MaterialEditorFloatBackedValuePolicy.Approximately(value, original))
+            if (overrideExists && value == original)
             {
                 overrideExists = false;
                 return;
@@ -349,6 +399,11 @@ internal static class ManifestSchemaV2Tests
             MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(-2f, false),
             "legacy non-zero Float reads as enabled without being rewritten");
         True(
+            MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(
+                0.00000001f,
+                false),
+            "small non-zero Float reads directly as enabled without normalization");
+        True(
             MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(0f, true),
             "Invert reverses the displayed state");
 
@@ -381,6 +436,57 @@ internal static class ManifestSchemaV2Tests
                     false),
                 "Boolean Float round-trip " + displayValue);
         }
+    }
+
+    private static void BindingDoesNotWriteWhileOpeningOrRefreshing()
+    {
+        var root = FindRepositoryRoot();
+        var binder = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowBinder.FloatKeyword.cs");
+
+        var bindEnum = ExtractMethod(binder, "private void BindEnum(");
+        var enumListener = bindEnum.IndexOf(
+            "listeners.Listen(controls.Dropdown",
+            StringComparison.Ordinal);
+        True(enumListener > 0, "Enum listener is present");
+        var enumInitialization = bindEnum.Substring(0, enumListener);
+        Contains(enumInitialization, "controls.Dropdown.Set(selectedIndex);",
+            "Enum initializes the dropdown without a user event");
+        Contains(enumInitialization, "rebuild();\n            refresh();",
+            "Enum draws current state before registering its listener");
+        DoesNotContain(enumInitialization, "item.ValueOnChange",
+            "opening or refreshing Enum does not write a value");
+        DoesNotContain(enumInitialization, "item.ValueOnReset",
+            "opening or refreshing Enum does not reset a value");
+        DoesNotContain(enumInitialization, "item.Value =",
+            "opening or refreshing Enum preserves the material value");
+        Contains(bindEnum, "optionValues.Add(option.Value);",
+            "Enum dropdown stores each declared value directly");
+        Contains(bindEnum, "var value = optionValues[index];",
+            "Enum selection reads the declared value instead of its index");
+
+        var bindBoolean = ExtractMethod(binder, "private void BindFloatToggle(");
+        var booleanListener = bindBoolean.IndexOf(
+            "listeners.Listen(controls.Toggle",
+            StringComparison.Ordinal);
+        True(booleanListener > 0, "Boolean listener is present");
+        var booleanInitialization = bindBoolean.Substring(0, booleanListener);
+        Contains(booleanInitialization, "controls.Toggle.Set(",
+            "Boolean draws its existing material value");
+        Contains(booleanInitialization, "false);",
+            "Boolean initialization suppresses change notification");
+        DoesNotContain(booleanInitialization, "item.ValueOnChange",
+            "opening or refreshing Boolean does not write a value");
+        DoesNotContain(booleanInitialization, "item.ValueOnReset",
+            "opening or refreshing Boolean does not reset a value");
+        DoesNotContain(booleanInitialization, "item.Value =",
+            "opening or refreshing Boolean preserves the material value");
+        Contains(bindBoolean, "GetBooleanStoredValue(",
+            "Boolean user changes use the zero-or-one storage policy");
     }
 
     private static void ShowIfSupportsTheDocumentedFormsAndFailsOpen()
@@ -481,6 +587,52 @@ internal static class ManifestSchemaV2Tests
             ?? throw new InvalidOperationException("XML has no root element.");
     }
 
+    private static string ReadSource(string root, params string[] parts)
+    {
+        var path = parts.Aggregate(root, Path.Combine);
+        return File.ReadAllText(path).Replace("\r\n", "\n");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (var start in new[]
+                 {
+                     Directory.GetCurrentDirectory(),
+                     AppContext.BaseDirectory
+                 })
+        {
+            var directory = new DirectoryInfo(start);
+            while (directory != null)
+            {
+                if (File.Exists(Path.Combine(
+                        directory.FullName,
+                        "tests",
+                        "MaterialEditor.MetadataTests",
+                        "MaterialEditor.MetadataTests.csproj")))
+                    return directory.FullName;
+                directory = directory.Parent;
+            }
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root.");
+    }
+
+    private static string ExtractMethod(string source, string signature)
+    {
+        var signatureIndex = source.IndexOf(signature, StringComparison.Ordinal);
+        if (signatureIndex < 0)
+            throw new InvalidOperationException("Method not found: " + signature);
+        var openingBrace = source.IndexOf('{', signatureIndex);
+        var depth = 0;
+        for (var index = openingBrace; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+                depth++;
+            else if (source[index] == '}' && --depth == 0)
+                return source.Substring(openingBrace, index - openingBrace + 1);
+        }
+        throw new InvalidOperationException("Unterminated method: " + signature);
+    }
+
     private static void Alias(
         string declaredType,
         string expectedType,
@@ -553,6 +705,16 @@ internal static class ManifestSchemaV2Tests
     private static void False(bool value, string name)
     {
         Equal(false, value, name);
+    }
+
+    private static void Contains(string source, string value, string name)
+    {
+        True(source.Contains(value, StringComparison.Ordinal), name);
+    }
+
+    private static void DoesNotContain(string source, string value, string name)
+    {
+        False(source.Contains(value, StringComparison.Ordinal), name);
     }
 
     private static void Equal<T>(T expected, T actual, string name)

--- a/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
+++ b/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
@@ -8,7 +8,11 @@ internal static class ManifestSchemaV2Tests
         SchemaVersionTwoIsAnExplicitCompatibilityGate();
         SchemaTwoMetadataIsParsedWithSafeDefaults();
         FloatBackedAliasesAreLimitedToSchemaTwo();
+        BooleanIsCanonicalAndToggleIsReadCompatible();
         EnumOptionsUseUnityStyleAttributeWithInvariantValues();
+        EnumSelectionUsesDeclaredValuesAndPreservesSpecialStates();
+        ExplicitMixedEnumSelectionRecreatesThePersistedOverride();
+        BooleanValuesRoundTripAsFloatZeroOrOne();
         ShowIfSupportsTheDocumentedFormsAndFailsOpen();
     }
 
@@ -57,7 +61,7 @@ internal static class ManifestSchemaV2Tests
         var metadata = ShaderPropertyMetadataParser.Parse(
             Element(
                 "<Property Name=\"Detail\" DisplayName=\"Detail strength\" "
-                + "UiLevel=\"advanced\" Editor=\"Toggle\" Invert=\"true\" "
+                + "UiLevel=\"advanced\" Editor=\"Boolean\" Invert=\"true\" "
                 + "ShowIf=\"_Enabled &gt;= 1\" />"),
             warnings.Add);
 
@@ -66,8 +70,8 @@ internal static class ManifestSchemaV2Tests
             MaterialEditorPropertyUiLevel.Advanced,
             metadata.UiLevel,
             "advanced UI level");
-        Equal(ShaderPropertyEditorIds.Toggle, metadata.EditorId, "toggle editor");
-        Equal(true, metadata.Invert, "inverted toggle");
+        Equal(ShaderPropertyEditorIds.Toggle, metadata.EditorId, "Boolean uses the Float toggle editor");
+        Equal(true, metadata.Invert, "inverted boolean");
         NotNull(metadata.ShowIf, "parsed ShowIf");
         Equal("Enabled", metadata.ShowIf.PropertyName, "normalized condition source");
         Equal(
@@ -84,7 +88,7 @@ internal static class ManifestSchemaV2Tests
             MaterialEditorPropertyUiLevel.Basic,
             defaults.UiLevel,
             "default UI level");
-        Equal(false, defaults.Invert, "toggle is not inverted by default");
+        Equal(false, defaults.Invert, "boolean is not inverted by default");
         Equal(0, defaults.EnumOptions.Count, "default enum option count");
 
         warnings.Clear();
@@ -103,13 +107,16 @@ internal static class ManifestSchemaV2Tests
 
     private static void FloatBackedAliasesAreLimitedToSchemaTwo()
     {
+        Alias("Boolean", "Float", ShaderPropertyEditorIds.Toggle);
+        Alias("boolean", "Float", ShaderPropertyEditorIds.Toggle);
         Alias("Toggle", "Float", ShaderPropertyEditorIds.Toggle);
         Alias("toggle", "Float", ShaderPropertyEditorIds.Toggle);
         Alias("Enum", "Float", ShaderPropertyEditorIds.Enum);
 
         NoAlias("Float", 2, "ordinary type is not an alias");
         NoAlias("Dropdown", 2, "dropdown is not a data type alias");
-        NoAlias("Toggle", 1, "toggle is not a legacy alias");
+        NoAlias("Boolean", 1, "boolean is not a legacy schema alias");
+        NoAlias("Toggle", 1, "toggle is not a legacy schema alias");
         NoAlias("Enum", 1, "enum is not a legacy alias");
         NoAlias("Dropdown", 3, "unknown schema does not enable aliases");
 
@@ -119,6 +126,40 @@ internal static class ManifestSchemaV2Tests
             "Toggle",
             unknownSchema,
             "unknown schema fallback remains legacy for aliases");
+    }
+
+    private static void BooleanIsCanonicalAndToggleIsReadCompatible()
+    {
+        var canonical = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Enabled\" Type=\"Float\" "
+                + "Editor=\"Boolean\" />"));
+        Equal(
+            ShaderPropertyEditorIds.Toggle,
+            canonical.EditorId,
+            "Float property with canonical Boolean editor");
+
+        var legacyName = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Enabled\" Type=\"Float\" "
+                + "Editor=\"Toggle\" />"));
+        Equal(
+            ShaderPropertyEditorIds.Toggle,
+            legacyName.EditorId,
+            "legacy Toggle editor normalizes to Boolean");
+
+        var legacyId = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Enabled\" Type=\"Float\" "
+                + "Editor=\"materialeditor.toggle\" />"));
+        Equal(
+            ShaderPropertyEditorIds.Toggle,
+            legacyId.EditorId,
+            "legacy Toggle editor ID normalizes to Boolean");
+
+        var plainFloat = ShaderPropertyMetadataParser.Parse(
+            Element("<Property Name=\"Strength\" Type=\"Float\" />"));
+        Equal(null, plainFloat.EditorId, "ordinary Float editor remains unchanged");
     }
 
     private static void EnumOptionsUseUnityStyleAttributeWithInvariantValues()
@@ -176,6 +217,170 @@ internal static class ManifestSchemaV2Tests
             warnings.Add);
         Equal(null, empty.EditorId, "empty enum falls back to the type editor");
         Equal(1, warnings.Count, "empty enum warning count");
+    }
+
+    private static void EnumSelectionUsesDeclaredValuesAndPreservesSpecialStates()
+    {
+        var consecutive = new List<MaterialEditorEnumOption>
+        {
+            new MaterialEditorEnumOption(0f, "Off"),
+            new MaterialEditorEnumOption(1f, "On"),
+            new MaterialEditorEnumOption(2f, "Extra")
+        };
+        var consecutiveSelection =
+            MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                consecutive,
+                new[] { 1f, 1f });
+        Equal(
+            MaterialEditorEnumValueState.Matched,
+            consecutiveSelection.State,
+            "consecutive enum selection state");
+        Equal(1, consecutiveSelection.OptionIndex, "consecutive enum option index");
+        Equal(1f, consecutive[consecutiveSelection.OptionIndex].Value,
+            "consecutive enum declared value");
+
+        var declared = new List<MaterialEditorEnumOption>
+        {
+            new MaterialEditorEnumOption(-3f, "Off"),
+            new MaterialEditorEnumOption(0.25f, "Low"),
+            new MaterialEditorEnumOption(7.5f, "High")
+        };
+        var decimalSelection =
+            MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                declared,
+                new[] { 0.25f, 0.25f });
+        Equal(
+            MaterialEditorEnumValueState.Matched,
+            decimalSelection.State,
+            "non-consecutive decimal enum selection state");
+        Equal(1, decimalSelection.OptionIndex,
+            "non-consecutive decimal enum option index");
+        Equal(0.25f, declared[decimalSelection.OptionIndex].Value,
+            "dropdown writes the declared numeric value, not its index");
+
+        var unmatched =
+            MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+                declared,
+                new[] { 0.75f, 0.75f });
+        Equal(
+            MaterialEditorEnumValueState.Unmatched,
+            unmatched.State,
+            "unmatched enum value state");
+        Equal(-1, unmatched.OptionIndex, "unmatched enum has no option index");
+        Equal(0.75f, unmatched.CurrentValue,
+            "unmatched enum preserves the current float");
+
+        var mixed = MaterialEditorFloatBackedValuePolicy.ResolveEnumSelection(
+            declared,
+            new[] { 0.25f, 7.5f });
+        Equal(
+            MaterialEditorEnumValueState.Mixed,
+            mixed.State,
+            "multiple materials preserve mixed enum state");
+        Equal(-1, mixed.OptionIndex, "mixed enum has no option index");
+        False(
+            MaterialEditorFloatBackedValuePolicy.ShouldRemoveEnumOverride(
+                true,
+                0.25f,
+                0.25f),
+            "an explicit selection from Mixed remains persisted even when it matches the representative original");
+        True(
+            MaterialEditorFloatBackedValuePolicy.ShouldRemoveEnumOverride(
+                false,
+                0.25f,
+                0.25f),
+            "a non-mixed value matching the original removes a redundant override");
+    }
+
+    private static void ExplicitMixedEnumSelectionRecreatesThePersistedOverride()
+    {
+        const float original = 0.25f;
+        var overrideExists = true;
+        var storedValue = 7.5f;
+        var calls = new List<string>();
+
+        Action removeOverride = () =>
+        {
+            calls.Add("remove");
+            overrideExists = false;
+        };
+        Action<float> legacySetOverride = value =>
+        {
+            calls.Add("set");
+            if (overrideExists &&
+                MaterialEditorFloatBackedValuePolicy.Approximately(value, original))
+            {
+                overrideExists = false;
+                return;
+            }
+
+            overrideExists = true;
+            storedValue = value;
+        };
+
+        // A direct legacy set demonstrates the cleanup behavior that used to
+        // lose an explicit Mixed -> original selection on the next load.
+        legacySetOverride(original);
+        False(overrideExists, "legacy backend removes an existing original-valued override");
+
+        overrideExists = true;
+        calls.Clear();
+        MaterialEditorFloatBackedValuePolicy.PersistExplicitEnumSelection(
+            removeOverride,
+            legacySetOverride,
+            original);
+
+        True(overrideExists, "explicit Mixed selection remains persisted");
+        Equal(original, storedValue, "persisted enum keeps the selected declared value");
+        Equal("remove", calls[0], "existing override is removed first");
+        Equal("set", calls[1], "selected value is persisted after removal");
+        Equal(2, calls.Count, "force-persist sequence performs exactly two operations");
+    }
+
+    private static void BooleanValuesRoundTripAsFloatZeroOrOne()
+    {
+        False(
+            MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(0f, false),
+            "zero reads as disabled");
+        True(
+            MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(1f, false),
+            "one reads as enabled");
+        True(
+            MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(-2f, false),
+            "legacy non-zero Float reads as enabled without being rewritten");
+        True(
+            MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(0f, true),
+            "Invert reverses the displayed state");
+
+        Equal(
+            0f,
+            MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(false, false),
+            "disabled Boolean stores Float zero");
+        Equal(
+            1f,
+            MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(true, false),
+            "enabled Boolean stores Float one");
+        Equal(
+            0f,
+            MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(true, true),
+            "inverted enabled Boolean stores Float zero");
+        Equal(
+            1f,
+            MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(false, true),
+            "inverted disabled Boolean stores Float one");
+
+        foreach (var displayValue in new[] { false, true })
+        {
+            var stored = MaterialEditorFloatBackedValuePolicy.GetBooleanStoredValue(
+                displayValue,
+                false);
+            Equal(
+                displayValue,
+                MaterialEditorFloatBackedValuePolicy.GetBooleanDisplayValue(
+                    stored,
+                    false),
+                "Boolean Float round-trip " + displayValue);
+        }
     }
 
     private static void ShowIfSupportsTheDocumentedFormsAndFailsOpen()

--- a/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
+++ b/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
@@ -8,7 +8,7 @@ internal static class ManifestSchemaV2Tests
         SchemaVersionTwoIsAnExplicitCompatibilityGate();
         SchemaTwoMetadataIsParsedWithSafeDefaults();
         FloatBackedAliasesAreLimitedToSchemaTwo();
-        EnumOptionsAreDirectChildrenWithNumericValues();
+        EnumOptionsUseUnityStyleAttributeWithInvariantValues();
         ShowIfSupportsTheDocumentedFormsAndFailsOpen();
     }
 
@@ -57,21 +57,17 @@ internal static class ManifestSchemaV2Tests
         var metadata = ShaderPropertyMetadataParser.Parse(
             Element(
                 "<Property Name=\"Detail\" DisplayName=\"Detail strength\" "
-                + "Order=\"30\" CategoryOrder=\"20\" UiLevel=\"advanced\" "
-                + "Editor=\"Toggle\" OffValue=\"-1.5\" OnValue=\"2.5\" "
+                + "UiLevel=\"advanced\" Editor=\"Toggle\" Invert=\"true\" "
                 + "ShowIf=\"_Enabled &gt;= 1\" />"),
             warnings.Add);
 
         Equal("Detail strength", metadata.DisplayName, "display name");
-        Equal((int?)30, metadata.Order, "property order");
-        Equal((int?)20, metadata.CategoryOrder, "category order");
         Equal(
             MaterialEditorPropertyUiLevel.Advanced,
             metadata.UiLevel,
             "advanced UI level");
         Equal(ShaderPropertyEditorIds.Toggle, metadata.EditorId, "toggle editor");
-        Equal(-1.5f, metadata.OffValue, "toggle off value");
-        Equal(2.5f, metadata.OnValue, "toggle on value");
+        Equal(true, metadata.Invert, "inverted toggle");
         NotNull(metadata.ShowIf, "parsed ShowIf");
         Equal("Enabled", metadata.ShowIf.PropertyName, "normalized condition source");
         Equal(
@@ -84,32 +80,25 @@ internal static class ManifestSchemaV2Tests
         var defaults = ShaderPropertyMetadataParser.Parse(
             Element("<Property Name=\"PlainFloat\" Type=\"Float\" />"));
         Equal(null, defaults.DisplayName, "display name remains optional");
-        Equal(null, defaults.Order, "optional order");
-        Equal(null, defaults.CategoryOrder, "optional category order");
         Equal(
             MaterialEditorPropertyUiLevel.Basic,
             defaults.UiLevel,
             "default UI level");
-        Equal(0f, defaults.OffValue, "default toggle off value");
-        Equal(1f, defaults.OnValue, "default toggle on value");
+        Equal(false, defaults.Invert, "toggle is not inverted by default");
         Equal(0, defaults.EnumOptions.Count, "default enum option count");
 
         warnings.Clear();
         var invalid = ShaderPropertyMetadataParser.Parse(
             Element(
-                "<Property Name=\"Invalid\" Order=\"first\" "
-                + "CategoryOrder=\"early\" UiLevel=\"Expert\" "
-                + "OffValue=\"NaN\" OnValue=\"Infinity\" />"),
+                "<Property Name=\"Invalid\" UiLevel=\"Expert\" "
+                + "Invert=\"sometimes\" />"),
             warnings.Add);
-        Equal(null, invalid.Order, "invalid order fallback");
-        Equal(null, invalid.CategoryOrder, "invalid category order fallback");
         Equal(
             MaterialEditorPropertyUiLevel.Basic,
             invalid.UiLevel,
             "invalid UI level fallback");
-        Equal(0f, invalid.OffValue, "invalid off value fallback");
-        Equal(1f, invalid.OnValue, "invalid on value fallback");
-        Equal(5, warnings.Count, "invalid metadata warning count");
+        Equal(false, invalid.Invert, "invalid invert fallback");
+        Equal(2, warnings.Count, "invalid metadata warning count");
     }
 
     private static void FloatBackedAliasesAreLimitedToSchemaTwo()
@@ -117,9 +106,9 @@ internal static class ManifestSchemaV2Tests
         Alias("Toggle", "Float", ShaderPropertyEditorIds.Toggle);
         Alias("toggle", "Float", ShaderPropertyEditorIds.Toggle);
         Alias("Enum", "Float", ShaderPropertyEditorIds.Enum);
-        Alias("DROPDOWN", "Float", ShaderPropertyEditorIds.Enum);
 
         NoAlias("Float", 2, "ordinary type is not an alias");
+        NoAlias("Dropdown", 2, "dropdown is not a data type alias");
         NoAlias("Toggle", 1, "toggle is not a legacy alias");
         NoAlias("Enum", 1, "enum is not a legacy alias");
         NoAlias("Dropdown", 3, "unknown schema does not enable aliases");
@@ -132,31 +121,58 @@ internal static class ManifestSchemaV2Tests
             "unknown schema fallback remains legacy for aliases");
     }
 
-    private static void EnumOptionsAreDirectChildrenWithNumericValues()
+    private static void EnumOptionsUseUnityStyleAttributeWithInvariantValues()
     {
         var warnings = new List<string>();
-        var metadata = ShaderPropertyMetadataParser.Parse(
-            Element(
-                "<Property Name=\"Mode\" Editor=\"Enum\">"
-                + "<Option Value=\"0\" DisplayName=\"Off\" />"
-                + "<Group><Option Value=\"99\" DisplayName=\"Nested\" /></Group>"
-                + "<Option Value=\"1.5\" DisplayName=\"Soft\" />"
-                + "<Option Value=\"2\">Sharp</Option>"
-                + "<Option Value=\"invalid\" DisplayName=\"Invalid\" />"
-                + "<Option Value=\"2\" DisplayName=\"Duplicate\" />"
-                + "</Property>"),
-            warnings.Add);
+        ShaderPropertyUiMetadata metadata;
+        var originalCulture = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            System.Globalization.CultureInfo.CurrentCulture =
+                new System.Globalization.CultureInfo("fr-FR");
+            metadata = ShaderPropertyMetadataParser.Parse(
+                Element(
+                    "<Property Name=\"Mode\" Editor=\"Enum\" "
+                    + "Enums=\"Off,0, Soft,1.5, Sharp,2\">"
+                    + "<Group><Option Value=\"99\" DisplayName=\"Ignored\" /></Group>"
+                    + "</Property>"),
+                warnings.Add);
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = originalCulture;
+        }
 
         Equal(ShaderPropertyEditorIds.Enum, metadata.EditorId, "enum editor");
-        Equal(3, metadata.EnumOptions.Count, "valid direct option count");
+        Equal(3, metadata.EnumOptions.Count, "valid enum option count");
         Option(metadata.EnumOptions[0], 0f, "Off", "first enum option");
         Option(metadata.EnumOptions[1], 1.5f, "Soft", "fractional enum option");
-        Option(metadata.EnumOptions[2], 2f, "Sharp", "text enum option label");
-        Equal(2, warnings.Count, "invalid and duplicate options warn");
+        Option(metadata.EnumOptions[2], 2f, "Sharp", "third enum option");
+        Equal(
+            false,
+            metadata.EnumOptions.Any(option => option.Value == 99f),
+            "nested Option elements are ignored");
+        Equal(0, warnings.Count, "valid enum warning count");
+
+        warnings.Clear();
+        var invalid = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"InvalidMode\" Editor=\"Enum\" "
+                + "Enums=\"Off,0,,1,NotFinite,Infinity,"
+                + "DuplicateValue,0,Off,3,Dangling\" />"),
+            warnings.Add);
+        Equal(ShaderPropertyEditorIds.Enum, invalid.EditorId, "partially valid enum editor");
+        Equal(1, invalid.EnumOptions.Count, "only valid unique enum option remains");
+        Option(invalid.EnumOptions[0], 0f, "Off", "surviving enum option");
+        Equal(
+            5,
+            warnings.Count,
+            "odd pair, empty label, non-finite value and duplicates warn");
 
         warnings.Clear();
         var empty = ShaderPropertyMetadataParser.Parse(
-            Element("<Property Name=\"EmptyMode\" Editor=\"Enum\" />"),
+            Element(
+                "<Property Name=\"EmptyMode\" Editor=\"Enum\" Enums=\"\" />"),
             warnings.Add);
         Equal(null, empty.EditorId, "empty enum falls back to the type editor");
         Equal(1, warnings.Count, "empty enum warning count");

--- a/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
+++ b/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
@@ -8,7 +8,7 @@ internal static class ManifestSchemaV2Tests
         SchemaVersionTwoIsAnExplicitCompatibilityGate();
         SchemaTwoMetadataIsParsedWithSafeDefaults();
         FloatBackedAliasesAreLimitedToSchemaTwo();
-        BooleanIsCanonicalAndToggleIsReadCompatible();
+        BooleanIsTheOnlyManifestBooleanSpelling();
         EnumOptionsUseUnityStyleAttributeWithInvariantValues();
         EnumSelectionUsesDeclaredValuesAndPreservesSpecialStates();
         ExplicitMixedEnumSelectionRecreatesThePersistedOverride();
@@ -71,7 +71,7 @@ internal static class ManifestSchemaV2Tests
             MaterialEditorPropertyUiLevel.Advanced,
             metadata.UiLevel,
             "advanced UI level");
-        Equal(ShaderPropertyEditorIds.Toggle, metadata.EditorId, "Boolean uses the Float toggle editor");
+        Equal(ShaderPropertyEditorIds.Boolean, metadata.EditorId, "Boolean uses the Float Boolean editor");
         Equal(true, metadata.Invert, "inverted boolean");
         NotNull(metadata.ShowIf, "parsed ShowIf");
         Equal("Enabled", metadata.ShowIf.PropertyName, "normalized condition source");
@@ -108,14 +108,15 @@ internal static class ManifestSchemaV2Tests
 
     private static void FloatBackedAliasesAreLimitedToSchemaTwo()
     {
-        Alias("Boolean", "Float", ShaderPropertyEditorIds.Toggle);
-        Alias("boolean", "Float", ShaderPropertyEditorIds.Toggle);
-        Alias("Toggle", "Float", ShaderPropertyEditorIds.Toggle);
-        Alias("toggle", "Float", ShaderPropertyEditorIds.Toggle);
+        Alias("Boolean", "Float", ShaderPropertyEditorIds.Boolean);
+        Alias("boolean", "Float", ShaderPropertyEditorIds.Boolean);
         Alias("Enum", "Float", ShaderPropertyEditorIds.Enum);
 
         NoAlias("Float", 2, "ordinary type is not an alias");
         NoAlias("Dropdown", 2, "dropdown is not a data type alias");
+        NoAlias("Toggle", 2, "removed Toggle spelling is not an alias");
+        NoAlias("toggle", 2, "removed lowercase toggle spelling is not an alias");
+        NoAlias(" Toggle ", 2, "removed Toggle spelling stays rejected after trimming");
         NoAlias("Boolean", 1, "boolean is not a legacy schema alias");
         NoAlias("Toggle", 1, "toggle is not a legacy schema alias");
         NoAlias("Enum", 1, "enum is not a legacy alias");
@@ -129,34 +130,39 @@ internal static class ManifestSchemaV2Tests
             "unknown schema fallback remains legacy for aliases");
     }
 
-    private static void BooleanIsCanonicalAndToggleIsReadCompatible()
+    private static void BooleanIsTheOnlyManifestBooleanSpelling()
     {
+        DoesNotContain(
+            ReadSource(
+                FindRepositoryRoot(),
+                "src",
+                "MaterialEditor.Base",
+                "UI",
+                "UI.MaterialPropertyMetadata.cs"),
+            "materialeditor.toggle",
+            "removed Toggle editor ID is absent from production metadata");
+
         var canonical = ShaderPropertyMetadataParser.Parse(
             Element(
                 "<Property Name=\"Enabled\" Type=\"Float\" "
                 + "Editor=\"Boolean\" />"));
         Equal(
-            ShaderPropertyEditorIds.Toggle,
+            ShaderPropertyEditorIds.Boolean,
             canonical.EditorId,
             "Float property with canonical Boolean editor");
 
-        var legacyName = ShaderPropertyMetadataParser.Parse(
+        var canonicalId = ShaderPropertyMetadataParser.Parse(
             Element(
                 "<Property Name=\"Enabled\" Type=\"Float\" "
-                + "Editor=\"Toggle\" />"));
+                + "Editor=\"materialeditor.boolean\" />"));
         Equal(
-            ShaderPropertyEditorIds.Toggle,
-            legacyName.EditorId,
-            "legacy Toggle editor normalizes to Boolean");
+            ShaderPropertyEditorIds.Boolean,
+            canonicalId.EditorId,
+            "Float property with canonical Boolean editor ID");
 
-        var legacyId = ShaderPropertyMetadataParser.Parse(
-            Element(
-                "<Property Name=\"Enabled\" Type=\"Float\" "
-                + "Editor=\"materialeditor.toggle\" />"));
-        Equal(
-            ShaderPropertyEditorIds.Toggle,
-            legacyId.EditorId,
-            "legacy Toggle editor ID normalizes to Boolean");
+        UnknownEditor("Toggle");
+        UnknownEditor("ToggleFloat");
+        UnknownEditor("materialeditor.toggle");
 
         var plainFloat = ShaderPropertyMetadataParser.Parse(
             Element("<Property Name=\"Strength\" Type=\"Float\" />"));
@@ -660,6 +666,19 @@ internal static class ManifestSchemaV2Tests
             name);
         Equal(null, normalizedType, name + " normalized type");
         Equal(null, editorId, name + " editor id");
+    }
+
+    private static void UnknownEditor(string editor)
+    {
+        var warnings = new List<string>();
+        var metadata = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Enabled\" Type=\"Float\" Editor=\""
+                + editor
+                + "\" />"),
+            warnings.Add);
+        Equal(null, metadata.EditorId, editor + " is not a manifest editor");
+        Equal(1, warnings.Count, editor + " warning count");
     }
 
     private static void Option(

--- a/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
+++ b/tests/MaterialEditor.MetadataTests/ManifestSchemaV2Tests.cs
@@ -1,0 +1,345 @@
+using System.Xml;
+using MaterialEditorAPI;
+
+internal static class ManifestSchemaV2Tests
+{
+    internal static void Run()
+    {
+        SchemaVersionTwoIsAnExplicitCompatibilityGate();
+        SchemaTwoMetadataIsParsedWithSafeDefaults();
+        FloatBackedAliasesAreLimitedToSchemaTwo();
+        EnumOptionsAreDirectChildrenWithNumericValues();
+        ShowIfSupportsTheDocumentedFormsAndFailsOpen();
+    }
+
+    private static void SchemaVersionTwoIsAnExplicitCompatibilityGate()
+    {
+        var warnings = new List<string>();
+
+        Equal(
+            1,
+            ShaderPropertyMetadataParser.ReadSchemaVersion(
+                Element("<MaterialEditor />"),
+                warnings.Add),
+            "missing schema version uses legacy mode");
+        Equal(
+            1,
+            ShaderPropertyMetadataParser.ReadSchemaVersion(
+                Element("<MaterialEditor SchemaVersion=\"1\" />"),
+                warnings.Add),
+            "explicit schema version 1");
+        Equal(
+            2,
+            ShaderPropertyMetadataParser.ReadSchemaVersion(
+                Element("<MaterialEditor SchemaVersion=\"2\" />"),
+                warnings.Add),
+            "explicit schema version 2");
+        Equal(0, warnings.Count, "known schema versions do not warn");
+
+        Equal(
+            1,
+            ShaderPropertyMetadataParser.ReadSchemaVersion(
+                Element("<MaterialEditor SchemaVersion=\"3\" />"),
+                warnings.Add),
+            "future schema version falls back to legacy mode");
+        Equal(
+            1,
+            ShaderPropertyMetadataParser.ReadSchemaVersion(
+                Element("<MaterialEditor SchemaVersion=\"invalid\" />"),
+                warnings.Add),
+            "invalid schema version falls back to legacy mode");
+        Equal(2, warnings.Count, "unsupported schema versions warn");
+    }
+
+    private static void SchemaTwoMetadataIsParsedWithSafeDefaults()
+    {
+        var warnings = new List<string>();
+        var metadata = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Detail\" DisplayName=\"Detail strength\" "
+                + "Order=\"30\" CategoryOrder=\"20\" UiLevel=\"advanced\" "
+                + "Editor=\"Toggle\" OffValue=\"-1.5\" OnValue=\"2.5\" "
+                + "ShowIf=\"_Enabled &gt;= 1\" />"),
+            warnings.Add);
+
+        Equal("Detail strength", metadata.DisplayName, "display name");
+        Equal((int?)30, metadata.Order, "property order");
+        Equal((int?)20, metadata.CategoryOrder, "category order");
+        Equal(
+            MaterialEditorPropertyUiLevel.Advanced,
+            metadata.UiLevel,
+            "advanced UI level");
+        Equal(ShaderPropertyEditorIds.Toggle, metadata.EditorId, "toggle editor");
+        Equal(-1.5f, metadata.OffValue, "toggle off value");
+        Equal(2.5f, metadata.OnValue, "toggle on value");
+        NotNull(metadata.ShowIf, "parsed ShowIf");
+        Equal("Enabled", metadata.ShowIf.PropertyName, "normalized condition source");
+        Equal(
+            MaterialEditorConditionComparison.GreaterThanOrEqual,
+            metadata.ShowIf.Comparison,
+            "condition comparison");
+        Equal(1f, metadata.ShowIf.Value, "condition value");
+        Equal(0, warnings.Count, "valid metadata warning count");
+
+        var defaults = ShaderPropertyMetadataParser.Parse(
+            Element("<Property Name=\"PlainFloat\" Type=\"Float\" />"));
+        Equal(null, defaults.DisplayName, "display name remains optional");
+        Equal(null, defaults.Order, "optional order");
+        Equal(null, defaults.CategoryOrder, "optional category order");
+        Equal(
+            MaterialEditorPropertyUiLevel.Basic,
+            defaults.UiLevel,
+            "default UI level");
+        Equal(0f, defaults.OffValue, "default toggle off value");
+        Equal(1f, defaults.OnValue, "default toggle on value");
+        Equal(0, defaults.EnumOptions.Count, "default enum option count");
+
+        warnings.Clear();
+        var invalid = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Invalid\" Order=\"first\" "
+                + "CategoryOrder=\"early\" UiLevel=\"Expert\" "
+                + "OffValue=\"NaN\" OnValue=\"Infinity\" />"),
+            warnings.Add);
+        Equal(null, invalid.Order, "invalid order fallback");
+        Equal(null, invalid.CategoryOrder, "invalid category order fallback");
+        Equal(
+            MaterialEditorPropertyUiLevel.Basic,
+            invalid.UiLevel,
+            "invalid UI level fallback");
+        Equal(0f, invalid.OffValue, "invalid off value fallback");
+        Equal(1f, invalid.OnValue, "invalid on value fallback");
+        Equal(5, warnings.Count, "invalid metadata warning count");
+    }
+
+    private static void FloatBackedAliasesAreLimitedToSchemaTwo()
+    {
+        Alias("Toggle", "Float", ShaderPropertyEditorIds.Toggle);
+        Alias("toggle", "Float", ShaderPropertyEditorIds.Toggle);
+        Alias("Enum", "Float", ShaderPropertyEditorIds.Enum);
+        Alias("DROPDOWN", "Float", ShaderPropertyEditorIds.Enum);
+
+        NoAlias("Float", 2, "ordinary type is not an alias");
+        NoAlias("Toggle", 1, "toggle is not a legacy alias");
+        NoAlias("Enum", 1, "enum is not a legacy alias");
+        NoAlias("Dropdown", 3, "unknown schema does not enable aliases");
+
+        var unknownSchema = ShaderPropertyMetadataParser.ReadSchemaVersion(
+            Element("<MaterialEditor SchemaVersion=\"99\" />"));
+        NoAlias(
+            "Toggle",
+            unknownSchema,
+            "unknown schema fallback remains legacy for aliases");
+    }
+
+    private static void EnumOptionsAreDirectChildrenWithNumericValues()
+    {
+        var warnings = new List<string>();
+        var metadata = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Mode\" Editor=\"Enum\">"
+                + "<Option Value=\"0\" DisplayName=\"Off\" />"
+                + "<Group><Option Value=\"99\" DisplayName=\"Nested\" /></Group>"
+                + "<Option Value=\"1.5\" DisplayName=\"Soft\" />"
+                + "<Option Value=\"2\">Sharp</Option>"
+                + "<Option Value=\"invalid\" DisplayName=\"Invalid\" />"
+                + "<Option Value=\"2\" DisplayName=\"Duplicate\" />"
+                + "</Property>"),
+            warnings.Add);
+
+        Equal(ShaderPropertyEditorIds.Enum, metadata.EditorId, "enum editor");
+        Equal(3, metadata.EnumOptions.Count, "valid direct option count");
+        Option(metadata.EnumOptions[0], 0f, "Off", "first enum option");
+        Option(metadata.EnumOptions[1], 1.5f, "Soft", "fractional enum option");
+        Option(metadata.EnumOptions[2], 2f, "Sharp", "text enum option label");
+        Equal(2, warnings.Count, "invalid and duplicate options warn");
+
+        warnings.Clear();
+        var empty = ShaderPropertyMetadataParser.Parse(
+            Element("<Property Name=\"EmptyMode\" Editor=\"Enum\" />"),
+            warnings.Add);
+        Equal(null, empty.EditorId, "empty enum falls back to the type editor");
+        Equal(1, warnings.Count, "empty enum warning count");
+    }
+
+    private static void ShowIfSupportsTheDocumentedFormsAndFailsOpen()
+    {
+        Condition(
+            "Enabled",
+            "Enabled",
+            MaterialEditorConditionComparison.NotEqual,
+            0f,
+            1f,
+            true);
+        Condition(
+            "!Enabled",
+            "Enabled",
+            MaterialEditorConditionComparison.Equal,
+            0f,
+            0f,
+            true);
+        Condition(
+            "_Mode == true",
+            "Mode",
+            MaterialEditorConditionComparison.Equal,
+            1f,
+            1f,
+            true);
+        Condition(
+            "Mode != false",
+            "Mode",
+            MaterialEditorConditionComparison.NotEqual,
+            0f,
+            1f,
+            true);
+        Condition(
+            "Strength > 0.5",
+            "Strength",
+            MaterialEditorConditionComparison.GreaterThan,
+            0.5f,
+            0.25f,
+            false);
+        Condition(
+            "Strength >= 0.5",
+            "Strength",
+            MaterialEditorConditionComparison.GreaterThanOrEqual,
+            0.5f,
+            0.5f,
+            true);
+        Condition(
+            "Strength < 0.5",
+            "Strength",
+            MaterialEditorConditionComparison.LessThan,
+            0.5f,
+            0.25f,
+            true);
+        Condition(
+            "Strength <= 0.5",
+            "Strength",
+            MaterialEditorConditionComparison.LessThanOrEqual,
+            0.5f,
+            0.75f,
+            false);
+
+        MaterialEditorPropertyCondition parsed;
+        True(
+            ShaderPropertyMetadataParser.TryParseCondition(
+                "Enabled == 1",
+                out parsed),
+            "condition used by fail-open policy");
+        False(
+            MaterialEditorConditionPolicy.Evaluate(parsed, _ => 0f),
+            "resolved false condition");
+        True(
+            MaterialEditorConditionPolicy.Evaluate(parsed, _ => null),
+            "missing source fails open");
+        True(
+            MaterialEditorConditionPolicy.Evaluate(
+                parsed,
+                _ => throw new InvalidOperationException("unavailable material")),
+            "resolver failure fails open");
+
+        var warnings = new List<string>();
+        var invalid = ShaderPropertyMetadataParser.Parse(
+            Element(
+                "<Property Name=\"Dependent\" "
+                + "ShowIf=\"Enabled == not-a-number\" />"),
+            warnings.Add);
+        Equal(null, invalid.ShowIf, "invalid ShowIf is discarded");
+        Equal(1, warnings.Count, "invalid ShowIf warning count");
+        True(
+            MaterialEditorConditionPolicy.Evaluate(invalid.ShowIf, _ => 0f),
+            "discarded condition remains visible");
+    }
+
+    private static XmlElement Element(string xml)
+    {
+        var document = new XmlDocument();
+        document.LoadXml(xml);
+        return document.DocumentElement
+            ?? throw new InvalidOperationException("XML has no root element.");
+    }
+
+    private static void Alias(
+        string declaredType,
+        string expectedType,
+        string expectedEditor)
+    {
+        True(
+            ShaderPropertyMetadataParser.TryResolvePropertyTypeAlias(
+                declaredType,
+                2,
+                out var normalizedType,
+                out var editorId),
+            declaredType + " schema 2 alias");
+        Equal(expectedType, normalizedType, declaredType + " backing type");
+        Equal(expectedEditor, editorId, declaredType + " editor id");
+    }
+
+    private static void NoAlias(string declaredType, int schemaVersion, string name)
+    {
+        False(
+            ShaderPropertyMetadataParser.TryResolvePropertyTypeAlias(
+                declaredType,
+                schemaVersion,
+                out var normalizedType,
+                out var editorId),
+            name);
+        Equal(null, normalizedType, name + " normalized type");
+        Equal(null, editorId, name + " editor id");
+    }
+
+    private static void Option(
+        MaterialEditorEnumOption option,
+        float expectedValue,
+        string expectedDisplayName,
+        string name)
+    {
+        Equal(expectedValue, option.Value, name + " value");
+        Equal(expectedDisplayName, option.DisplayName, name + " display name");
+    }
+
+    private static void Condition(
+        string expression,
+        string expectedProperty,
+        MaterialEditorConditionComparison expectedComparison,
+        float expectedValue,
+        float currentValue,
+        bool expectedResult)
+    {
+        True(
+            ShaderPropertyMetadataParser.TryParseCondition(
+                expression,
+                out var condition),
+            expression + " parses");
+        Equal(expectedProperty, condition.PropertyName, expression + " source");
+        Equal(expectedComparison, condition.Comparison, expression + " comparison");
+        Equal(expectedValue, condition.Value, expression + " value");
+        Equal(expectedResult, condition.Evaluate(currentValue), expression + " result");
+    }
+
+    private static void NotNull(object value, string name)
+    {
+        if (value == null)
+            throw new InvalidOperationException(name + ": expected a value.");
+    }
+
+    private static void True(bool value, string name)
+    {
+        Equal(true, value, name);
+    }
+
+    private static void False(bool value, string name)
+    {
+        Equal(false, value, name);
+    }
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException(
+                $"{name}: expected '{expected}', got '{actual}'.");
+        }
+    }
+}

--- a/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
+++ b/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.ShaderUiMetadata.cs"
              Link="UI.ShaderUiMetadata.cs" />
+    <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.MaterialPropertyMetadata.cs"
+             Link="UI.MaterialPropertyMetadata.cs" />
+    <Compile Include="..\..\src\MaterialEditor.Base\ShaderPropertyFallbackPolicy.cs"
+             Link="ShaderPropertyFallbackPolicy.cs" />
     <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.TooltipPolicy.cs"
              Link="UI.TooltipPolicy.cs" />
     <Compile Include="..\..\src\MaterialEditor.Core\Core.MaterialEditor.SiruSyncPolicy.cs"

--- a/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
+++ b/tests/MaterialEditor.MetadataTests/MaterialEditor.MetadataTests.csproj
@@ -10,6 +10,8 @@
              Link="UI.ShaderUiMetadata.cs" />
     <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.MaterialPropertyMetadata.cs"
              Link="UI.MaterialPropertyMetadata.cs" />
+    <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.ShaderUiMode.cs"
+             Link="UI.ShaderUiMode.cs" />
     <Compile Include="..\..\src\MaterialEditor.Base\ShaderPropertyFallbackPolicy.cs"
              Link="ShaderPropertyFallbackPolicy.cs" />
     <Compile Include="..\..\src\MaterialEditor.Base\UI\UI.TooltipPolicy.cs"

--- a/tests/MaterialEditor.MetadataTests/Program.cs
+++ b/tests/MaterialEditor.MetadataTests/Program.cs
@@ -10,6 +10,9 @@ internal static class Program
             ReferencesAndWhitespaceAreResolved();
             InvalidCatalogsAreRejected();
             ShaderHintDisplayPolicyIsIndependentOfStandardTooltips();
+            ManifestSchemaV2Tests.Run();
+            ShaderPropertyFallbackPolicyTests.Run();
+            ConditionDeferredRefreshTests.Run();
             SiruSyncPolicyTests.Run();
             Console.WriteLine("Material Editor metadata regression tests passed.");
             return 0;

--- a/tests/MaterialEditor.MetadataTests/Program.cs
+++ b/tests/MaterialEditor.MetadataTests/Program.cs
@@ -11,6 +11,8 @@ internal static class Program
             InvalidCatalogsAreRejected();
             ShaderHintDisplayPolicyIsIndependentOfStandardTooltips();
             ManifestSchemaV2Tests.Run();
+            ShaderUiModeTests.Run();
+            UiLevelPerShaderContractTests.Run();
             ShaderPropertyFallbackPolicyTests.Run();
             ConditionDeferredRefreshTests.Run();
             SiruSyncPolicyTests.Run();

--- a/tests/MaterialEditor.MetadataTests/ShaderPropertyFallbackPolicyTests.cs
+++ b/tests/MaterialEditor.MetadataTests/ShaderPropertyFallbackPolicyTests.cs
@@ -1,0 +1,176 @@
+using MaterialEditorAPI;
+
+internal static class ShaderPropertyFallbackPolicyTests
+{
+    internal static void Run()
+    {
+        var condition = new MaterialEditorPropertyCondition(
+            "Enabled",
+            MaterialEditorConditionComparison.NotEqual,
+            0f);
+        var shaderSpecific = new MaterialEditorPluginBase.ShaderPropertyData(
+            "Mode",
+            7)
+        {
+            DefaultValue = "2",
+            DefaultValueAssetBundle = "bundle",
+            AnisoLevel = 16,
+            FilterMode = "Trilinear",
+            WrapMode = "Clamp",
+            MinValue = -2.5f,
+            MaxValue = 8.5f,
+            Hidden = true,
+            Category = "Surface",
+            CategoryOrder = 20,
+            DeclarationOrder = 4,
+            DisplayName = "Rendering mode",
+            Order = 30,
+            EditorId = ShaderPropertyEditorIds.Enum,
+            UiLevel = MaterialEditorPropertyUiLevel.Advanced,
+            ShowIf = condition,
+            OffValue = -1f,
+            OnValue = 3f
+        };
+        shaderSpecific.EnumOptions.Add(
+            new MaterialEditorEnumOption(2f, "Opaque"));
+
+        var existingFallback =
+            new MaterialEditorPluginBase.ShaderPropertyData("Existing", 3);
+        var fallbackProperties =
+            new Dictionary<string, MaterialEditorPluginBase.ShaderPropertyData>
+            {
+                [existingFallback.Name] = existingFallback
+            };
+        var fallback = ShaderPropertyFallbackPolicy.MergeInto(
+            fallbackProperties,
+            shaderSpecific);
+
+        False(ReferenceEquals(shaderSpecific, fallback), "fallback is isolated");
+        Equal(2, fallbackProperties.Count, "merge preserves existing fallback entries");
+        Equal(
+            existingFallback,
+            fallbackProperties[existingFallback.Name],
+            "merge does not replace unrelated fallback entries");
+        Equal(
+            fallback,
+            fallbackProperties[shaderSpecific.Name],
+            "merge stores the neutral fallback clone");
+        Equal(shaderSpecific.Name, fallback.Name, "legacy Name");
+        Equal(shaderSpecific.Type, fallback.Type, "legacy Type");
+        Equal(shaderSpecific.DefaultValue, fallback.DefaultValue, "legacy DefaultValue");
+        Equal(
+            shaderSpecific.DefaultValueAssetBundle,
+            fallback.DefaultValueAssetBundle,
+            "legacy DefaultValueAssetBundle");
+        Equal(shaderSpecific.AnisoLevel, fallback.AnisoLevel, "legacy AnisoLevel");
+        Equal(shaderSpecific.FilterMode, fallback.FilterMode, "legacy FilterMode");
+        Equal(shaderSpecific.WrapMode, fallback.WrapMode, "legacy WrapMode");
+        Equal(shaderSpecific.MinValue, fallback.MinValue, "legacy MinValue");
+        Equal(shaderSpecific.MaxValue, fallback.MaxValue, "legacy MaxValue");
+        Equal(shaderSpecific.Hidden, fallback.Hidden, "legacy Hidden");
+        Equal(shaderSpecific.Category, fallback.Category, "legacy Category");
+
+        Equal(fallback.Name, fallback.DisplayName, "neutral DisplayName");
+        Equal(null, fallback.Order, "neutral Order");
+        Equal(null, fallback.CategoryOrder, "neutral CategoryOrder");
+        Equal(0, fallback.DeclarationOrder, "neutral DeclarationOrder");
+        Equal(
+            MaterialEditorPropertyUiLevel.Basic,
+            fallback.UiLevel,
+            "neutral UiLevel");
+        Equal(null, fallback.EditorId, "neutral EditorId");
+        Equal(null, fallback.ShowIf, "neutral ShowIf");
+        Equal(0, fallback.EnumOptions.Count, "neutral EnumOptions");
+        False(
+            ReferenceEquals(shaderSpecific.EnumOptions, fallback.EnumOptions),
+            "fallback EnumOptions are isolated");
+        Equal(0f, fallback.OffValue, "neutral OffValue");
+        Equal(1f, fallback.OnValue, "neutral OnValue");
+
+        Equal(
+            "Rendering mode",
+            shaderSpecific.DisplayName,
+            "shader metadata remains intact");
+        Equal(30, shaderSpecific.Order, "shader Order remains intact");
+        Equal(
+            20,
+            shaderSpecific.CategoryOrder,
+            "shader CategoryOrder remains intact");
+        Equal(
+            ShaderPropertyEditorIds.Enum,
+            shaderSpecific.EditorId,
+            "shader Editor remains intact");
+        Equal(condition, shaderSpecific.ShowIf, "shader ShowIf remains intact");
+        Equal(1, shaderSpecific.EnumOptions.Count, "shader options remain intact");
+        Equal(-1f, shaderSpecific.OffValue, "shader OffValue remains intact");
+        Equal(3f, shaderSpecific.OnValue, "shader OnValue remains intact");
+
+        True(
+            ShaderPropertyFallbackPolicy.IsReservedShaderName("default"),
+            "exact fallback key is reserved");
+        False(
+            ShaderPropertyFallbackPolicy.IsReservedShaderName("Default"),
+            "ordinary differently-cased shader name remains unaffected");
+    }
+
+    private static void True(bool value, string name)
+    {
+        Equal(true, value, name);
+    }
+
+    private static void False(bool value, string name)
+    {
+        Equal(false, value, name);
+    }
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException(
+                $"{name}: expected '{expected}', got '{actual}'.");
+        }
+    }
+}
+
+namespace MaterialEditorAPI
+{
+    public class MaterialEditorPluginBase
+    {
+        public class ShaderPropertyData
+        {
+            public ShaderPropertyData(string name, int type)
+            {
+                Name = name;
+                Type = type;
+                DisplayName = name;
+                UiLevel = MaterialEditorPropertyUiLevel.Basic;
+                EnumOptions = new List<MaterialEditorEnumOption>();
+                OffValue = 0f;
+                OnValue = 1f;
+            }
+
+            public string Name;
+            public int Type;
+            public string DefaultValue;
+            public string DefaultValueAssetBundle;
+            public int? AnisoLevel;
+            public string FilterMode;
+            public string WrapMode;
+            public float? MinValue;
+            public float? MaxValue;
+            public bool Hidden;
+            public string Category;
+            internal int? CategoryOrder;
+            internal int DeclarationOrder;
+            internal string DisplayName;
+            internal int? Order;
+            internal string EditorId;
+            internal MaterialEditorPropertyUiLevel UiLevel;
+            internal MaterialEditorPropertyCondition ShowIf;
+            internal List<MaterialEditorEnumOption> EnumOptions;
+            internal float OffValue;
+            internal float OnValue;
+        }
+    }
+}

--- a/tests/MaterialEditor.MetadataTests/ShaderPropertyFallbackPolicyTests.cs
+++ b/tests/MaterialEditor.MetadataTests/ShaderPropertyFallbackPolicyTests.cs
@@ -21,15 +21,12 @@ internal static class ShaderPropertyFallbackPolicyTests
             MaxValue = 8.5f,
             Hidden = true,
             Category = "Surface",
-            CategoryOrder = 20,
             DeclarationOrder = 4,
             DisplayName = "Rendering mode",
-            Order = 30,
             EditorId = ShaderPropertyEditorIds.Enum,
             UiLevel = MaterialEditorPropertyUiLevel.Advanced,
             ShowIf = condition,
-            OffValue = -1f,
-            OnValue = 3f
+            Invert = true
         };
         shaderSpecific.EnumOptions.Add(
             new MaterialEditorEnumOption(2f, "Opaque"));
@@ -71,8 +68,6 @@ internal static class ShaderPropertyFallbackPolicyTests
         Equal(shaderSpecific.Category, fallback.Category, "legacy Category");
 
         Equal(fallback.Name, fallback.DisplayName, "neutral DisplayName");
-        Equal(null, fallback.Order, "neutral Order");
-        Equal(null, fallback.CategoryOrder, "neutral CategoryOrder");
         Equal(0, fallback.DeclarationOrder, "neutral DeclarationOrder");
         Equal(
             MaterialEditorPropertyUiLevel.Basic,
@@ -84,26 +79,19 @@ internal static class ShaderPropertyFallbackPolicyTests
         False(
             ReferenceEquals(shaderSpecific.EnumOptions, fallback.EnumOptions),
             "fallback EnumOptions are isolated");
-        Equal(0f, fallback.OffValue, "neutral OffValue");
-        Equal(1f, fallback.OnValue, "neutral OnValue");
+        Equal(false, fallback.Invert, "neutral Invert");
 
         Equal(
             "Rendering mode",
             shaderSpecific.DisplayName,
             "shader metadata remains intact");
-        Equal(30, shaderSpecific.Order, "shader Order remains intact");
-        Equal(
-            20,
-            shaderSpecific.CategoryOrder,
-            "shader CategoryOrder remains intact");
         Equal(
             ShaderPropertyEditorIds.Enum,
             shaderSpecific.EditorId,
             "shader Editor remains intact");
         Equal(condition, shaderSpecific.ShowIf, "shader ShowIf remains intact");
         Equal(1, shaderSpecific.EnumOptions.Count, "shader options remain intact");
-        Equal(-1f, shaderSpecific.OffValue, "shader OffValue remains intact");
-        Equal(3f, shaderSpecific.OnValue, "shader OnValue remains intact");
+        Equal(true, shaderSpecific.Invert, "shader Invert remains intact");
 
         True(
             ShaderPropertyFallbackPolicy.IsReservedShaderName("default"),
@@ -146,8 +134,6 @@ namespace MaterialEditorAPI
                 DisplayName = name;
                 UiLevel = MaterialEditorPropertyUiLevel.Basic;
                 EnumOptions = new List<MaterialEditorEnumOption>();
-                OffValue = 0f;
-                OnValue = 1f;
             }
 
             public string Name;
@@ -161,16 +147,13 @@ namespace MaterialEditorAPI
             public float? MaxValue;
             public bool Hidden;
             public string Category;
-            internal int? CategoryOrder;
             internal int DeclarationOrder;
             internal string DisplayName;
-            internal int? Order;
             internal string EditorId;
             internal MaterialEditorPropertyUiLevel UiLevel;
             internal MaterialEditorPropertyCondition ShowIf;
             internal List<MaterialEditorEnumOption> EnumOptions;
-            internal float OffValue;
-            internal float OnValue;
+            internal bool Invert;
         }
     }
 }

--- a/tests/MaterialEditor.MetadataTests/ShaderUiModeTests.cs
+++ b/tests/MaterialEditor.MetadataTests/ShaderUiModeTests.cs
@@ -6,7 +6,6 @@ internal static class ShaderUiModeTests
     {
         ModesAreIndependentPerShader();
         BasicIsTheDefaultAndRemovesStoredState();
-        AdvancedLabelsHaveAnExplicitMarker();
     }
 
     private static void ModesAreIndependentPerShader()
@@ -45,26 +44,6 @@ internal static class ShaderUiModeTests
             state.SetMode("Shader/A", MaterialEditorUiMode.Basic),
             "returning to Basic removes state");
         Equal(MaterialEditorUiMode.Basic, state.GetMode("Shader/A"), "restored Basic");
-    }
-
-    private static void AdvancedLabelsHaveAnExplicitMarker()
-    {
-        Equal(
-            "Property",
-            MaterialEditorAdvancedPropertyPresentation.FormatLabel(
-                "Property",
-                false),
-            "Basic label");
-        Equal(
-            "[A] Property",
-            MaterialEditorAdvancedPropertyPresentation.FormatLabel(
-                "Property",
-                true),
-            "Advanced label");
-        Equal(
-            "[A] ",
-            MaterialEditorAdvancedPropertyPresentation.FormatLabel(null, true),
-            "null Advanced label");
     }
 
     private static void True(bool value, string name)

--- a/tests/MaterialEditor.MetadataTests/ShaderUiModeTests.cs
+++ b/tests/MaterialEditor.MetadataTests/ShaderUiModeTests.cs
@@ -1,0 +1,90 @@
+using MaterialEditorAPI;
+
+internal static class ShaderUiModeTests
+{
+    internal static void Run()
+    {
+        ModesAreIndependentPerShader();
+        BasicIsTheDefaultAndRemovesStoredState();
+        AdvancedLabelsHaveAnExplicitMarker();
+    }
+
+    private static void ModesAreIndependentPerShader()
+    {
+        var state = new MaterialEditorShaderUiModeState();
+
+        True(
+            state.SetMode("Shader/A", MaterialEditorUiMode.Advanced),
+            "first Shader/A change");
+        Equal(
+            MaterialEditorUiMode.Advanced,
+            state.GetMode("Shader/A"),
+            "Shader/A mode");
+        Equal(
+            MaterialEditorUiMode.Basic,
+            state.GetMode("Shader/B"),
+            "Shader/B remains independent");
+        False(
+            state.SetMode("Shader/A", MaterialEditorUiMode.Advanced),
+            "same Shader/A mode is a no-op");
+    }
+
+    private static void BasicIsTheDefaultAndRemovesStoredState()
+    {
+        var state = new MaterialEditorShaderUiModeState();
+
+        Equal(MaterialEditorUiMode.Basic, state.GetMode(null), "null shader");
+        Equal(MaterialEditorUiMode.Basic, state.GetMode(string.Empty), "empty shader");
+        Equal(MaterialEditorUiMode.Basic, state.GetMode("Shader/A"), "fresh shader");
+        False(
+            state.SetMode(string.Empty, MaterialEditorUiMode.Advanced),
+            "empty shader is not stored");
+
+        state.SetMode("Shader/A", MaterialEditorUiMode.Advanced);
+        True(
+            state.SetMode("Shader/A", MaterialEditorUiMode.Basic),
+            "returning to Basic removes state");
+        Equal(MaterialEditorUiMode.Basic, state.GetMode("Shader/A"), "restored Basic");
+    }
+
+    private static void AdvancedLabelsHaveAnExplicitMarker()
+    {
+        Equal(
+            "Property",
+            MaterialEditorAdvancedPropertyPresentation.FormatLabel(
+                "Property",
+                false),
+            "Basic label");
+        Equal(
+            "[A] Property",
+            MaterialEditorAdvancedPropertyPresentation.FormatLabel(
+                "Property",
+                true),
+            "Advanced label");
+        Equal(
+            "[A] ",
+            MaterialEditorAdvancedPropertyPresentation.FormatLabel(null, true),
+            "null Advanced label");
+    }
+
+    private static void True(bool value, string name)
+    {
+        if (!value)
+            throw new InvalidOperationException(name + ": expected true.");
+    }
+
+    private static void False(bool value, string name)
+    {
+        if (value)
+            throw new InvalidOperationException(name + ": expected false.");
+    }
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException(
+                name + ": expected '" + expected + "', got '" + actual + "'.");
+        }
+    }
+}

--- a/tests/MaterialEditor.MetadataTests/UiLevelPerShaderContractTests.cs
+++ b/tests/MaterialEditor.MetadataTests/UiLevelPerShaderContractTests.cs
@@ -200,7 +200,7 @@ internal static class UiLevelPerShaderContractTests
         DoesNotContain(bindMethod, "new GameObject", "rebind creates no GameObjects");
         Contains(
             bindMethod,
-            "if (!force && ReferenceEquals(item, _currentModel))\n                return;",
+            "if (!force && ReferenceEquals(item, _currentModel))",
             "same-model fast path preserves the already-correct accent state");
     }
 

--- a/tests/MaterialEditor.MetadataTests/UiLevelPerShaderContractTests.cs
+++ b/tests/MaterialEditor.MetadataTests/UiLevelPerShaderContractTests.cs
@@ -41,6 +41,30 @@ internal static class UiLevelPerShaderContractTests
             "MaterialEditor.Base",
             "UI",
             "UI.PropertyDescriptor.cs");
+        var shaderMode = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.ShaderUiMode.cs");
+        var rowFactory = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowViewFactory.cs");
+        var rowBinder = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowBinder.cs");
+        var style = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.StyleSystem.cs");
 
         DoesNotContain(
             window,
@@ -97,8 +121,98 @@ internal static class UiLevelPerShaderContractTests
 
         Contains(
             descriptor,
-            "MaterialEditorAdvancedPropertyPresentation.FormatLabel",
-            "Advanced rows receive an explicit visible marker before binding");
+            "row.IsAdvanced = isAdvanced;",
+            "Advanced metadata reaches the row model");
+        DoesNotContain(descriptor, "FormatLabel", "metadata does not decorate property labels");
+        DoesNotContain(
+            shaderMode,
+            "MaterialEditorAdvancedPropertyPresentation",
+            "obsolete textual marker helper is removed");
+        var obsoleteAdvancedMarker = "[" + "A" + "]";
+        DoesNotContain(
+            descriptor + shaderMode,
+            obsoleteAdvancedMarker,
+            "Advanced labels contain no textual marker");
+
+        Contains(
+            rowFactory,
+            "CreateAdvancedPropertyAccent(contentList.transform);",
+            "pooled template precreates one Advanced accent overlay");
+        Equal(
+            1,
+            CountOccurrences(rowFactory, "\"AdvancedPropertyAccent\","),
+            "Advanced accent object is created once per pooled template");
+        Contains(
+            rowFactory,
+            "accent.color = MaterialEditorStyles.AdvancedPropertyAccentColor;",
+            "accent uses its semantic color");
+        Contains(rowFactory, "accent.raycastTarget = false;", "accent consumes no pointer events");
+        Contains(rowFactory, "canvasGroup.interactable = false;", "accent is non-interactive");
+        Contains(rowFactory, "canvasGroup.blocksRaycasts = false;", "accent blocks no row controls");
+        Contains(rowFactory, "accent.transform.SetAsLastSibling();", "accent renders over the row panel");
+        Contains(rowFactory, "accent.gameObject.SetActive(false);", "template starts without a stale accent");
+        DoesNotContain(rowFactory, "SetWidth(accent", "overlay consumes no horizontal layout width");
+        Equal(
+            true,
+            rowFactory.IndexOf("RowLayoutCatalog.Apply(contentList.gameObject);", StringComparison.Ordinal)
+            < rowFactory.IndexOf("CreateAdvancedPropertyAccent(contentList.transform);", StringComparison.Ordinal),
+            "accent remains outside the family HorizontalLayoutGroups");
+        Contains(
+            style,
+            "internal const float AdvancedPropertyAccentWidth = 5f;",
+            "Advanced accent width is structural");
+        Contains(
+            style,
+            "internal const float AdvancedPropertyAccentVerticalInset = 2f;",
+            "Advanced accent vertical inset is structural");
+        Contains(
+            style,
+            "new Color32(0x4A, 0xA3, 0xFF, 0xFF);",
+            "Advanced accent keeps the final blue color without the wider redesign");
+
+        Contains(
+            controls,
+            "owner.GetUIComponent<Image>(\"AdvancedPropertyAccent\")",
+            "pooled controls cache the accent without a bind-time lookup");
+        Contains(
+            controls,
+            "SetAdvancedPropertyAccent(false);",
+            "every rebind first clears the previous row accent");
+        Contains(
+            rowBinder,
+            "_controls.SetAdvancedPropertyAccent(item.IsAdvanced);",
+            "binding applies the accent only from the row Advanced flag");
+        var bindMethod = Slice(
+            rowBinder,
+            "internal void Bind(RowModel item, bool force)",
+            "public void SetVisible(bool visible)");
+        Equal(
+            true,
+            bindMethod.IndexOf("_controls.HideAll();", StringComparison.Ordinal)
+            < bindMethod.IndexOf("_controls.SetAdvancedPropertyAccent(item.IsAdvanced);", StringComparison.Ordinal),
+            "Basic/Advanced rebinds clear stale state before applying the model");
+        Equal(
+            1,
+            CountOccurrences(bindMethod, "SetAdvancedPropertyAccent("),
+            "each successful bind applies one accent state");
+        DoesNotContain(bindMethod, "GetUIComponent", "rebind performs no name lookup");
+        DoesNotContain(bindMethod, "AddComponent", "rebind creates no UI components");
+        DoesNotContain(bindMethod, "new GameObject", "rebind creates no GameObjects");
+        Contains(
+            bindMethod,
+            "if (!force && ReferenceEquals(item, _currentModel))\n                return;",
+            "same-model fast path preserves the already-correct accent state");
+    }
+
+    private static string Slice(string source, string start, string end)
+    {
+        var startIndex = source.IndexOf(start, StringComparison.Ordinal);
+        if (startIndex < 0)
+            throw new InvalidOperationException("Could not locate source slice start.");
+        var endIndex = source.IndexOf(end, startIndex, StringComparison.Ordinal);
+        if (endIndex < 0)
+            throw new InvalidOperationException("Could not locate source slice end.");
+        return source.Substring(startIndex, endIndex - startIndex);
     }
 
     private static string ReadSource(string root, params string[] parts)

--- a/tests/MaterialEditor.MetadataTests/UiLevelPerShaderContractTests.cs
+++ b/tests/MaterialEditor.MetadataTests/UiLevelPerShaderContractTests.cs
@@ -1,0 +1,157 @@
+internal static class UiLevelPerShaderContractTests
+{
+    internal static void Run()
+    {
+        var root = FindRepositoryRoot();
+        var window = ReadSource(root, "src", "MaterialEditor.Base", "UI", "UI.WindowView.cs");
+        var session = ReadSource(root, "src", "MaterialEditor.Base", "UI", "UI.SessionState.cs");
+        var presenter = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.MaterialSectionPresenter.cs");
+        var model = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowModel.MaterialShader.cs");
+        var factory = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowViewFactory.MaterialShader.cs");
+        var controls = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowControls.cs");
+        var binder = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.RowBinder.MaterialShader.cs");
+        var descriptor = ReadSource(
+            root,
+            "src",
+            "MaterialEditor.Base",
+            "UI",
+            "UI.PropertyDescriptor.cs");
+
+        DoesNotContain(
+            window,
+            "MaterialEditorModePanel",
+            "the global Basic/Advanced panel is removed");
+        DoesNotContain(
+            window,
+            "BasicModeButton",
+            "the global Basic button is removed");
+        DoesNotContain(
+            window,
+            "AdvancedModeButton",
+            "the global Advanced button is removed");
+        Contains(
+            session,
+            "MaterialEditorShaderUiModeState ShaderUiModes",
+            "session owns per-shader modes");
+        DoesNotContain(
+            session,
+            "MaterialEditorUiMode UiMode =",
+            "session has no scalar global mode");
+
+        Contains(model, "HasAdvancedProperties", "shader model advertises Advanced metadata");
+        Contains(model, "UiModeOnChange", "shader model owns the mode action");
+        Contains(factory, "ShaderUiModeButton", "shader row creates the mode control");
+        Contains(controls, "ShaderUiModeButton", "pooled controls cache the mode control");
+        Contains(
+            binder,
+            "controls.UiModeButton.gameObject.SetActive(item.HasAdvancedProperties);",
+            "mode control is absent for shaders without Advanced properties");
+        Contains(
+            binder,
+            "item.UiMode == MaterialEditorUiMode.Advanced",
+            "mode control reflects its shader snapshot");
+
+        Contains(
+            presenter,
+            "_session.ShaderUiModes.GetMode(context.ShaderName)",
+            "property filtering resolves the current shader mode");
+        Contains(
+            presenter,
+            "if (_session.ShaderUiModes.SetMode(shaderItem.ShaderName, value))",
+            "changing a shader mode is guarded against no-op rebuilds");
+        Equal(
+            1,
+            CountOccurrences(
+                presenter,
+                "if (_session.ShaderUiModes.SetMode(shaderItem.ShaderName, value))"),
+            "one mode mutation site");
+        DoesNotContain(
+            presenter,
+            "_session.UiMode",
+            "presenter no longer reads global mode");
+
+        Contains(
+            descriptor,
+            "MaterialEditorAdvancedPropertyPresentation.FormatLabel",
+            "Advanced rows receive an explicit visible marker before binding");
+    }
+
+    private static string ReadSource(string root, params string[] parts)
+    {
+        var path = parts.Aggregate(root, Path.Combine);
+        return File.ReadAllText(path).Replace("\r\n", "\n");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            var directory = new DirectoryInfo(start);
+            while (directory != null)
+            {
+                if (File.Exists(Path.Combine(
+                        directory.FullName,
+                        "tests",
+                        "MaterialEditor.MetadataTests",
+                        "MaterialEditor.MetadataTests.csproj")))
+                {
+                    return directory.FullName;
+                }
+                directory = directory.Parent;
+            }
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root.");
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
+
+    private static void Contains(string source, string value, string name) =>
+        Equal(true, source.Contains(value, StringComparison.Ordinal), name);
+
+    private static void DoesNotContain(string source, string value, string name) =>
+        Equal(false, source.Contains(value, StringComparison.Ordinal), name);
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException(
+                name + ": expected '" + expected + "', got '" + actual + "'.");
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Add opt-in `<MaterialEditor SchemaVersion="2">` metadata for `DisplayName`, `UiLevel`, and `ShowIf`.
- Add Float-backed `Boolean` and `Enum` controls using the reviewed canonical syntax: optional `Invert="true"` for Boolean and `Enums="Label,Value,..."` for Enum.
- Make the Basic/Advanced selector independent per shader and identify visible Advanced property rows with a vertical blue accent bar.
- Preserve declaration-driven property/category ordering instead of adding manifest-only order fields.
- Add focused documentation, an updated schema 2 example manifest, and regression tests.

## Motivation and Context

Shader authors currently have to rely on internal property names and legacy controls. This adds an explicitly versioned, backward-compatible UI metadata layer so manifests can provide clearer labels, conditional visibility, and simple Float-backed controls without changing save data or material-edit paths.

Sideloader's outer `<manifest schema-ver="1">` remains unchanged. Missing, invalid, or unsupported Material Editor `SchemaVersion` values retain schema 1 behavior. Shader-specific schema 2 metadata is prevented from leaking into the global legacy fallback.

## Review Feedback Addressed

- Removed `Dropdown` as a schema 2 type alias; use `Type="Enum"`.
- Removed manifest-only `Order` and `CategoryOrder`; declaration order remains authoritative.
- Replaced nested options with Unity-style `Enums="Label,Value,..."` pairs and invariant validation.
- Use `Boolean` as the sole Float-backed Boolean data type; manifests use `Type="Boolean"`.
- Boolean writes only `0` or `1` after an explicit checkbox change; optional `Invert="true"` only reverses the displayed state. Existing values are not rewritten when the UI opens or refreshes.
- Enum values are matched by direct equality only. Unmatched values are displayed without being changed, and an explicit choice writes exactly its declared value, including when resolving a mixed selection.
- Scoped Basic/Advanced state and its selector per shader, with a vertical accent bar.
- Deferred Cubemap support to a separate follow-up PR, as requested.
- Relaxed two formatting-sensitive source-contract assertions raised in the latest review.

## How Has This Been Tested?

- Material Editor metadata regression suite: PASS.
- Release build of `MaterialEditor.API`: PASS, including its normal PublicApiAnalyzers configuration.
- Release builds for AI, EC, HS2, KK, KKS, and PH: PASS.
- Schema 2 example manifest parsed as valid XML.
- `git diff --check origin/master...HEAD`: PASS.

Existing XML-documentation warnings remain unchanged; no build errors were introduced.

## Screenshots (if appropriate)

Not included; this PR is focused on the parser/UI contract and manifest authoring workflow.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Compatibility

- No shipped public API or save-data format changes.
- Boolean and Enum edits continue through existing Float paths.
- Schema 1 manifests preserve their existing behavior.
- The reviewed schema 2 syntax replaces only unshipped PR syntax.

## Non-goals

- Cubemap support; it will be proposed in a separate follow-up PR.
- No Color/Vector distinction in this PR.
- No broader local UI redesign, theme, sidebar, renderer-collapse, or deployment changes.
- No persisted Basic/Advanced preference.
- No changes to legacy `DefaultValue` application or material serialization semantics.