### PR TITLE
[ME][1/7] Unify operation results and import ownership

### DIFF
--- a/src/MaterialEditor.Base/IMaterialEditRepository.cs
+++ b/src/MaterialEditor.Base/IMaterialEditRepository.cs
@@ -74,13 +74,13 @@ namespace MaterialEditorAPI
     /// </summary>
     internal interface IMaterialTextureImportCompletionRepository
     {
-        void SetMaterialTexture(
+        Action SetMaterialTexture(
             object data,
             Material material,
             string propertyName,
             string filePath,
             GameObject gameObject,
-            Action<bool> completed);
+            Action<MaterialEditResult> completed);
     }
 
     /// <summary>

--- a/src/MaterialEditor.Base/MaterialEditService.cs
+++ b/src/MaterialEditor.Base/MaterialEditService.cs
@@ -177,26 +177,25 @@ namespace MaterialEditorAPI
         internal void SetMaterialTexture(object data, Material material, string propertyName, string filePath, GameObject gameObject) =>
             GetRepository(data).SetMaterialTexture(data, material, propertyName, filePath, gameObject);
 
-        internal void SetMaterialTexture(
+        internal Action SetMaterialTexture(
             object data,
             Material material,
             string propertyName,
             string filePath,
             GameObject gameObject,
-            Action<bool> completed)
+            Action<MaterialEditResult> completed)
         {
             var repository = GetRepository(data);
             var completionRepository = repository as IMaterialTextureImportCompletionRepository;
             if (completionRepository != null)
             {
-                completionRepository.SetMaterialTexture(
+                return completionRepository.SetMaterialTexture(
                     data,
                     material,
                     propertyName,
                     filePath,
                     gameObject,
                     completed);
-                return;
             }
 
             try
@@ -205,11 +204,12 @@ namespace MaterialEditorAPI
             }
             catch
             {
-                completed?.Invoke(false);
+                completed?.Invoke(new MaterialEditResult(MaterialEditStatus.Failed, "Legacy import"));
                 throw;
             }
 
-            completed?.Invoke(true);
+            completed?.Invoke(new MaterialEditResult(MaterialEditStatus.Unverified, "Legacy void API"));
+            return null;
         }
 
         internal void RemoveMaterialTexture(object data, Material material, string propertyName, GameObject gameObject) =>

--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -9,6 +9,8 @@
     <Import_RootNamespace>MaterialEditor.API</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\MaterialEditResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\MaterialEditRequestQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NormalMapManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IMaterialEditorColorPalette.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MaterialAPI.cs" />

--- a/src/MaterialEditor.Base/Operations/MaterialEditRequestQueue.cs
+++ b/src/MaterialEditor.Base/Operations/MaterialEditRequestQueue.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MaterialEditorAPI
+{
+    /// <summary>Runtime-only target identity; never serialized into cards or scenes.</summary>
+    internal sealed class MaterialEditTarget
+    {
+        internal readonly GameObject Root;
+        internal readonly Material Material;
+        internal readonly string MaterialName;
+        internal readonly string Property;
+        private readonly Shader _shader;
+
+        internal MaterialEditTarget(GameObject root, Material material, string property)
+        {
+            Root = root;
+            Material = material;
+            MaterialName = material == null ? null : material.NameFormatted();
+            Property = property;
+            _shader = material == null ? null : material.shader;
+        }
+
+        internal bool IsAlive => Root != null && Material != null
+            && Material.shader == _shader && Material.NameFormatted() == MaterialName;
+
+        internal bool Matches(GameObject root, string materialName, string property) =>
+            ReferenceEquals(Root, root) && (materialName == null || MaterialName == materialName)
+            && (property == null || Property == property);
+
+        internal bool SameProperty(MaterialEditTarget other) =>
+            other != null && Matches(other.Root, other.MaterialName, other.Property);
+    }
+
+    /// <summary>
+    /// Main-thread FIFO. Acceptance precedes async reads. Owners pump at most one
+    /// start per Update; completions never recursively start the next request.
+    /// </summary>
+    internal sealed class MaterialEditRequestQueue : IDisposable
+    {
+        private sealed class Request
+        {
+            internal MaterialEditTarget Target;
+            internal string WatchPath;
+            internal Func<bool> IsValid;
+            internal Func<Action<MaterialEditResult>, Action> Start;
+            internal Action<MaterialEditResult> Completed;
+            internal Action Cancel;
+            internal bool Finished;
+            internal MaterialEditStatus Status;
+
+            internal void Finish(MaterialEditResult result)
+            {
+                if (Finished) return;
+                Finished = true;
+                Status = result.Status;
+                var callback = Completed;
+                Completed = null;
+                Start = null;
+                Cancel = null;
+                IsValid = null;
+                try { callback?.Invoke(result); }
+                catch (Exception ex) { MaterialEditorPluginBase.Logger?.LogWarning(ex); }
+            }
+        }
+
+        private const int Capacity = 32;
+        private static readonly List<WeakReference> Queues = new List<WeakReference>();
+        private readonly List<Request> _pending = new List<Request>();
+        private Request _active;
+        private bool _disposed;
+
+        internal MaterialEditRequestQueue()
+        {
+            Queues.RemoveAll(x => !x.IsAlive);
+            Queues.Add(new WeakReference(this));
+        }
+
+        internal Action Enqueue(MaterialEditTarget target, Func<bool> valid,
+            Func<Action<MaterialEditResult>, Action> start,
+            Action<MaterialEditResult> completed, string watchPath = null)
+        {
+            var request = new Request { Target = target, IsValid = valid,
+                Start = start, Completed = completed, WatchPath = watchPath };
+            // Only watcher refreshes coalesce. Explicit user imports are never displaced.
+            if (watchPath != null)
+                CancelWhere(x => x.WatchPath == watchPath && target.SameProperty(x.Target),
+                    MaterialEditStatus.Superseded, false);
+            // A superseded completion may dispose this owner reentrantly.
+            if (_disposed)
+            {
+                request.Finish(new MaterialEditResult(MaterialEditStatus.Cancelled, "Owner disposed"));
+                return null;
+            }
+            if (_pending.Count + (_active == null || _active.Finished ? 0 : 1) >= Capacity)
+            {
+                request.Finish(new MaterialEditResult(MaterialEditStatus.Failed, "Queue", "Import queue is full."));
+                return null;
+            }
+            _pending.Add(request);
+            return () =>
+            {
+                _pending.Remove(request);
+                CancelRequest(request, MaterialEditStatus.Cancelled);
+            };
+        }
+
+        internal void Pump()
+        {
+            if (_disposed) return;
+            if (_active != null && !_active.Finished)
+            {
+                if (!Valid(_active)) CancelRequest(_active, MaterialEditStatus.Cancelled);
+                return;
+            }
+            _active = null;
+            if (_pending.Count == 0) return;
+            var request = _pending[0];
+            _pending.RemoveAt(0);
+            _active = request;
+            if (!Valid(request))
+            {
+                request.Finish(new MaterialEditResult(MaterialEditStatus.Cancelled, "Stale target"));
+                return;
+            }
+            try
+            {
+                var cancel = request.Start(request.Finish);
+                if (!request.Finished) request.Cancel = cancel;
+                else if (request.Status == MaterialEditStatus.Cancelled || request.Status == MaterialEditStatus.Superseded)
+                    cancel?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                request.Finish(new MaterialEditResult(MaterialEditStatus.Failed, "Import", ex.Message));
+            }
+        }
+
+        private static bool Valid(Request request)
+        {
+            try { return request.Target.IsAlive && (request.IsValid == null || request.IsValid()); }
+            catch { return false; }
+        }
+
+        private static void CancelRequest(Request request, MaterialEditStatus status)
+        {
+            if (request.Finished) return;
+            var cancel = request.Cancel;
+            request.Cancel = null;
+            // Mark terminal before cancelling a runner, which can call back synchronously.
+            request.Finish(new MaterialEditResult(status, "Lifecycle"));
+            try { cancel?.Invoke(); }
+            catch (Exception ex) { MaterialEditorPluginBase.Logger?.LogWarning(ex); }
+        }
+
+        private void CancelWhere(Predicate<Request> match, MaterialEditStatus status, bool includeActive)
+        {
+            var removed = _pending.FindAll(match);
+            _pending.RemoveAll(match);
+            if (includeActive && _active != null && match(_active))
+                CancelRequest(_active, status);
+            foreach (var request in removed) CancelRequest(request, status);
+        }
+
+        internal void CancelAll() => CancelWhere(x => true, MaterialEditStatus.Cancelled, true);
+
+        internal static void CancelTarget(GameObject root, string materialName = null, string property = null)
+        {
+            foreach (var weak in Queues.ToArray())
+            {
+                var queue = weak.Target as MaterialEditRequestQueue;
+                queue?.CancelWhere(x => x.Target.Matches(root, materialName, property),
+                    MaterialEditStatus.Cancelled, true);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            CancelAll();
+            _active = null;
+            Queues.RemoveAll(x => !x.IsAlive || ReferenceEquals(x.Target, this));
+        }
+    }
+}

--- a/src/MaterialEditor.Base/Operations/MaterialEditResult.cs
+++ b/src/MaterialEditor.Base/Operations/MaterialEditResult.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace MaterialEditorAPI
+{
+    internal enum MaterialEditStatus { Succeeded, Failed, Cancelled, Superseded, Unverified }
+
+    /// <summary>Internal completion contract; legacy public void APIs remain unchanged.</summary>
+    internal sealed class MaterialEditResult
+    {
+        internal readonly MaterialEditStatus Status;
+        internal readonly string Stage;
+        internal readonly string Diagnostic;
+        internal bool Succeeded => Status == MaterialEditStatus.Succeeded;
+
+        internal MaterialEditResult(MaterialEditStatus status, string stage = null, string diagnostic = null)
+        {
+            Status = status;
+            Stage = stage;
+            Diagnostic = diagnostic;
+        }
+
+        internal static MaterialEditResult FromApplied(bool applied) =>
+            new MaterialEditResult(applied ? MaterialEditStatus.Succeeded : MaterialEditStatus.Failed, "Apply/commit");
+    }
+}

--- a/src/MaterialEditor.Base/UI/Assets/MaterialEditorAssetWorkflow.cs
+++ b/src/MaterialEditor.Base/UI/Assets/MaterialEditorAssetWorkflow.cs
@@ -17,6 +17,9 @@ namespace MaterialEditorAPI
         private readonly MaterialEditService _editService;
         // Texture watching is process-wide so all UI hosts share one active watcher.
         private static FileSystemWatcher _textureWatcher;
+        private static MaterialEditorAssetWorkflow _watcherOwner;
+        private readonly MaterialEditRequestQueue _imports = new MaterialEditRequestQueue();
+        private FileSystemWatcher _ownedWatcher;
         private bool _disposed;
 
         internal MaterialEditorAssetWorkflow(
@@ -29,247 +32,139 @@ namespace MaterialEditorAPI
                 throw new ArgumentNullException("editService");
             _host = host;
             _editService = editService;
+            _host.StartCoroutine(PumpImports());
         }
 
-        internal void ImportTexture(
-            TexturePropertyRowModel textureItem,
-            GameObject gameObject,
-            object data,
-            Material material,
-            string propertyName)
+        private IEnumerator PumpImports()
+        {
+            while (!_disposed && _host != null)
+            {
+                _imports.Pump();
+                yield return null;
+            }
+            Dispose();
+        }
+
+        internal void ImportTexture(TexturePropertyRowModel row, GameObject root,
+            object data, Material material, string propertyName)
         {
 #if !API
-            string fileFilter = KK_Plugins.ImageHelper.FileFilter;
+            string filter = KK_Plugins.ImageHelper.FileFilter;
 #else
-            string fileFilter = "Images (*.png;.jpg)|*.png;*.jpg|All files|*.*";
+            string filter = "Images (*.png;.jpg)|*.png;*.jpg|All files|*.*";
 #endif
-            var propertyHandle = MaterialPropertyIdCache.Get(propertyName);
-            KKAPI.Utilities.OpenFileDialog.Show(
-                OnFileAccept,
-                "Open image",
-                ExportPath,
-                fileFilter,
-                ".png");
-
-            void OnFileAccept(string[] files)
-            {
-                ThreadingHelper.Instance.StartSyncInvoke(
-                    () =>
-                    {
-                        if (IsHostAlive())
-                            _host.StartCoroutine(
-                                ApplyFileSelectionOnMainThread(files));
-                    });
-            }
-
-            IEnumerator ApplyFileSelectionOnMainThread(string[] files)
-            {
-                // StartSyncInvoke is drained by BepInEx.Update. Yield once so
-                // disk reads run outside that drain.
-                yield return null;
-
-                if (material == null || gameObject == null)
-                    yield break;
-
-                if (files == null || files.Length == 0 || files[0].IsNullOrEmpty())
+            var target = new MaterialEditTarget(root, material, propertyName);
+            KKAPI.Utilities.OpenFileDialog.Show(files =>
+                ThreadingHelper.Instance.StartSyncInvoke(() =>
                 {
-                    textureItem.Changed =
-                        !_editService.GetMaterialTextureValueOriginal(
-                            data,
-                            material,
-                            propertyName,
-                            gameObject);
-                    var currentTexture = MaterialPropertyAccess.GetTexture(
-                        material,
-                        propertyHandle);
-                    textureItem.Exists = currentTexture != null;
-                    textureItem.RefreshState?.Invoke();
-                    yield break;
-                }
-
-                string filePath = files[0];
-                _editService.SetMaterialTexture(
-                    data,
-                    material,
-                    propertyName,
-                    filePath,
-                    gameObject,
-                    succeeded =>
+                    if (!IsHostAlive() || !target.IsAlive || files == null
+                        || files.Length == 0 || string.IsNullOrEmpty(files[0])) return;
+                    QueueTexture(target, data, files[0], result =>
                     {
-                        if (!IsHostAlive()
-                            || material == null
-                            || gameObject == null)
-                            return;
-
-                        // Character and Studio repositories apply Texture2D imports
-                        // on their next Update. Refresh only after that work reports
-                        // completion, and derive both flags from the real edit/material
-                        // state instead of assuming that decoding succeeded.
-                        textureItem.Changed =
-                            !_editService.GetMaterialTextureValueOriginal(
-                                data,
-                                material,
-                                propertyName,
-                                gameObject);
-                        textureItem.Exists = MaterialPropertyAccess.GetTexture(
-                            material,
-                            propertyHandle) != null;
-                        textureItem.RefreshState?.Invoke();
-
-                        if (!succeeded)
-                        {
-                            MaterialEditorPluginBase.Logger.LogWarning(
-                                $"Could not import texture '{filePath}' for {propertyName}.");
-                        }
+                        if (!IsHostAlive() || !target.IsAlive) return;
+                        row.Changed = !_editService.GetMaterialTextureValueOriginal(data, material, propertyName, root);
+                        row.Exists = MaterialPropertyAccess.GetTexture(material, MaterialPropertyIdCache.Get(propertyName)) != null;
+                        row.RefreshState?.Invoke();
+                        ReportImportResult(result, propertyName);
                     });
-
-                DisposeTextureWatcher();
-                if (!WatchTexChanges.Value)
-                    yield break;
-
-                var directory = Path.GetDirectoryName(filePath);
-                if (directory == null)
-                    yield break;
-
-                _textureWatcher = new FileSystemWatcher(
-                    directory,
-                    Path.GetFileName(filePath));
-                _textureWatcher.Changed += (sender, args) =>
-                {
-                    if (WatchTexChanges.Value && File.Exists(filePath))
-                        ScheduleTextureWatcherImport(
-                            data,
-                            material,
-                            propertyName,
-                            filePath,
-                            gameObject);
-                };
-                _textureWatcher.Deleted +=
-                    (sender, args) => DisposeTextureWatcher();
-                _textureWatcher.Error +=
-                    (sender, args) => DisposeTextureWatcher();
-                _textureWatcher.EnableRaisingEvents = true;
-            }
+                    WatchTexture(target, data, files[0]);
+                }), "Open image", ExportPath, filter, ".png");
         }
 
-        internal void ImportCubemap(
-            CubemapPropertyRowModel cubemapItem,
-            GameObject gameObject,
-            object data,
-            Material material,
-            string propertyName)
+        private void QueueTexture(MaterialEditTarget target, object data, string path,
+            Action<MaterialEditResult> completed, bool watching = false)
         {
-            const string fileFilter = "Cubemap panoramas (*.png;*.hdr)|*.png;*.hdr|PNG images (*.png)|*.png|Radiance HDR images (*.hdr)|*.hdr|All files|*.*";
-            var propertyHandle = MaterialPropertyIdCache.Get(propertyName);
-            KKAPI.Utilities.OpenFileDialog.Show(
-                OnFileAccept,
-                "Open Cubemap source",
-                ExportPath,
-                fileFilter,
-                ".png");
-
-            void OnFileAccept(string[] files)
+            _imports.Enqueue(target, IsHostAlive, done =>
             {
-                ThreadingHelper.Instance.StartSyncInvoke(
-                    () =>
-                    {
-                        if (!IsHostAlive()
-                            || material == null
-                            || gameObject == null
-                            || files == null
-                            || files.Length == 0
-                            || files[0].IsNullOrEmpty())
-                            return;
+                // Cancel only this repository request, not another UI owner's work.
+                return _editService.SetMaterialTexture(data, target.Material, target.Property, path, target.Root, done);
+            }, completed, watching ? path : null);
+        }
 
-                        var filePath = files[0];
+        internal void ImportCubemap(CubemapPropertyRowModel row, GameObject root,
+            object data, Material material, string propertyName)
+        {
+            const string filter = "Cubemap panoramas (*.png;*.hdr)|*.png;*.hdr|All files|*.*";
+            var target = new MaterialEditTarget(root, material, propertyName);
+            KKAPI.Utilities.OpenFileDialog.Show(files =>
+                ThreadingHelper.Instance.StartSyncInvoke(() =>
+                {
+                    if (!IsHostAlive() || !target.IsAlive || files == null
+                        || files.Length == 0 || string.IsNullOrEmpty(files[0])) return;
+                    var path = files[0];
+                    _imports.Enqueue(target, IsHostAlive, done =>
+                    {
+                        var runner = _host.gameObject.AddComponent<MaterialEditorCubemapImportRunner>();
                         try
                         {
-                            var runner = _host.gameObject.AddComponent<
-                                MaterialEditorCubemapImportRunner>();
-                            runner.Begin(
-                                filePath,
-                                () => IsHostAlive()
-                                      && material != null
-                                      && gameObject != null
-                                      && MaterialPropertyAccess.HasProperty(
-                                          material,
-                                          propertyHandle),
-                                (encodedData, contentKey, warmLease) =>
+                            runner.Begin(path, () => IsHostAlive() && target.IsAlive,
+                                (bytes, key, lease) =>
                                 {
-                                    // Keep the preheated cache entry alive until
-                                    // the repository has acquired its own lease.
-                                    if (warmLease == null)
-                                        return false;
-                                    if (_editService.SupportsMaterialCubemapDataImport(
-                                            data))
-                                    {
-                                        // A supported repository reports the
-                                        // real persistence/application result.
-                                        // Do not reinterpret failure as a reason
-                                        // to retry through the file-path API.
-                                        return _editService.SetMaterialCubemap(
-                                            data,
-                                            material,
-                                            propertyName,
-                                            encodedData,
-                                            contentKey,
-                                            gameObject);
-                                    }
-
-                                    // Repositories without preloaded-data support expose only
-                                    // the file-path API. Built-in Chara
-                                    // and Studio repositories use the byte seam,
-                                    // so they do not repeat disk IO here.
-                                    MaterialEditorPluginBase.Logger?.LogWarning(
-                                        "The active Material Editor repository does not support "
-                                        + "preloaded Cubemap data; using its file import path.");
-                                    _editService.SetMaterialCubemap(
-                                        data,
-                                        material,
-                                        propertyName,
-                                        filePath,
-                                        gameObject);
-                                    return true;
+                                    if (lease == null) return MaterialEditResult.FromApplied(false);
+                                    if (_editService.SupportsMaterialCubemapDataImport(data))
+                                        return MaterialEditResult.FromApplied(_editService.SetMaterialCubemap(
+                                            data, material, propertyName, bytes, key, root));
+                                    _editService.SetMaterialCubemap(data, material, propertyName, path, root);
+                                    return new MaterialEditResult(MaterialEditStatus.Unverified, "Legacy void API");
                                 },
-                                message => MaterialEditorPluginBase.Logger?.LogInfo(
-                                    message),
-                                message => MaterialEditorPluginBase.Logger?.LogWarning(
-                                    message),
-                                message => MaterialEditorPluginBase.Logger?.LogError(
-                                    "Could not import Cubemap '"
-                                    + propertyName
-                                    + "': "
-                                    + message),
-                                succeeded =>
-                                {
-                                    if (!IsHostAlive()
-                                        || material == null
-                                        || gameObject == null)
-                                        return;
-
-                                    cubemapItem.Changed =
-                                        !_editService.GetMaterialCubemapValueOriginal(
-                                            data,
-                                            material,
-                                            propertyName,
-                                            gameObject);
-                                    cubemapItem.Exists =
-                                        MaterialPropertyAccess.GetTexture(
-                                            material,
-                                            propertyHandle) is Cubemap;
-                                    cubemapItem.RefreshState?.Invoke();
-                                });
+                                message => MaterialEditorPluginBase.Logger?.LogInfo(message),
+                                message => MaterialEditorPluginBase.Logger?.LogWarning(message),
+                                message => MaterialEditorPluginBase.Logger?.LogError(message),
+                                done);
                         }
-                        catch (Exception exception)
+                        catch
                         {
-                            MaterialEditorPluginBase.Logger?.LogError(
-                                "Could not start Cubemap import '"
-                                + propertyName
-                                + "': "
-                                + exception.Message);
+                            UnityEngine.Object.Destroy(runner);
+                            throw;
                         }
+                        return runner.Cancel;
+                    }, result =>
+                    {
+                        if (!IsHostAlive() || !target.IsAlive) return;
+                        row.Changed = !_editService.GetMaterialCubemapValueOriginal(data, material, propertyName, root);
+                        row.Exists = MaterialPropertyAccess.GetTexture(material, MaterialPropertyIdCache.Get(propertyName)) is Cubemap;
+                        row.RefreshState?.Invoke();
+                        ReportImportResult(result, propertyName);
                     });
-            }
+                }), "Open Cubemap source", ExportPath, filter, ".png");
+        }
+
+        private static void ReportImportResult(MaterialEditResult result, string property)
+        {
+            if (result.Status == MaterialEditStatus.Failed || result.Status == MaterialEditStatus.Unverified)
+                MaterialEditorPluginBase.Logger?.LogWarning("Import " + property + ": "
+                    + result.Status + " (" + result.Stage + ") " + result.Diagnostic);
+        }
+
+        private void WatchTexture(MaterialEditTarget target, object data, string path)
+        {
+            DisposeTextureWatcher();
+            if (!WatchTexChanges.Value) return;
+            var directory = Path.GetDirectoryName(path);
+            if (directory == null) return;
+            var watcher = new FileSystemWatcher(directory, Path.GetFileName(path));
+            _textureWatcher = _ownedWatcher = watcher;
+            _watcherOwner = this;
+            int notificationPending = 0;
+            watcher.Changed += (sender, args) =>
+            {
+                // No Unity/config access on the watcher thread; at most one marshalled notification.
+                if (System.Threading.Interlocked.Exchange(ref notificationPending, 1) != 0) return;
+                ThreadingHelper.Instance.StartSyncInvoke(() =>
+                {
+                    System.Threading.Interlocked.Exchange(ref notificationPending, 0);
+                    if (IsHostAlive() && ReferenceEquals(_textureWatcher, watcher)
+                        && target.IsAlive && WatchTexChanges.Value && File.Exists(path))
+                        QueueTexture(target, data, path, result => ReportImportResult(result, target.Property), true);
+                });
+            };
+            Action close = () => ThreadingHelper.Instance.StartSyncInvoke(() =>
+            {
+                if (ReferenceEquals(_textureWatcher, watcher)) DisposeTextureWatcher();
+            });
+            watcher.Deleted += (sender, args) => close();
+            watcher.Error += (sender, args) => close();
+            watcher.EnableRaisingEvents = true;
         }
 
         internal void ExportTexture(Material material, string propertyName)
@@ -340,46 +235,21 @@ namespace MaterialEditorAPI
         {
             var watcher = _textureWatcher;
             _textureWatcher = null;
+            if (_watcherOwner != null) _watcherOwner._ownedWatcher = null;
+            _watcherOwner = null;
             watcher?.Dispose();
         }
 
         public void Dispose()
         {
-            if (_disposed)
-                return;
+            if (_disposed) return;
             _disposed = true;
-            DisposeTextureWatcher();
+            _imports.Dispose();
+            if (_ownedWatcher != null && ReferenceEquals(_textureWatcher, _ownedWatcher))
+                DisposeTextureWatcher();
         }
 
-        private void ScheduleTextureWatcherImport(
-            object data,
-            Material material,
-            string propertyName,
-            string filePath,
-            GameObject gameObject)
-        {
-            // FileSystemWatcher raises Changed on a ThreadPool thread, so
-            // marshal the Texture2D import before it touches Unity objects.
-            ThreadingHelper.Instance.StartSyncInvoke(() =>
-            {
-                if (IsHostAlive()
-                    && material != null
-                    && gameObject != null
-                    && WatchTexChanges.Value
-                    && File.Exists(filePath))
-                    _editService.SetMaterialTexture(
-                        data,
-                        material,
-                        propertyName,
-                        filePath,
-                        gameObject);
-            });
-        }
-
-        private bool IsHostAlive()
-        {
-            return _host != null;
-        }
+        private bool IsHostAlive() => !_disposed && _host != null;
 
         private static string SanitizeMaterialName(Material material)
         {

--- a/src/MaterialEditor.Base/UI/Assets/UI.CubemapImportCoordinator.cs
+++ b/src/MaterialEditor.Base/UI/Assets/UI.CubemapImportCoordinator.cs
@@ -260,6 +260,7 @@ namespace MaterialEditorAPI
     {
         private MaterialEditorCubemapImportCoordinator _coordinator;
         private Coroutine _coroutine;
+        private Action<MaterialEditResult> _completed;
 
         internal void Begin(
             string filePath,
@@ -268,16 +269,17 @@ namespace MaterialEditorAPI
                 byte[],
                 MaterialEditorCubemapContentKey,
                 MaterialEditorCubemapLease,
-                bool> apply,
+                MaterialEditResult> apply,
             Action<string> logInfo,
             Action<string> logWarning,
             Action<string> logError,
-            Action<bool> completed)
+            Action<MaterialEditResult> completed)
         {
             if (_coordinator != null)
                 throw new InvalidOperationException(
                     "This Cubemap import runner is already in use.");
 
+            _completed = completed;
             _coordinator = new MaterialEditorCubemapImportCoordinator(filePath);
             _coroutine = StartCoroutine(
                 Run(
@@ -295,13 +297,14 @@ namespace MaterialEditorAPI
                 byte[],
                 MaterialEditorCubemapContentKey,
                 MaterialEditorCubemapLease,
-                bool> apply,
+                MaterialEditResult> apply,
             Action<string> logInfo,
             Action<string> logWarning,
             Action<string> logError,
-            Action<bool> completed)
+            Action<MaterialEditResult> completed)
         {
             var success = false;
+            var result = new MaterialEditResult(MaterialEditStatus.Cancelled, "Target lifecycle");
             var previousState = _coordinator.State;
             SafeInvoke(
                 logInfo,
@@ -349,19 +352,23 @@ namespace MaterialEditorAPI
             {
                 if (!string.IsNullOrEmpty(_coordinator.Warning))
                     SafeInvoke(logWarning, _coordinator.Warning);
-                success = _coordinator.TryApply(apply);
+                success = _coordinator.TryApply((bytes, key, lease) =>
+                {
+                    result = apply(bytes, key, lease);
+                    return result.Succeeded || result.Status == MaterialEditStatus.Unverified;
+                });
             }
 
             if (_coordinator.State == MaterialEditorCubemapImportState.Failed)
                 SafeInvoke(logError, _coordinator.Error);
-            else if (success)
+            else if (result.Succeeded)
                 SafeInvoke(logInfo, "Cubemap import completed.");
-            if (_coordinator.State != MaterialEditorCubemapImportState.Cancelled)
-                SafeInvoke(completed, success);
-
+            if (_coordinator.State == MaterialEditorCubemapImportState.Failed)
+                result = new MaterialEditResult(MaterialEditStatus.Failed, "Cubemap import", _coordinator.Error);
             _coordinator.Dispose();
             _coordinator = null;
             _coroutine = null;
+            Complete(result);
             Destroy(this);
         }
 
@@ -392,27 +399,30 @@ namespace MaterialEditorAPI
             }
         }
 
-        private static void SafeInvoke(Action<bool> callback, bool value)
+        private void Complete(MaterialEditResult result)
         {
-            if (callback == null)
-                return;
-            try
-            {
-                callback(value);
-            }
-            catch
-            {
-            }
+            var callback = _completed;
+            _completed = null;
+            try { callback?.Invoke(result); }
+            catch (Exception ex) { MaterialEditorPluginBase.Logger?.LogWarning(ex); }
         }
 
+        internal void Cancel()
+        {
+            if (_coroutine != null) StopCoroutine(_coroutine);
+            _coroutine = null;
+            _coordinator?.Dispose();
+            _coordinator = null;
+            Complete(new MaterialEditResult(MaterialEditStatus.Cancelled, "Runner lifecycle"));
+            Destroy(this);
+        }
+
+        private void OnDisable() => Cancel();
         private void OnDestroy()
         {
-            if (_coroutine != null)
-                StopCoroutine(_coroutine);
-            _coroutine = null;
-            if (_coordinator != null)
-                _coordinator.Dispose();
+            _coordinator?.Dispose();
             _coordinator = null;
+            Complete(new MaterialEditResult(MaterialEditStatus.Cancelled, "Runner destroyed"));
         }
     }
 }

--- a/src/MaterialEditor.Base/UI/Lifecycle/UI.MaterialEditorTargetLifecycle.cs
+++ b/src/MaterialEditor.Base/UI/Lifecycle/UI.MaterialEditorTargetLifecycle.cs
@@ -35,8 +35,8 @@ namespace MaterialEditorAPI
             if (ReferenceEquals(host, null))
                 return;
 
+            host.CancelAssetImportsForLifecycle();
             host.CancelPendingRefreshesForLifecycle();
-            MaterialEditorUI.DisposeTexChangeWatcher();
             host.LifecycleVirtualList?.ReleaseContent();
             host.LifecycleSelectionController?.ReleaseTransientContent();
             host.LifecycleWindowView?.ReleasePresentation();

--- a/src/MaterialEditor.Base/UI/UI.cs
+++ b/src/MaterialEditor.Base/UI/UI.cs
@@ -665,6 +665,12 @@ namespace MaterialEditorAPI
 
         private void CloseTargetColorPalette() =>
             TargetLifecycle.CloseTargetColorPalette();
+        internal void CancelAssetImportsForLifecycle()
+        {
+            _assetWorkflow?.Dispose();
+            _assetWorkflow = null;
+        }
+
         internal void ShutdownMaterialEditorUi()
         {
             if (!ReferenceEquals(ActiveUi, this))

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.Cubemap.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.Cubemap.cs
@@ -49,6 +49,7 @@ namespace KK_Plugins.MaterialEditor
             string propertyName,
             byte[] data)
         {
+            MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted(), propertyName);
             SetMaterialCubemap(id, material, propertyName, data, null, false);
         }
 
@@ -323,6 +324,7 @@ namespace KK_Plugins.MaterialEditor
             Material material,
             string propertyName)
         {
+            MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted(), propertyName);
             var cubemapProperty = MaterialCubemapPropertyList.FirstOrDefault(x =>
                 x.ID == id
                 && x.MaterialName == material.NameFormatted()

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.TextureShader.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.TextureShader.cs
@@ -36,31 +36,25 @@ namespace KK_Plugins.MaterialEditor
             }
             else
             {
+                MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted(), propertyName);
                 TrySetMaterialTextureFromFile(id, material, propertyName, filePath);
             }
         }
 
-        internal void QueueMaterialTextureFromFile(
+        internal Action QueueMaterialTextureFromFile(
             int id,
             Material material,
             string propertyName,
             string filePath,
-            Action<bool> completed)
+            Action<MaterialEditResult> completed)
         {
-            if (!File.Exists(filePath))
-            {
-                completed?.Invoke(false);
-                return;
-            }
-
-            if (FileToSet != null)
-                TextureImportCompleted?.Invoke(false);
-
-            FileToSet = filePath;
-            PropertyToSet = propertyName;
-            MatToSet = material;
-            IDToSet = id;
-            TextureImportCompleted = completed;
+            var go = GetObjectByID(id);
+            var target = new MaterialEditTarget(go, material, propertyName);
+            return _textureImports.Enqueue(target,
+                () => this != null && GetObjectByID(id) == go && File.Exists(filePath),
+                done => { done(MaterialEditResult.FromApplied(
+                    TrySetMaterialTextureFromFile(id, material, propertyName, filePath))); return null; },
+                completed);
         }
 
         private bool TrySetMaterialTextureFromFile(
@@ -127,6 +121,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="data">Byte array containing the texture data</param>
         public void SetMaterialTexture(int id, Material material, string propertyName, byte[] data)
         {
+            MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted(), propertyName);
             TrySetMaterialTexture(id, material, propertyName, data);
         }
 
@@ -242,6 +237,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="displayMessage">Whether to display a message on screen telling the user to save and reload to refresh textures</param>
         public void RemoveMaterialTexture(int id, Material material, string propertyName, bool displayMessage = true)
         {
+            MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted(), propertyName);
             var textureProperty = MaterialTexturePropertyList.FirstOrDefault(x => x.ID == id && x.MaterialName == material.NameFormatted() && x.Property == propertyName);
             if (textureProperty != null)
             {
@@ -427,6 +423,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="setProperty">Whether to also apply the value to the materials</param>
         public void SetMaterialShader(int id, Material material, string shaderName, bool setProperty = true)
         {
+            MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted());
             GameObject gameObject = GetObjectByID(id);
             var materialProperty = MaterialShaderList.FirstOrDefault(x => x.ID == id && x.MaterialName == material.NameFormatted());
             if (materialProperty == null)
@@ -476,6 +473,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="setProperty">Whether to also apply the value to the materials</param>
         public void RemoveMaterialShader(int id, Material material, bool setProperty = true)
         {
+            MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted());
             GameObject gameObject = GetObjectByID(id);
             if (setProperty)
             {

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -51,11 +51,7 @@ namespace KK_Plugins.MaterialEditor
         private static readonly MaterialEditorCubemapLeaseStore CubemapLeases =
             new MaterialEditorCubemapLeaseStore();
 
-        private static string FileToSet;
-        private static string PropertyToSet;
-        private static Material MatToSet;
-        private static int IDToSet;
-        private static Action<bool> TextureImportCompleted;
+        private readonly MaterialEditRequestQueue _textureImports = new MaterialEditRequestQueue();
 
         private Dictionary<string, object> AAAAAA;
         private Dictionary<string, object> BBBBBB;
@@ -64,6 +60,8 @@ namespace KK_Plugins.MaterialEditor
         {
             InitAnimationController();
         }
+
+        private void OnDisable() => _textureImports.CancelAll();
 
         /// <summary>
         /// Saves data
@@ -234,6 +232,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="loadedItems"></param>
         protected override void OnSceneLoad(SceneOperationKind operation, ReadOnlyDictionary<int, ObjectCtrlInfo> loadedItems)
         {
+            _textureImports.CancelAll();
             if (operation == SceneOperationKind.Clear
                 || operation == SceneOperationKind.Load)
             {
@@ -773,32 +772,7 @@ namespace KK_Plugins.MaterialEditor
                 if (count > 0)
                     MaterialEditorPlugin.Logger.LogMessage($"Reset ReceiveShadows for {count} items");
             }
-            if (FileToSet != null)
-            {
-                bool succeeded = false;
-                var completed = TextureImportCompleted;
-                try
-                {
-                    if (!FileToSet.IsNullOrEmpty())
-                        succeeded = TrySetMaterialTextureFromFile(
-                            IDToSet,
-                            MatToSet,
-                            PropertyToSet,
-                            FileToSet);
-                }
-                catch
-                {
-                    //MaterialEditorPlugin.Logger.Log(BepInEx.Logging.LogLevel.Error | BepInEx.Logging.LogLevel.Message, "Failed to load texture.");
-                }
-                finally
-                {
-                    FileToSet = null;
-                    PropertyToSet = null;
-                    MatToSet = null;
-                    TextureImportCompleted = null;
-                    completed?.Invoke(succeeded);
-                }
-            }
+            _textureImports.Pump();
 
             MEAnimationController.UpdateAnimations(AnimationControllerMap);
         }

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneRepository.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneRepository.cs
@@ -97,13 +97,13 @@ namespace KK_Plugins.MaterialEditor
         public void SetMaterialTexture(object data, Material material, string propertyName, string filePath, GameObject gameObject) =>
             GetController().SetMaterialTextureFromFile(GetObjectId(data), material, propertyName, filePath, true);
 
-        public void SetMaterialTexture(
+        public Action SetMaterialTexture(
             object data,
             Material material,
             string propertyName,
             string filePath,
             GameObject gameObject,
-            Action<bool> completed) =>
+            Action<MaterialEditResult> completed) =>
             GetController().QueueMaterialTextureFromFile(
                 GetObjectId(data),
                 material,

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.Cubemap.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.Cubemap.cs
@@ -55,6 +55,7 @@ namespace KK_Plugins.MaterialEditor
             byte[] data,
             GameObject go)
         {
+            MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted(), propertyName);
             SetMaterialCubemap(
                 slot,
                 objectType,
@@ -338,6 +339,7 @@ namespace KK_Plugins.MaterialEditor
             GameObject go,
             bool setProperty = true)
         {
+            MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted(), propertyName);
             var cubemapProperty = FindMaterialCubemapProperty(
                 slot,
                 objectType,

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.TextureShader.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.TextureShader.cs
@@ -37,6 +37,7 @@ namespace KK_Plugins.MaterialEditor
             }
             else
             {
+                MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted(), propertyName);
                 TrySetMaterialTextureFromFile(
                     slot,
                     objectType,
@@ -47,33 +48,27 @@ namespace KK_Plugins.MaterialEditor
             }
         }
 
-        internal void QueueMaterialTextureFromFile(
+        internal Action QueueMaterialTextureFromFile(
             int slot,
             ObjectType objectType,
             Material material,
             string propertyName,
             string filePath,
             GameObject go,
-            Action<bool> completed)
+            Action<MaterialEditResult> completed)
         {
-            if (!File.Exists(filePath))
-            {
-                completed?.Invoke(false);
-                return;
-            }
-
-            // Only one import can wait for Update. Replacing it completes the
-            // displaced request as failed so its UI cannot wait indefinitely.
-            if (FileToSet != null)
-                TextureImportCompleted?.Invoke(false);
-
-            FileToSet = filePath;
-            PropertyToSet = propertyName;
-            MatToSet = material;
-            GameObjectToSet = go;
-            SlotToSet = slot;
-            ObjectTypeToSet = objectType;
-            TextureImportCompleted = completed;
+            var coordinate = GetCoordinateIndex(objectType);
+            // Public callers may intentionally pass a subtree rather than the slot root.
+            // Track slot replacement without narrowing the caller's apply scope.
+            var location = FindGameObject(objectType, slot);
+            var target = new MaterialEditTarget(go, material, propertyName);
+            return _textureImports.Enqueue(target,
+                () => this != null && GetCoordinateIndex(objectType) == coordinate
+                    && FindGameObject(objectType, slot) == location
+                    && !CoordinateChanging && File.Exists(filePath),
+                done => { done(MaterialEditResult.FromApplied(
+                    TrySetMaterialTextureFromFile(slot, objectType, material, propertyName, filePath, go))); return null; },
+                completed);
         }
 
         private bool TrySetMaterialTextureFromFile(
@@ -107,6 +102,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="go">GameObject the material belongs to</param>
         public void SetMaterialTexture(int slot, ObjectType objectType, Material material, string propertyName, byte[] data, GameObject go)
         {
+            MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted(), propertyName);
             TrySetMaterialTexture(slot, objectType, material, propertyName, data, go);
         }
 
@@ -228,6 +224,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="displayMessage">Whether to display a message on screen telling the user to save and reload to refresh textures</param>
         public void RemoveMaterialTexture(int slot, ObjectType objectType, Material material, string propertyName, GameObject go, bool displayMessage = true)
         {
+            MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted(), propertyName);
             var textureProperty = MaterialTexturePropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.Property == propertyName && x.MaterialName == material.NameFormatted());
             if (textureProperty != null)
             {
@@ -422,6 +419,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="setProperty">Whether to also apply the value to the materials</param>
         public void SetMaterialShader(int slot, ObjectType objectType, Material material, string shaderName, GameObject go, bool setProperty = true)
         {
+            MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted());
             var materialProperty = MaterialShaderList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == GetCoordinateIndex(objectType) && x.Slot == slot && x.MaterialName == material.NameFormatted());
             if (materialProperty == null)
             {
@@ -488,6 +486,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="setProperty">Whether to also apply the value to the materials</param>
         public void RemoveMaterialShader(int slot, ObjectType objectType, Material material, GameObject go, bool setProperty = true)
         {
+            MaterialEditRequestQueue.CancelTarget(go, material == null ? null : material.NameFormatted());
             if (setProperty)
             {
                 var original = GetMaterialShaderOriginal(slot, objectType, material, go);

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -71,13 +71,7 @@ namespace KK_Plugins.MaterialEditor
 #else
         public int CurrentCoordinateIndex => 0;
 #endif
-        private string FileToSet;
-        private string PropertyToSet;
-        private Material MatToSet;
-        private int SlotToSet;
-        private ObjectType ObjectTypeToSet;
-        private GameObject GameObjectToSet;
-        private Action<bool> TextureImportCompleted;
+        private readonly MaterialEditRequestQueue _textureImports = new MaterialEditRequestQueue();
         internal int? DuplicatingFrom = null;
 
         /// <summary>
@@ -172,6 +166,7 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="maintainState"></param>
         protected override void OnReload(GameMode currentGameMode, bool maintainState)
         {
+            _textureImports.CancelAll();
             if (!maintainState)
             {
                 if (MakerAPI.InsideAndLoaded)
@@ -191,6 +186,7 @@ namespace KK_Plugins.MaterialEditor
         /// </summary>
         protected override void OnDestroy()
         {
+            _textureImports.Dispose();
             ChaControl targetControl = null;
             GameObject targetRoot = null;
             try
@@ -358,37 +354,7 @@ namespace KK_Plugins.MaterialEditor
         /// <summary>
         /// Used by SetMaterialTextureFromFile if setTexInUpdate is true, needed for loading files via file dialogue
         /// </summary>
-        private void SetMaterialTextureFromFileByUpdate()
-        {
-            if (FileToSet == null)
-                return;
-
-            bool succeeded = false;
-            var completed = TextureImportCompleted;
-            try
-            {
-                succeeded = TrySetMaterialTextureFromFile(
-                    SlotToSet,
-                    ObjectTypeToSet,
-                    MatToSet,
-                    PropertyToSet,
-                    FileToSet,
-                    GameObjectToSet);
-            }
-            catch
-            {
-                //MaterialEditorPlugin.Logger.Log(BepInEx.Logging.LogLevel.Error | BepInEx.Logging.LogLevel.Message, "Failed to load texture.");
-            }
-            finally
-            {
-                FileToSet = null;
-                PropertyToSet = null;
-                MatToSet = null;
-                GameObjectToSet = null;
-                TextureImportCompleted = null;
-                completed?.Invoke(succeeded);
-            }
-        }
+        private void SetMaterialTextureFromFileByUpdate() => _textureImports.Pump();
 
         /// <summary>
         /// Get the coordinate index based on object type, hair and character return 0, clothes and accessories return CurrentCoordinateIndex
@@ -411,6 +377,7 @@ namespace KK_Plugins.MaterialEditor
             get => coordinateChanging;
             set
             {
+                if (value) _textureImports.CancelAll();
                 coordinateChanging = value;
                 ChaControl.StartCoroutine(Reset());
                 IEnumerator Reset()

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaRepository.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaRepository.cs
@@ -166,16 +166,16 @@ namespace KK_Plugins.MaterialEditor
             GetController(gameObject).SetMaterialTextureFromFile(objectData.Slot, objectData.ObjectType, material, propertyName, filePath, gameObject, true);
         }
 
-        public void SetMaterialTexture(
+        public Action SetMaterialTexture(
             object data,
             Material material,
             string propertyName,
             string filePath,
             GameObject gameObject,
-            Action<bool> completed)
+            Action<MaterialEditResult> completed)
         {
             var objectData = GetObjectData(data);
-            GetController(gameObject).QueueMaterialTextureFromFile(
+            return GetController(gameObject).QueueMaterialTextureFromFile(
                 objectData.Slot,
                 objectData.ObjectType,
                 material,


### PR DESCRIPTION
## Description
Introduce structured internal operation results, bounded request queues and owner-scoped cancellation. Public signatures and save formats are unchanged.

## Motivation and Context
First stage of the maintenance split from #404. Later transaction, structural, scheduling and UI changes are intentionally excluded here.

## How Has This Been Tested?
This exact structure-stage snapshot previously passed a KKS build. Later full-series builds and KKS acceptance are not claimed as standalone runtime coverage of this stage.

## Screenshots (if appropriate):
No visual changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Review-only copy: https://github.com/tomTom1010-IEE/KK_Plugins_MEUI_revive/pull/1
The remaining stages are available as incremental reviews in the fork and will be submitted upstream in order.