### PR TITLE
[ME][2/7] Share import transactions and simplify persistence

### DIFF
--- a/src/MaterialEditor.Base/MaterialEditor.Base.projitems
+++ b/src/MaterialEditor.Base/MaterialEditor.Base.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>MaterialEditor.API</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)UI\Sections\Properties\PropertyRowBuilders.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\MaterialTextureImportTransaction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Operations\MaterialCubemapImportTransaction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\MaterialEditResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Operations\MaterialEditRequestQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NormalMapManager.cs" />
@@ -81,7 +84,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.Presentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.ShaderUiMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.PropertyDescriptor.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UI\Sections\Properties\PropertyRowBuilders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.AutoScrollToCenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.FloatLabelDragTrigger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\UI.DropdownFilter.cs" />

--- a/src/MaterialEditor.Base/Operations/MaterialCubemapImportTransaction.cs
+++ b/src/MaterialEditor.Base/Operations/MaterialCubemapImportTransaction.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MaterialEditorAPI
+{
+    /// <summary>Controller-owned byte storage and leases; no serialization types cross this boundary.</summary>
+    internal sealed class MaterialCubemapImportStorage
+    {
+        internal Func<int> Count;
+        internal Func<byte[], int> StoreData;
+        internal Action<int, MaterialEditorCubemapLease> StoreLease;
+        internal Action<int> RemoveCreated;
+        internal Action PurgeLeases;
+    }
+
+    internal sealed class MaterialCubemapRecordAccess<T>
+    {
+        internal Func<T, int?> GetId;
+        internal Action<T, int?> SetId;
+        internal Func<T, MaterialCubemapOriginalState> Original;
+    }
+
+    /// <summary>One transaction for Chara and Studio; candidates stay detached until application succeeds.</summary>
+    internal static class MaterialCubemapImportTransaction
+    {
+        private static void Cleanup(Action action)
+        {
+            try { action(); }
+            catch (Exception ex) { MaterialEditorPluginBase.Logger?.LogWarning("Cubemap cleanup: " + ex.Message); }
+        }
+
+        internal static MaterialEditResult Execute<T>(byte[] data, MaterialEditorCubemapContentKey key,
+            GameObject root, string materialName, string property, bool logNormalization,
+            MaterialCubemapImportStorage storage, IList<T> records, T existing,
+            Func<int, T> create, MaterialCubemapRecordAccess<T> access, Func<T, bool> apply) where T : class
+        {
+            if (data == null || root == null)
+                return new MaterialEditResult(MaterialEditStatus.Failed, "Validate");
+
+            MaterialEditorCubemapLease lease = null;
+            MaterialTextureSnapshot runtime = null;
+            T candidate = null;
+            var created = false;
+            var committed = false;
+            var texId = 0;
+            var stage = "Acquire";
+            var previousId = existing == null ? null : access.GetId(existing);
+            var previousState = existing == null ? null : access.Original(existing).CaptureCheckpoint();
+            try
+            {
+                string warning;
+                string error;
+                var acquired = key == null
+                    ? MaterialEditorCubemapCache.TryAcquire(data, out lease, out warning, out error)
+                    : MaterialEditorCubemapCache.TryAcquire(data, key, out lease, out warning, out error);
+                if (!acquired) return new MaterialEditResult(MaterialEditStatus.Failed, stage, error);
+                if (logNormalization && !string.IsNullOrEmpty(warning))
+                    MaterialEditorPluginBase.Logger?.LogWarning(warning);
+                stage = "Store";
+                var count = storage.Count();
+                texId = storage.StoreData(data);
+                created = storage.Count() > count;
+                storage.StoreLease(texId, lease);
+                lease = null;
+
+                stage = "Snapshot";
+                runtime = new MaterialTextureSnapshot(root, materialName, property);
+                candidate = create(texId);
+                // Checkpoints are copy-on-replace state; Synchronize builds new collections.
+                if (existing != null) access.Original(candidate).RestoreCheckpoint(previousState, false);
+                stage = "Apply";
+                if (!apply(candidate))
+                    return new MaterialEditResult(MaterialEditStatus.Failed, stage, "Previous override preserved.");
+                stage = "Commit";
+                if (existing == null) records.Add(candidate);
+                else
+                {
+                    access.SetId(existing, texId);
+                    access.Original(existing).RestoreCheckpoint(access.Original(candidate).CaptureCheckpoint(), false);
+                }
+                committed = true;
+                return new MaterialEditResult(MaterialEditStatus.Succeeded, stage);
+            }
+            catch (Exception ex) { return new MaterialEditResult(MaterialEditStatus.Failed, stage, ex.Message); }
+            finally
+            {
+                if (!committed)
+                {
+                    runtime?.Restore();
+                    if (existing != null)
+                    {
+                        access.SetId(existing, previousId);
+                        access.Original(existing).RestoreCheckpoint(previousState, true);
+                    }
+                    else if (candidate != null) records.Remove(candidate);
+                    if (candidate != null) access.Original(candidate).Clear();
+                    if (created) Cleanup(() => storage.RemoveCreated(texId));
+                }
+                if (lease != null) Cleanup(lease.Dispose);
+                Cleanup(storage.PurgeLeases);
+            }
+        }
+    }
+}

--- a/src/MaterialEditor.Base/Operations/MaterialTextureImportTransaction.cs
+++ b/src/MaterialEditor.Base/Operations/MaterialTextureImportTransaction.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MaterialEditorAPI
+{
+    /// <summary>Texture2D prepare/apply/commit boundary; animation-specific rollback stays with its controller.</summary>
+    internal static class MaterialTextureImportTransaction
+    {
+        internal static MaterialEditResult Execute<T>(GameObject root, string materialName, string property,
+            Func<T> prepare, Func<T, bool> apply, Action<T> commit, Action<T> discard) where T : class
+        {
+            T candidate = null;
+            MaterialTextureSnapshot snapshot = null;
+            var committed = false;
+            var stage = "Snapshot";
+            try
+            {
+                snapshot = new MaterialTextureSnapshot(root, materialName, property);
+                stage = "Prepare texture/animation";
+                candidate = prepare();
+                stage = "Apply";
+                if (!apply(candidate))
+                    return new MaterialEditResult(MaterialEditStatus.Failed, stage);
+                stage = "Commit";
+                commit(candidate);
+                committed = true;
+                return new MaterialEditResult(MaterialEditStatus.Succeeded, stage);
+            }
+            catch (Exception ex)
+            {
+                return new MaterialEditResult(MaterialEditStatus.Failed, stage, ex.Message);
+            }
+            finally
+            {
+                if (!committed)
+                {
+                    snapshot?.Restore();
+                    try { discard(candidate); }
+                    catch (Exception ex) { MaterialEditorPluginBase.Logger?.LogWarning("Texture cleanup: " + ex.Message); }
+                }
+            }
+        }
+
+        // Keep the existing DTO identity: animation bindings may still reference it.
+        internal static void Commit<T, TController, TAnimation>(IList<T> records, IDictionary<T, TController> animations,
+            T existing, T candidate, Func<T, int?> getId, Action<T, int?> setId,
+            Func<T, TAnimation> getAnimation, Action<T, TAnimation> setAnimation) where T : class
+        {
+            if (existing == null)
+            {
+                records.Add(candidate);
+                return;
+            }
+            var previousId = getId(existing);
+            var previousAnimation = getAnimation(existing);
+            TController previousController;
+            TController candidateController;
+            var hadPrevious = animations.TryGetValue(existing, out previousController);
+            var hasCandidate = animations.TryGetValue(candidate, out candidateController);
+            try
+            {
+                setId(existing, getId(candidate));
+                setAnimation(existing, getAnimation(candidate));
+                animations.Remove(candidate);
+                if (hasCandidate) animations[existing] = candidateController;
+                else animations.Remove(existing);
+            }
+            catch
+            {
+                setId(existing, previousId);
+                setAnimation(existing, previousAnimation);
+                animations.Remove(candidate);
+                if (hadPrevious) animations[existing] = previousController;
+                else animations.Remove(existing);
+                throw;
+            }
+        }
+    }
+
+    /// <summary>Rollback values for every runtime material touched by SetTexture, including projectors.</summary>
+    internal sealed class MaterialTextureSnapshot
+    {
+        private readonly Dictionary<Material, Texture> _values = new Dictionary<Material, Texture>();
+        private readonly string _property;
+
+        internal MaterialTextureSnapshot(GameObject root, string name, string property)
+        {
+            _property = "_" + property;
+            foreach (var material in MaterialAPI.GetObjectMaterials(root, name))
+                if (material != null && material.HasProperty(_property))
+                    _values[material] = material.GetTexture(_property);
+        }
+
+        internal void Restore()
+        {
+            foreach (var entry in _values)
+            {
+                try
+                {
+                    if (entry.Key != null && entry.Key.HasProperty(_property))
+                        entry.Key.SetTexture(_property, entry.Value);
+                }
+                catch (Exception ex) { MaterialEditorPluginBase.Logger?.LogWarning("Texture rollback: " + ex.Message); }
+            }
+        }
+    }
+}

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.Cubemap.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.Cubemap.cs
@@ -77,190 +77,41 @@ namespace KK_Plugins.MaterialEditor
             MaterialEditorCubemapContentKey contentKey,
             bool logNormalizationWarning)
         {
-            if (data == null)
-                return false;
-
-            MaterialEditorCubemapLease lease = null;
-            var storedLease = false;
-            var textureEntryCreated = false;
-            var texID = 0;
-            MaterialCubemapProperty cubemapProperty = null;
-            var propertyAdded = false;
-            int? previousTexID = null;
-            MaterialCubemapOriginalState.Checkpoint previousOriginalState = null;
-            Dictionary<Material, Cubemap> previousAppliedValues = null;
-            string materialName = null;
-            GameObject gameObject = null;
-            try
-            {
-                string warning;
-                string error;
-                var acquired = contentKey == null
-                    ? MaterialEditorCubemapCache.TryAcquire(
-                        data,
-                        out lease,
-                        out warning,
-                        out error)
-                    : MaterialEditorCubemapCache.TryAcquire(
-                        data,
-                        contentKey,
-                        out lease,
-                        out warning,
-                        out error);
-                if (!acquired)
+            if (material == null) return false;
+            var go = GetObjectByID(id);
+            var existing = MaterialCubemapPropertyList.FirstOrDefault(x => x.ID == id && x.Property == propertyName && x.MaterialName == material.NameFormatted());
+            var result = MaterialCubemapImportTransaction.Execute(data, contentKey,
+                go, material.NameFormatted(), propertyName, logNormalizationWarning,
+                new MaterialCubemapImportStorage
                 {
-                    MaterialEditorPlugin.Logger.LogMessage(error);
-                    return false;
-                }
-                if (logNormalizationWarning && !string.IsNullOrEmpty(warning))
-                    MaterialEditorPlugin.Logger.LogWarning(warning);
-
-                var textureCountBefore = TextureDictionary.Count;
-                texID = SetAndGetTextureID(data);
-                textureEntryCreated = TextureDictionary.Count > textureCountBefore;
-                CubemapLeases.Store(texID, lease);
-                lease = null;
-                storedLease = true;
-
-                materialName = material.NameFormatted();
-                gameObject = GetObjectByID(id);
-                previousAppliedValues =
-                    MaterialCubemapOriginalSnapshot.SynchronizeByMaterialReference(
-                        gameObject,
-                        materialName,
-                        propertyName,
-                        null);
-                cubemapProperty = MaterialCubemapPropertyList.FirstOrDefault(x =>
-                    x.ID == id
-                    && x.Property == propertyName
-                    && x.MaterialName == materialName);
-                if (cubemapProperty == null)
-                {
-                    cubemapProperty = new MaterialCubemapProperty(
-                        id,
-                        materialName,
-                        propertyName,
-                        texID);
-                    MaterialCubemapPropertyList.Add(cubemapProperty);
-                    propertyAdded = true;
-                }
-                else
-                {
-                    previousTexID = cubemapProperty.TexID;
-                    previousOriginalState =
-                        cubemapProperty.CubemapOriginalState.CaptureCheckpoint();
-                    cubemapProperty.TexID = texID;
-                }
-
-                if (SetCubemapWithProperty(gameObject, cubemapProperty))
-                    return true;
-
-                RollbackMaterialCubemapSet(
-                    gameObject,
-                    materialName,
-                    propertyName,
-                    cubemapProperty,
-                    propertyAdded,
-                    previousTexID,
-                    previousOriginalState,
-                    previousAppliedValues,
-                    texID,
-                    textureEntryCreated);
-                textureEntryCreated = false;
-                MaterialEditorPluginBase.Logger.LogWarning(
-                    "Could not apply Cubemap " + materialName + "/" + propertyName
-                    + "; the previous override was preserved.");
-                return false;
-            }
-            catch (Exception exception)
-            {
-                RollbackMaterialCubemapSet(
-                    gameObject,
-                    materialName,
-                    propertyName,
-                    cubemapProperty,
-                    propertyAdded,
-                    previousTexID,
-                    previousOriginalState,
-                    previousAppliedValues,
-                    texID,
-                    textureEntryCreated);
-                textureEntryCreated = false;
-                MaterialEditorPluginBase.Logger.LogWarning(
-                    "Could not apply Cubemap; the previous override was preserved. "
-                    + exception.Message);
-                return false;
-            }
-            finally
-            {
-                if (lease != null)
-                    lease.Dispose();
-                if (storedLease)
-                    PurgeUnusedCubemapLeases();
-            }
+                    Count = () => TextureDictionary.Count,
+                    StoreData = SetAndGetTextureID,
+                    StoreLease = CubemapLeases.Store,
+                    RemoveCreated = RemoveFailedCubemapData,
+                    PurgeLeases = PurgeUnusedCubemapLeases
+                }, MaterialCubemapPropertyList, existing,
+                texId => new MaterialCubemapProperty(id, material.NameFormatted(), propertyName, texId),
+                CubemapRecordAccess, candidate => SetCubemapWithProperty(go, candidate));
+            if (!result.Succeeded)
+                MaterialEditorPluginBase.Logger?.LogWarning("Cubemap import: " + result.Stage + ": " + result.Diagnostic);
+            return result.Succeeded;
         }
 
-        private void RollbackMaterialCubemapSet(
-            GameObject gameObject,
-            string materialName,
-            string propertyName,
-            MaterialCubemapProperty cubemapProperty,
-            bool propertyAdded,
-            int? previousTexID,
-            MaterialCubemapOriginalState.Checkpoint previousOriginalState,
-            Dictionary<Material, Cubemap> previousAppliedValues,
-            int texID,
-            bool textureEntryCreated)
+        private static readonly MaterialCubemapRecordAccess<MaterialCubemapProperty> CubemapRecordAccess =
+            new MaterialCubemapRecordAccess<MaterialCubemapProperty>
+            {
+                GetId = x => x.TexID,
+                SetId = (x, id) => x.TexID = id,
+                Original = x => x.CubemapOriginalState
+            };
+
+        private void RemoveFailedCubemapData(int texId)
         {
-            try
-            {
-                MaterialCubemapOriginalSnapshot.RestoreByMaterialReference(
-                    gameObject,
-                    materialName,
-                    propertyName,
-                    previousAppliedValues);
-            }
-            catch (Exception exception)
-            {
-                MaterialEditorPluginBase.Logger.LogWarning(
-                    "Could not fully restore the previous Cubemap material value. "
-                    + exception.Message);
-            }
-
-            if (cubemapProperty != null)
-            {
-                if (propertyAdded)
-                {
-                    MaterialCubemapPropertyList.Remove(cubemapProperty);
-                    cubemapProperty.ClearCubemapOriginalSnapshot();
-                }
-                else
-                {
-                    cubemapProperty.TexID = previousTexID;
-                    cubemapProperty.CubemapOriginalState.RestoreCheckpoint(
-                        previousOriginalState,
-                        true);
-                }
-            }
-
-            if (textureEntryCreated)
-            {
-                CubemapLeases.Release(texID);
-                TextureContainer container;
-                if (TextureDictionary.TryGetValue(texID, out container))
-                {
-                    try
-                    {
-                        if (container != null)
-                            container.Dispose();
-                    }
-                    finally
-                    {
-                        TextureDictionary.Remove(texID);
-                    }
-                }
-            }
-            PurgeUnusedCubemapLeases();
+            CubemapLeases.Release(texId);
+            TextureContainer container;
+            if (!TextureDictionary.TryGetValue(texId, out container)) return;
+            try { container?.Dispose(); }
+            finally { TextureDictionary.Remove(texId); }
         }
 
         private bool SetCubemapWithProperty(
@@ -294,10 +145,7 @@ namespace KK_Plugins.MaterialEditor
             Material material,
             string propertyName)
         {
-            var cubemapProperty = MaterialCubemapPropertyList.FirstOrDefault(x =>
-                x.ID == id
-                && x.MaterialName == material.NameFormatted()
-                && x.Property == propertyName);
+            var cubemapProperty = MaterialCubemapPropertyList.FirstOrDefault(x => x.ID == id && x.Property == propertyName && x.MaterialName == material.NameFormatted());
             if (cubemapProperty == null || !cubemapProperty.TexID.HasValue)
                 return null;
 
@@ -313,10 +161,7 @@ namespace KK_Plugins.MaterialEditor
             Material material,
             string propertyName)
         {
-            return MaterialCubemapPropertyList.FirstOrDefault(x =>
-                x.ID == id
-                && x.MaterialName == material.NameFormatted()
-                && x.Property == propertyName)?.TexID == null;
+            return MaterialCubemapPropertyList.FirstOrDefault(x => x.ID == id && x.Property == propertyName && x.MaterialName == material.NameFormatted())?.TexID == null;
         }
 
         public void RemoveMaterialCubemap(
@@ -325,10 +170,7 @@ namespace KK_Plugins.MaterialEditor
             string propertyName)
         {
             MaterialEditRequestQueue.CancelTarget(GetObjectByID(id), material == null ? null : material.NameFormatted(), propertyName);
-            var cubemapProperty = MaterialCubemapPropertyList.FirstOrDefault(x =>
-                x.ID == id
-                && x.MaterialName == material.NameFormatted()
-                && x.Property == propertyName);
+            var cubemapProperty = MaterialCubemapPropertyList.FirstOrDefault(x => x.ID == id && x.Property == propertyName && x.MaterialName == material.NameFormatted());
             if (cubemapProperty == null)
                 return;
 

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.TextureShader.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Edits.TextureShader.cs
@@ -133,14 +133,12 @@ namespace KK_Plugins.MaterialEditor
 
             var materialName = material.NameFormatted();
             var existingProperty = MaterialTexturePropertyList.FirstOrDefault(x => x.ID == id && x.Property == propertyName && x.MaterialName == materialName);
-            MaterialTextureProperty candidateProperty = null;
-            var committed = false;
-
-            try
-            {
+            var result = MaterialTextureImportTransaction.Execute(
+                go, materialName, propertyName, () =>
+                {
                 var texID = SetAndGetTextureID(data);
                 var animationDefinition = MEAnimationUtil.LoadAnimationDefFromBytes(texID, data, SetAndGetTextureID);
-                candidateProperty = new MaterialTextureProperty(
+                return new MaterialTextureProperty(
                     id,
                     materialName,
                     propertyName,
@@ -150,59 +148,23 @@ namespace KK_Plugins.MaterialEditor
                     existingProperty == null ? null : existingProperty.Scale,
                     existingProperty == null ? null : existingProperty.ScaleOriginal,
                     animationDefinition);
-
-                if (!SetTextureWithProperty(go, candidateProperty))
-                    return false;
-
-                CommitTextureImport(existingProperty, candidateProperty);
-                committed = true;
-                return true;
-            }
-            finally
-            {
-                if (!committed)
+                },
+                candidate => SetTextureWithProperty(go, candidate),
+                candidate => CommitTextureImport(existingProperty, candidate),
+                candidate =>
                 {
-                    if (candidateProperty != null)
-                        AnimationControllerMap.Remove(candidateProperty);
+                    if (candidate != null) AnimationControllerMap.Remove(candidate);
                     PurgeUnusedTextures();
-                }
-            }
+                });
+            if (!result.Succeeded)
+                MaterialEditorPluginBase.Logger?.LogWarning("Texture import: " + result.Stage + ": " + result.Diagnostic);
+            return result.Succeeded;
         }
 
-        private void CommitTextureImport(MaterialTextureProperty existingProperty, MaterialTextureProperty candidateProperty)
-        {
-            if (existingProperty == null)
-            {
-                MaterialTexturePropertyList.Add(candidateProperty);
-                return;
-            }
-
-            var previousTexID = existingProperty.TexID;
-            var previousAnimationDefinition = existingProperty.TexAnimationDef;
-            var hadPreviousController = AnimationControllerMap.TryGetValue(existingProperty, out var previousController);
-            var hasCandidateController = AnimationControllerMap.TryGetValue(candidateProperty, out var candidateController);
-            try
-            {
-                existingProperty.TexID = candidateProperty.TexID;
-                existingProperty.TexAnimationDef = candidateProperty.TexAnimationDef;
-                AnimationControllerMap.Remove(candidateProperty);
-                if (hasCandidateController)
-                    AnimationControllerMap[existingProperty] = candidateController;
-                else
-                    AnimationControllerMap.Remove(existingProperty);
-            }
-            catch
-            {
-                existingProperty.TexID = previousTexID;
-                existingProperty.TexAnimationDef = previousAnimationDefinition;
-                AnimationControllerMap.Remove(candidateProperty);
-                if (hadPreviousController)
-                    AnimationControllerMap[existingProperty] = previousController;
-                else
-                    AnimationControllerMap.Remove(existingProperty);
-                throw;
-            }
-        }
+        private void CommitTextureImport(MaterialTextureProperty existingProperty, MaterialTextureProperty candidateProperty) =>
+            MaterialTextureImportTransaction.Commit(MaterialTexturePropertyList, AnimationControllerMap,
+                existingProperty, candidateProperty, x => x.TexID, (x, id) => x.TexID = id,
+                x => x.TexAnimationDef, (x, animation) => x.TexAnimationDef = animation);
 
         /// <summary>
         /// Get the saved material property value or null if none is saved

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Persistence.Copy.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Persistence.Copy.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using MaterialEditorAPI;
+using UnityEngine;
+using static MaterialEditorAPI.MaterialAPI;
+
+namespace KK_Plugins.MaterialEditor
+{
+    public partial class SceneController
+    {
+        // Accumulate for the entire copy event so new records cannot become sources
+        // for a later destination in the same event.
+        private sealed class SceneCopyBatch
+        {
+            internal readonly List<RendererProperty> rendererPropertyListNew = new List<RendererProperty>();
+            internal readonly List<ProjectorProperty> projectorPropertyListNew = new List<ProjectorProperty>();
+            internal readonly List<MaterialNameProperty> materialNamePropertyListNew = new List<MaterialNameProperty>();
+            internal readonly List<MaterialFloatProperty> materialFloatPropertyListNew = new List<MaterialFloatProperty>();
+            internal readonly List<MaterialKeywordProperty> materialKeywordPropertyListNew = new List<MaterialKeywordProperty>();
+            internal readonly List<MaterialColorProperty> materialColorPropertyListNew = new List<MaterialColorProperty>();
+            internal readonly List<MaterialVectorProperty> materialVectorPropertyListNew = new List<MaterialVectorProperty>();
+            internal readonly List<MaterialTextureProperty> materialTexturePropertyListNew = new List<MaterialTextureProperty>();
+            internal readonly List<MaterialCubemapProperty> materialCubemapPropertyListNew = new List<MaterialCubemapProperty>();
+            internal readonly List<MaterialShader> materialShaderListNew = new List<MaterialShader>();
+            internal readonly List<MaterialCopy> materialCopyListNew = new List<MaterialCopy>();
+        }
+
+        private sealed class SceneCopyContext
+        {
+            internal int SourceId;
+            internal int DestinationId;
+            internal GameObject Root;
+            internal GameObject SourceRoot;
+            internal SceneCopyBatch Output;
+        }
+
+        private void CopyMaterialCopyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialCopyList), MaterialCopyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                {
+                    CopyMaterial(context.Root, loadedProperty.MaterialName, loadedProperty.MaterialCopyName);
+                    context.Output.materialCopyListNew.Add(new MaterialCopy(context.DestinationId, loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
+                }
+            });
+        }
+
+        private void CopyMaterialNamePropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialNamePropertyList), MaterialNamePropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                {
+                    MaterialAPI.SetName(context.Root, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value);
+                    context.Output.materialNamePropertyListNew.Add(new MaterialNameProperty(context.DestinationId, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
+                }
+            });
+        }
+
+        private void CopyMaterialShaderList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialShaderList), MaterialShaderList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                {
+                    bool setShader = SetShader(context.Root, loadedProperty.MaterialName, loadedProperty.ShaderName);
+                    bool setRenderQueue = SetRenderQueue(context.Root, loadedProperty.MaterialName, loadedProperty.RenderQueue);
+                    if (setShader || setRenderQueue)
+                        context.Output.materialShaderListNew.Add(new MaterialShader(context.DestinationId, loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
+                }
+            });
+        }
+
+        private void CopyRendererPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(RendererPropertyList), RendererPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                    if (MaterialAPI.SetRendererProperty(context.Root, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value))
+                        context.Output.rendererPropertyListNew.Add(new RendererProperty(context.DestinationId, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void CopyProjectorPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(ProjectorPropertyList), ProjectorPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                    if (MaterialAPI.SetProjectorProperty(context.Root, loadedProperty.ProjectorName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
+                        context.Output.projectorPropertyListNew.Add(new ProjectorProperty(context.DestinationId, loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void CopyMaterialFloatPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialFloatPropertyList), MaterialFloatPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                    if (SetFloat(context.Root, loadedProperty.MaterialName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
+                        context.Output.materialFloatPropertyListNew.Add(new MaterialFloatProperty(context.DestinationId, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void CopyMaterialKeywordPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialKeywordPropertyList), MaterialKeywordPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                    if (SetKeyword(context.Root, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
+                        context.Output.materialKeywordPropertyListNew.Add(new MaterialKeywordProperty(context.DestinationId, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void CopyMaterialColorPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialColorPropertyList), MaterialColorPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                    if (SetColor(context.Root, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
+                        context.Output.materialColorPropertyListNew.Add(new MaterialColorProperty(context.DestinationId, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void CopyMaterialVectorPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialVectorPropertyList), MaterialVectorPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                    if (SetVector(context.Root, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
+                        context.Output.materialVectorPropertyListNew.Add(new MaterialVectorProperty(context.DestinationId, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void CopyMaterialTexturePropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialTexturePropertyList), MaterialTexturePropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID == context.SourceId)
+                {
+                    MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(context.DestinationId, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.TexID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
+
+                    bool setTex = false;
+                    if (loadedProperty.TexID != null)
+                        setTex = SetTextureWithProperty(context.Root, newTextureProperty);
+
+                    bool setOffset = SetTextureOffset(context.Root, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Offset);
+                    bool setScale = SetTextureScale(context.Root, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Scale);
+
+                    if (setTex || setOffset || setScale) context.Output.materialTexturePropertyListNew.Add(newTextureProperty);
+                }
+            });
+        }
+
+        private void CopyMaterialCubemapPropertyList(SceneCopyContext context)
+        {
+            MaterialEditLoadContext.ApplyRecords(nameof(MaterialCubemapPropertyList), MaterialCubemapPropertyList, loadedProperty =>
+            {
+                if (loadedProperty.ID != context.SourceId)
+                    return;
+
+                var newCubemapProperty = new MaterialCubemapProperty(
+                    context.DestinationId,
+                    loadedProperty.MaterialName,
+                    loadedProperty.Property,
+                    loadedProperty.TexID);
+                newCubemapProperty.InheritCubemapOriginalSnapshot(
+                    loadedProperty,
+                    context.SourceRoot);
+                if (newCubemapProperty.TexID.HasValue
+                    && SetCubemapWithProperty(
+                        context.Root,
+                        newCubemapProperty))
+                    context.Output.materialCubemapPropertyListNew.Add(newCubemapProperty);
+            });
+        }
+
+        private void CommitCopiedProperties(SceneCopyBatch batch)
+        {
+            RendererPropertyList.AddRange(batch.rendererPropertyListNew);
+            ProjectorPropertyList.AddRange(batch.projectorPropertyListNew);
+            MaterialNamePropertyList.AddRange(batch.materialNamePropertyListNew);
+            MaterialFloatPropertyList.AddRange(batch.materialFloatPropertyListNew);
+            MaterialKeywordPropertyList.AddRange(batch.materialKeywordPropertyListNew);
+            MaterialColorPropertyList.AddRange(batch.materialColorPropertyListNew);
+            MaterialVectorPropertyList.AddRange(batch.materialVectorPropertyListNew);
+            MaterialTexturePropertyList.AddRange(batch.materialTexturePropertyListNew);
+            MaterialCubemapPropertyList.AddRange(batch.materialCubemapPropertyListNew);
+            MaterialShaderList.AddRange(batch.materialShaderListNew);
+            MaterialCopyList.AddRange(batch.materialCopyListNew);
+        }
+    }
+}

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Persistence.Properties.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Persistence.Properties.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using KKAPI.Utilities;
+using System.Linq;
+using KKAPI.Studio.SaveLoad;
+using MaterialEditorAPI;
+using Studio;
+using UnityEngine;
+using static MaterialEditorAPI.MaterialAPI;
+
+namespace KK_Plugins.MaterialEditor
+{
+    public partial class SceneController
+    {
+        private sealed class SceneLoadContext
+        {
+            internal MaterialEditLoadContext Data;
+            internal SceneOperationKind Operation;
+            internal ReadOnlyDictionary<int, ObjectCtrlInfo> Items;
+        }
+
+        private void LoadSceneMaterialCopyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialCopy>(nameof(MaterialCopyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                {
+                    CopyMaterial(go, loadedProperty.MaterialName, loadedProperty.MaterialCopyName);
+                    if (MaterialCopyList.Any(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.MaterialCopyName == loadedProperty.MaterialCopyName))
+                        return;
+                    MaterialCopyList.Add(new MaterialCopy(objID, loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
+                }
+            });
+        }
+
+        private void LoadSceneMaterialNamePropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialNameProperty>(nameof(MaterialNamePropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                    if (MaterialAPI.SetName(go, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value))
+                        MaterialNamePropertyList.Add(new MaterialNameProperty(objID, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
+                    else
+                        MaterialEditorPlugin.Logger.LogMessage($"Could not rename material ({loadedProperty.MaterialName}) of renderer ({loadedProperty.Renderer}) to ({loadedProperty.Value}) on load!");
+            });
+        }
+
+        private void LoadSceneMaterialShaderList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialShader>(nameof(MaterialShaderList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                {
+                    bool setShader = SetShader(go, loadedProperty.MaterialName, loadedProperty.ShaderName);
+                    bool setRenderQueue = SetRenderQueue(go, loadedProperty.MaterialName, loadedProperty.RenderQueue);
+                    if (setShader || setRenderQueue)
+                        MaterialShaderList.Add(new MaterialShader(objID, loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
+                }
+            });
+        }
+
+        private void LoadSceneRendererPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<RendererProperty>(nameof(RendererPropertyList), loadedProperty =>
+            {
+#if KK
+                if (loadedProperty.Property == RendererProperties.UpdateWhenOffscreen) return;
+#endif
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                    if (MaterialAPI.SetRendererProperty(go, loadedProperty.RendererName, loadedProperty.Property, int.Parse(loadedProperty.Value)))
+                        RendererPropertyList.Add(new RendererProperty(objID, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadSceneProjectorPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<ProjectorProperty>(nameof(ProjectorPropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                    if (MaterialAPI.SetProjectorProperty(go, loadedProperty.ProjectorName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
+                        ProjectorPropertyList.Add(new ProjectorProperty(objID, loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadSceneMaterialFloatPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialFloatProperty>(nameof(MaterialFloatPropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                    if (SetFloat(go, loadedProperty.MaterialName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
+                        MaterialFloatPropertyList.Add(new MaterialFloatProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadSceneMaterialKeywordPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialKeywordProperty>(nameof(MaterialKeywordPropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                    if (SetKeyword(go, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
+                        MaterialKeywordPropertyList.Add(new MaterialKeywordProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadSceneMaterialColorPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialColorProperty>(nameof(MaterialColorPropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                {
+                    if (IsVectorProperty(go, loadedProperty.MaterialName, loadedProperty.Property))
+                    {
+                        var value = new Vector4(loadedProperty.Value.r, loadedProperty.Value.g, loadedProperty.Value.b, loadedProperty.Value.a);
+                        var valueOriginal = new Vector4(loadedProperty.ValueOriginal.r, loadedProperty.ValueOriginal.g, loadedProperty.ValueOriginal.b, loadedProperty.ValueOriginal.a);
+                        if (value != valueOriginal
+                            && SetVector(go, loadedProperty.MaterialName, loadedProperty.Property, value)
+                            && !MaterialVectorPropertyList.Any(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.Property == loadedProperty.Property))
+                            MaterialVectorPropertyList.Add(new MaterialVectorProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, value, valueOriginal));
+                    }
+                    else if (SetColor(go, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
+                        MaterialColorPropertyList.Add(new MaterialColorProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+                }
+            });
+        }
+
+        private void LoadSceneMaterialVectorPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialVectorProperty>(nameof(MaterialVectorPropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                {
+                    // Native Vector data takes precedence when both representations exist.
+                    MaterialColorPropertyList.RemoveAll(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.Property == loadedProperty.Property);
+                    MaterialVectorPropertyList.RemoveAll(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.Property == loadedProperty.Property);
+                    if (SetVector(go, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value)
+                        && loadedProperty.Value != loadedProperty.ValueOriginal)
+                        MaterialVectorPropertyList.Add(new MaterialVectorProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+                }
+            });
+        }
+
+    }
+}

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Persistence.Textures.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.Persistence.Textures.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using KKAPI.Utilities;
+using System.Linq;
+using KKAPI.Studio.SaveLoad;
+using MaterialEditorAPI;
+using Studio;
+using UnityEngine;
+using static MaterialEditorAPI.MaterialAPI;
+
+namespace KK_Plugins.MaterialEditor
+{
+    public partial class SceneController
+    {
+        private void LoadSceneMaterialTexturePropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialTextureProperty>(nameof(MaterialTexturePropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(context.Items, loadedProperty.ID, out var objID);
+                if (go != null)
+                {
+                    int? texID = null;
+                    if (context.Operation == SceneOperationKind.Import)
+                    {
+                        if (loadedProperty.TexID != null)
+                            texID = context.Data.RemapTexture(loadedProperty.TexID);
+                        MEAnimationUtil.RemapTexID(loadedProperty.TexAnimationDef, context.Data.TextureIds);
+                    }
+                    else
+                        texID = loadedProperty.TexID;
+
+                    MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, texID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
+
+                    bool setTex = false;
+                    if (newTextureProperty.TexID != null)
+                        setTex = SetTextureWithProperty(go, newTextureProperty);
+
+                    bool setOffset = SetTextureOffset(go, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Offset);
+                    bool setScale = SetTextureScale(go, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Scale);
+
+                    if (setTex || setOffset || setScale)
+                        MaterialTexturePropertyList.Add(newTextureProperty);
+                }
+            });
+        }
+
+        private void LoadSceneMaterialCubemapPropertyList(SceneLoadContext context)
+        {
+            context.Data.Read<MaterialCubemapProperty>(nameof(MaterialCubemapPropertyList), loadedProperty =>
+            {
+                GameObject go = ExtractGameObject(
+                    context.Items,
+                    loadedProperty.ID,
+                    out var objID);
+                if (go == null)
+                    return;
+
+                int? texID = loadedProperty.TexID;
+                if (context.Operation == SceneOperationKind.Import
+                    && loadedProperty.TexID.HasValue)
+                    texID = context.Data.RemapTexture(loadedProperty.TexID);
+
+                var newCubemapProperty = new MaterialCubemapProperty(
+                    objID,
+                    loadedProperty.MaterialName,
+                    loadedProperty.Property,
+                    texID);
+                if (newCubemapProperty.TexID.HasValue
+                    && SetCubemapWithProperty(go, newCubemapProperty))
+                    MaterialCubemapPropertyList.Add(newCubemapProperty);
+            });
+        }
+
+    }
+}

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.SceneController.cs
@@ -53,8 +53,6 @@ namespace KK_Plugins.MaterialEditor
 
         private readonly MaterialEditRequestQueue _textureImports = new MaterialEditRequestQueue();
 
-        private Dictionary<string, object> AAAAAA;
-        private Dictionary<string, object> BBBBBB;
 
         static SceneController()
         {
@@ -78,64 +76,26 @@ namespace KK_Plugins.MaterialEditor
             else
                 data.data.Add(TexDicSaveKey, null);
 
-            if (RendererPropertyList.Count > 0)
-                data.data.Add(nameof(RendererPropertyList), MessagePackSerializer.Serialize(RendererPropertyList));
-            else
-                data.data.Add(nameof(RendererPropertyList), null);
-
-            if (ProjectorPropertyList.Count > 0)
-                data.data.Add(nameof(ProjectorPropertyList), MessagePackSerializer.Serialize(ProjectorPropertyList));
-            else
-                data.data.Add(nameof(ProjectorPropertyList), null);
-
-            if (MaterialNamePropertyList.Count > 0)
-                data.data.Add(nameof(MaterialNamePropertyList), MessagePackSerializer.Serialize(MaterialNamePropertyList));
-            else
-                data.data.Add(nameof(MaterialNamePropertyList), null);
-            
-            if (MaterialFloatPropertyList.Count > 0)
-                data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(MaterialFloatPropertyList));
-            else
-                data.data.Add(nameof(MaterialFloatPropertyList), null);
-
-            if (MaterialKeywordPropertyList.Count > 0)
-                data.data.Add(nameof(MaterialKeywordPropertyList), MessagePackSerializer.Serialize(MaterialKeywordPropertyList));
-            else
-                data.data.Add(nameof(MaterialKeywordPropertyList), null);
-
-            if (MaterialColorPropertyList.Count > 0)
-                data.data.Add(nameof(MaterialColorPropertyList), MessagePackSerializer.Serialize(MaterialColorPropertyList));
-            else
-                data.data.Add(nameof(MaterialColorPropertyList), null);
-
-            if (MaterialVectorPropertyList.Count > 0)
-                data.data.Add(nameof(MaterialVectorPropertyList), MessagePackSerializer.Serialize(MaterialVectorPropertyList));
-            else
-                data.data.Add(nameof(MaterialVectorPropertyList), null);
-
-            if (MaterialTexturePropertyList.Count > 0)
-                data.data.Add(nameof(MaterialTexturePropertyList), MessagePackSerializer.Serialize(MaterialTexturePropertyList));
-            else
-                data.data.Add(nameof(MaterialTexturePropertyList), null);
-
-            if (MaterialCubemapPropertyList.Count > 0)
-                data.data.Add(nameof(MaterialCubemapPropertyList), MessagePackSerializer.Serialize(MaterialCubemapPropertyList));
-            else
-                data.data.Add(nameof(MaterialCubemapPropertyList), null);
-
-            if (MaterialShaderList.Count > 0)
-                data.data.Add(nameof(MaterialShaderList), MessagePackSerializer.Serialize(MaterialShaderList));
-            else
-                data.data.Add(nameof(MaterialShaderList), null);
-
-            if (MaterialCopyList.Count > 0)
-                data.data.Add(nameof(MaterialCopyList), MessagePackSerializer.Serialize(MaterialCopyList));
-            else
-                data.data.Add(nameof(MaterialCopyList), null);
-
-            AAAAAA = data.data;
+            WriteRecords(nameof(RendererPropertyList), RendererPropertyList);
+            WriteRecords(nameof(ProjectorPropertyList), ProjectorPropertyList);
+            WriteRecords(nameof(MaterialNamePropertyList), MaterialNamePropertyList);
+            WriteRecords(nameof(MaterialFloatPropertyList), MaterialFloatPropertyList);
+            WriteRecords(nameof(MaterialKeywordPropertyList), MaterialKeywordPropertyList);
+            WriteRecords(nameof(MaterialColorPropertyList), MaterialColorPropertyList);
+            WriteRecords(nameof(MaterialVectorPropertyList), MaterialVectorPropertyList);
+            WriteRecords(nameof(MaterialTexturePropertyList), MaterialTexturePropertyList);
+            WriteRecords(nameof(MaterialCubemapPropertyList), MaterialCubemapPropertyList);
+            WriteRecords(nameof(MaterialShaderList), MaterialShaderList);
+            WriteRecords(nameof(MaterialCopyList), MaterialCopyList);
 
             SetExtendedData(data);
+
+            void WriteRecords<T>(string key, List<T> records)
+            {
+                // Keep empty fields present as null in the saved data.
+                data.data.Add(key,
+                    records.Count > 0 ? MessagePackSerializer.Serialize(records) : null);
+            }
         }
 
         /// <summary>
@@ -273,8 +233,7 @@ namespace KK_Plugins.MaterialEditor
                 var importDictionaryTemp = TextureSaveHandler.Instance.Load<Dictionary<int, TextureContainer>>(data, TexDicSaveKey, false);
                 try
                 {
-                    foreach (var kvp in importDictionaryTemp)
-                        importDictionary[kvp.Key] = SetAndGetTextureID(kvp.Value.Data);
+                    importDictionary = MaterialEditLoadContext.ImportTextures(importDictionaryTemp, x => x.Data, SetAndGetTextureID);
                 }
                 finally
                 {
@@ -282,219 +241,34 @@ namespace KK_Plugins.MaterialEditor
                 }
             }
 
-            if (data.data.TryGetValue(nameof(MaterialCopyList), out var materialCopyData) && materialCopyData != null)
+            var context = new SceneLoadContext
             {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialCopy>>((byte[])materialCopyData);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                    {
-                        CopyMaterial(go, loadedProperty.MaterialName, loadedProperty.MaterialCopyName);
-                        if (MaterialCopyList.Any(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.MaterialCopyName == loadedProperty.MaterialCopyName))
-                            continue;
-                        MaterialCopyList.Add(new MaterialCopy(objID, loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
-                    }
-                }
-            }
+                Data = new MaterialEditLoadContext(data, importDictionary),
+                Operation = operation,
+                Items = loadedItems
+            };
+            LoadSceneMaterialCopyList(context);
 
-            BBBBBB = data.data;
 
-            if (data.data.TryGetValue(nameof(MaterialNamePropertyList), out var materialNameProperties) && materialNameProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialNameProperty>>((byte[])materialNameProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                        if (MaterialAPI.SetName(go, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value))
-                            MaterialNamePropertyList.Add(new MaterialNameProperty(objID, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
-                        else
-                            MaterialEditorPlugin.Logger.LogMessage($"Could not rename material ({loadedProperty.MaterialName}) of renderer ({loadedProperty.Renderer}) to ({loadedProperty.Value}) on load!");
-                }
-            }
+            LoadSceneMaterialNamePropertyList(context);
 
-            if (data.data.TryGetValue(nameof(MaterialShaderList), out var shaderProperties) && shaderProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialShader>>((byte[])shaderProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                    {
-                        bool setShader = SetShader(go, loadedProperty.MaterialName, loadedProperty.ShaderName);
-                        bool setRenderQueue = SetRenderQueue(go, loadedProperty.MaterialName, loadedProperty.RenderQueue);
-                        if (setShader || setRenderQueue)
-                            MaterialShaderList.Add(new MaterialShader(objID, loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
-                    }
-                }
-            }
+            LoadSceneMaterialShaderList(context);
 
-            if (data.data.TryGetValue(nameof(RendererPropertyList), out var rendererProperties) && rendererProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<RendererProperty>>((byte[])rendererProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-#if KK
-                    if (loadedProperty.Property == RendererProperties.UpdateWhenOffscreen) continue;
-#endif
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                        if (MaterialAPI.SetRendererProperty(go, loadedProperty.RendererName, loadedProperty.Property, int.Parse(loadedProperty.Value)))
-                            RendererPropertyList.Add(new RendererProperty(objID, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                }
-            }
+            LoadSceneRendererPropertyList(context);
 
-            if (data.data.TryGetValue(nameof(ProjectorPropertyList), out var projectorProperties) && projectorProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<ProjectorProperty>>((byte[])projectorProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                        if (MaterialAPI.SetProjectorProperty(go, loadedProperty.ProjectorName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
-                            ProjectorPropertyList.Add(new ProjectorProperty(objID, loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                }
-            }
+            LoadSceneProjectorPropertyList(context);
 
-            if (data.data.TryGetValue(nameof(MaterialFloatPropertyList), out var materialFloatProperties) && materialFloatProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialFloatProperty>>((byte[])materialFloatProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                        if (SetFloat(go, loadedProperty.MaterialName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
-                            MaterialFloatPropertyList.Add(new MaterialFloatProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                }
-            }
+            LoadSceneMaterialFloatPropertyList(context);
 
-            if (data.data.TryGetValue(nameof(MaterialKeywordPropertyList), out var materialKeywordProperties) && materialKeywordProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialKeywordProperty>>((byte[])materialKeywordProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                        if (SetKeyword(go, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
-                            MaterialKeywordPropertyList.Add(new MaterialKeywordProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                }
-            }
+            LoadSceneMaterialKeywordPropertyList(context);
 
-            if (data.data.TryGetValue(nameof(MaterialColorPropertyList), out var materialColorProperties) && materialColorProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialColorProperty>>((byte[])materialColorProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                    {
-                        if (IsVectorProperty(go, loadedProperty.MaterialName, loadedProperty.Property))
-                        {
-                            var value = new Vector4(loadedProperty.Value.r, loadedProperty.Value.g, loadedProperty.Value.b, loadedProperty.Value.a);
-                            var valueOriginal = new Vector4(loadedProperty.ValueOriginal.r, loadedProperty.ValueOriginal.g, loadedProperty.ValueOriginal.b, loadedProperty.ValueOriginal.a);
-                            if (value != valueOriginal
-                                && SetVector(go, loadedProperty.MaterialName, loadedProperty.Property, value)
-                                && !MaterialVectorPropertyList.Any(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.Property == loadedProperty.Property))
-                                MaterialVectorPropertyList.Add(new MaterialVectorProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, value, valueOriginal));
-                        }
-                        else if (SetColor(go, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
-                            MaterialColorPropertyList.Add(new MaterialColorProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
-            }
+            LoadSceneMaterialColorPropertyList(context);
 
-            if (data.data.TryGetValue(nameof(MaterialVectorPropertyList), out var materialVectorProperties) && materialVectorProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialVectorProperty>>((byte[])materialVectorProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                    {
-                        // Native Vector data takes precedence when both representations exist.
-                        MaterialColorPropertyList.RemoveAll(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.Property == loadedProperty.Property);
-                        MaterialVectorPropertyList.RemoveAll(x => x.ID == objID && x.MaterialName == loadedProperty.MaterialName && x.Property == loadedProperty.Property);
-                        if (SetVector(go, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value)
-                            && loadedProperty.Value != loadedProperty.ValueOriginal)
-                            MaterialVectorPropertyList.Add(new MaterialVectorProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
-            }
+            LoadSceneMaterialVectorPropertyList(context);
 
-            if (data.data.TryGetValue(nameof(MaterialTexturePropertyList), out var materialTextureProperties) && materialTextureProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialTextureProperty>>((byte[])materialTextureProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(loadedItems, loadedProperty.ID, out var objID);
-                    if (go != null)
-                    {
-                        int? texID = null;
-                        if (operation == SceneOperationKind.Import)
-                        {
-                            if (loadedProperty.TexID != null)
-                                texID = importDictionary[(int)loadedProperty.TexID];
-                            MEAnimationUtil.RemapTexID(loadedProperty.TexAnimationDef, importDictionary);
-                        }
-                        else
-                            texID = loadedProperty.TexID;
+            LoadSceneMaterialTexturePropertyList(context);
 
-                        MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(objID, loadedProperty.MaterialName, loadedProperty.Property, texID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
-
-                        bool setTex = false;
-                        if (newTextureProperty.TexID != null)
-                            setTex = SetTextureWithProperty(go, newTextureProperty);
-
-                        bool setOffset = SetTextureOffset(go, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Offset);
-                        bool setScale = SetTextureScale(go, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Scale);
-
-                        if (setTex || setOffset || setScale)
-                            MaterialTexturePropertyList.Add(newTextureProperty);
-                    }
-                }
-            }
-
-            if (data.data.TryGetValue(nameof(MaterialCubemapPropertyList), out var materialCubemapProperties)
-                && materialCubemapProperties != null)
-            {
-                var properties = MessagePackSerializer.Deserialize<List<MaterialCubemapProperty>>(
-                    (byte[])materialCubemapProperties);
-                for (var i = 0; i < properties.Count; i++)
-                {
-                    var loadedProperty = properties[i];
-                    GameObject go = ExtractGameObject(
-                        loadedItems,
-                        loadedProperty.ID,
-                        out var objID);
-                    if (go == null)
-                        continue;
-
-                    int? texID = loadedProperty.TexID;
-                    if (operation == SceneOperationKind.Import
-                        && loadedProperty.TexID.HasValue)
-                        texID = importDictionary[loadedProperty.TexID.Value];
-
-                    var newCubemapProperty = new MaterialCubemapProperty(
-                        objID,
-                        loadedProperty.MaterialName,
-                        loadedProperty.Property,
-                        texID);
-                    if (newCubemapProperty.TexID.HasValue
-                        && SetCubemapWithProperty(go, newCubemapProperty))
-                        MaterialCubemapPropertyList.Add(newCubemapProperty);
-                }
-            }
+            LoadSceneMaterialCubemapPropertyList(context);
 
             if (data.version < 1)
             {
@@ -524,141 +298,41 @@ namespace KK_Plugins.MaterialEditor
         /// <param name="copiedItems"></param>
         protected override void OnObjectsCopied(ReadOnlyDictionary<int, ObjectCtrlInfo> copiedItems)
         {
-            List<RendererProperty> rendererPropertyListNew = new List<RendererProperty>();
-            List<ProjectorProperty> projectorPropertyListNew = new List<ProjectorProperty>();
-            List<MaterialNameProperty> materialNamePropertyListNew = new List<MaterialNameProperty>();
-            List<MaterialFloatProperty> materialFloatPropertyListNew = new List<MaterialFloatProperty>();
-            List<MaterialKeywordProperty> materialKeywordPropertyListNew = new List<MaterialKeywordProperty>();
-            List<MaterialColorProperty> materialColorPropertyListNew = new List<MaterialColorProperty>();
-            List<MaterialVectorProperty> materialVectorPropertyListNew = new List<MaterialVectorProperty>();
-            List<MaterialTextureProperty> materialTexturePropertyListNew = new List<MaterialTextureProperty>();
-            List<MaterialCubemapProperty> materialCubemapPropertyListNew = new List<MaterialCubemapProperty>();
-            List<MaterialShader> materialShaderListNew = new List<MaterialShader>();
-            List<MaterialCopy> materialCopyListNew = new List<MaterialCopy>();
 
+            var batch = new SceneCopyBatch();
             foreach (var copiedItem in copiedItems)
             {
                 if (copiedItem.Value is OCIItem ociItem)
                 {
-                    var sourceGameObject = GetObjectByID(copiedItem.Key);
-                    for (var i = 0; i < MaterialCopyList.Count; i++)
+                    var context = new SceneCopyContext
                     {
-                        var loadedProperty = MaterialCopyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                        {
-                            CopyMaterial(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.MaterialCopyName);
-                            materialCopyListNew.Add(new MaterialCopy(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
-                        }
-                    }
+                        SourceId = copiedItem.Key,
+                        DestinationId = copiedItem.Value.GetSceneId(),
+                        Root = ociItem.objectItem,
+                        SourceRoot = GetObjectByID(copiedItem.Key),
+                        Output = batch
+                    };
+                    CopyMaterialCopyList(context);
 
-                    for (var i = 0; i < MaterialNamePropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialNamePropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                        {
-                            MaterialAPI.SetName(ociItem.objectItem, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value);
-                            materialNamePropertyListNew.Add(new MaterialNameProperty(copiedItem.Value.GetSceneId(), loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
-                        }
-                    }
+                    CopyMaterialNamePropertyList(context);
 
-                    for (var i = 0; i < MaterialShaderList.Count; i++)
-                    {
-                        var loadedProperty = MaterialShaderList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                        {
-                            bool setShader = SetShader(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.ShaderName);
-                            bool setRenderQueue = SetRenderQueue(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.RenderQueue);
-                            if (setShader || setRenderQueue)
-                                materialShaderListNew.Add(new MaterialShader(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
-                        }
-                    }
+                    CopyMaterialShaderList(context);
 
-                    for (var i = 0; i < RendererPropertyList.Count; i++)
-                    {
-                        var loadedProperty = RendererPropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                            if (MaterialAPI.SetRendererProperty(ociItem.objectItem, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value))
-                                rendererPropertyListNew.Add(new RendererProperty(copiedItem.Value.GetSceneId(), loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
+                    CopyRendererPropertyList(context);
 
-                    for (var i = 0; i < ProjectorPropertyList.Count; i++)
-                    {
-                        var loadedProperty = ProjectorPropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                            if (MaterialAPI.SetProjectorProperty(ociItem.objectItem, loadedProperty.ProjectorName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
-                                projectorPropertyListNew.Add(new ProjectorProperty(copiedItem.Value.GetSceneId(), loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
+                    CopyProjectorPropertyList(context);
 
-                    for (var i = 0; i < MaterialFloatPropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialFloatPropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                            if (SetFloat(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.Property, float.Parse(loadedProperty.Value)))
-                                materialFloatPropertyListNew.Add(new MaterialFloatProperty(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
+                    CopyMaterialFloatPropertyList(context);
 
-                    for (var i = 0; i < MaterialKeywordPropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialKeywordPropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                            if (SetKeyword(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
-                                materialKeywordPropertyListNew.Add(new MaterialKeywordProperty(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
+                    CopyMaterialKeywordPropertyList(context);
 
-                    for (var i = 0; i < MaterialColorPropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialColorPropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                            if (SetColor(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
-                                materialColorPropertyListNew.Add(new MaterialColorProperty(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
+                    CopyMaterialColorPropertyList(context);
 
-                    for (var i = 0; i < MaterialVectorPropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialVectorPropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                            if (SetVector(ociItem.objectItem, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value))
-                                materialVectorPropertyListNew.Add(new MaterialVectorProperty(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
+                    CopyMaterialVectorPropertyList(context);
 
-                    for (var i = 0; i < MaterialTexturePropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialTexturePropertyList[i];
-                        if (loadedProperty.ID == copiedItem.Key)
-                        {
-                            MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(copiedItem.Value.GetSceneId(), loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.TexID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
+                    CopyMaterialTexturePropertyList(context);
 
-                            bool setTex = false;
-                            if (loadedProperty.TexID != null)
-                                setTex = SetTextureWithProperty(ociItem.objectItem, newTextureProperty);
-
-                            bool setOffset = SetTextureOffset(ociItem.objectItem, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Offset);
-                            bool setScale = SetTextureScale(ociItem.objectItem, newTextureProperty.MaterialName, newTextureProperty.Property, newTextureProperty.Scale);
-
-                            if (setTex || setOffset || setScale) materialTexturePropertyListNew.Add(newTextureProperty);
-                        }
-                    }
-
-                    for (var i = 0; i < MaterialCubemapPropertyList.Count; i++)
-                    {
-                        var loadedProperty = MaterialCubemapPropertyList[i];
-                        if (loadedProperty.ID != copiedItem.Key)
-                            continue;
-
-                        var newCubemapProperty = new MaterialCubemapProperty(
-                            copiedItem.Value.GetSceneId(),
-                            loadedProperty.MaterialName,
-                            loadedProperty.Property,
-                            loadedProperty.TexID);
-                        newCubemapProperty.InheritCubemapOriginalSnapshot(
-                            loadedProperty,
-                            sourceGameObject);
-                        if (newCubemapProperty.TexID.HasValue
-                            && SetCubemapWithProperty(
-                                ociItem.objectItem,
-                                newCubemapProperty))
-                            materialCubemapPropertyListNew.Add(newCubemapProperty);
-                    }
+                    CopyMaterialCubemapPropertyList(context);
                 }
                 if (copiedItem.Value is OCIChar ociChar)
                 {
@@ -672,17 +346,7 @@ namespace KK_Plugins.MaterialEditor
                 }
             }
 
-            RendererPropertyList.AddRange(rendererPropertyListNew);
-            ProjectorPropertyList.AddRange(projectorPropertyListNew);
-            MaterialNamePropertyList.AddRange(materialNamePropertyListNew);
-            MaterialFloatPropertyList.AddRange(materialFloatPropertyListNew);
-            MaterialKeywordPropertyList.AddRange(materialKeywordPropertyListNew);
-            MaterialColorPropertyList.AddRange(materialColorPropertyListNew);
-            MaterialVectorPropertyList.AddRange(materialVectorPropertyListNew);
-            MaterialTexturePropertyList.AddRange(materialTexturePropertyListNew);
-            MaterialCubemapPropertyList.AddRange(materialCubemapPropertyListNew);
-            MaterialShaderList.AddRange(materialShaderListNew);
-            MaterialCopyList.AddRange(materialCopyListNew);
+            CommitCopiedProperties(batch);
         }
 
         private void Update()
@@ -981,18 +645,7 @@ namespace KK_Plugins.MaterialEditor
         /// </summary>
         internal static int SetAndGetTextureID(byte[] textureBytes)
         {
-            int highestID = 0;
-            foreach (var tex in TextureDictionary)
-                if (tex.Value.Data.SequenceEqualFast(textureBytes))
-                    return tex.Key;
-                else if (tex.Key > highestID)
-                    highestID = tex.Key;
-
-            highestID++;
-            TextureDictionary.Add(
-                highestID,
-                TextureSaveHandler.CreateTextureContainer(textureBytes));
-            return highestID;
+            return TextureSaveHandler.GetOrAddTexture(TextureDictionary, textureBytes);
         }
 
 

--- a/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.projitems
+++ b/src/MaterialEditor.Core.Studio/Core.MaterialEditor.Studio.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>Core.MaterialEditor.Studio</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SceneController.Persistence.Copy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SceneController.Persistence.Properties.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SceneController.Persistence.Textures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SceneController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SceneController.Edits.Core.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.SceneController.Edits.Cubemap.cs" />

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.Cubemap.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.Cubemap.cs
@@ -101,194 +101,42 @@ namespace KK_Plugins.MaterialEditor
             GameObject go,
             bool logNormalizationWarning)
         {
-            if (data == null)
-                return false;
-
-            MaterialEditorCubemapLease lease = null;
-            var storedLease = false;
-            var textureEntryCreated = false;
-            var texID = 0;
-            MaterialCubemapProperty cubemapProperty = null;
-            var propertyAdded = false;
-            int? previousTexID = null;
-            MaterialCubemapOriginalState.Checkpoint previousOriginalState = null;
-            Dictionary<Material, Cubemap> previousAppliedValues = null;
-            string materialName = null;
-            try
-            {
-                string warning;
-                string error;
-                var acquired = contentKey == null
-                    ? MaterialEditorCubemapCache.TryAcquire(
-                        data,
-                        out lease,
-                        out warning,
-                        out error)
-                    : MaterialEditorCubemapCache.TryAcquire(
-                        data,
-                        contentKey,
-                        out lease,
-                        out warning,
-                        out error);
-                if (!acquired)
+            if (material == null) return false;
+            var existing = FindMaterialCubemapProperty(slot, objectType, material, propertyName);
+            var result = MaterialCubemapImportTransaction.Execute(data, contentKey,
+                go, material.NameFormatted(), propertyName, logNormalizationWarning,
+                new MaterialCubemapImportStorage
                 {
-                    MaterialEditorPlugin.Logger.LogMessage(error);
-                    return false;
-                }
-                if (logNormalizationWarning && !string.IsNullOrEmpty(warning))
-                    MaterialEditorPlugin.Logger.LogWarning(warning);
-
-                var textureCountBefore = TextureDictionary.Count;
-                texID = SetAndGetTextureID(data);
-                textureEntryCreated = TextureDictionary.Count > textureCountBefore;
-                CubemapLeases.Store(texID, lease);
-                // Store consumes ownership both when it adds the lease and when
-                // an existing texture ID makes the new reference redundant.
-                lease = null;
-                storedLease = true;
-
-                materialName = material.NameFormatted();
-                previousAppliedValues =
-                    MaterialCubemapOriginalSnapshot.SynchronizeByMaterialReference(
-                        go,
-                        materialName,
-                        propertyName,
-                        null);
-                cubemapProperty = FindMaterialCubemapProperty(
-                    slot,
-                    objectType,
-                    material,
-                    propertyName);
-                if (cubemapProperty == null)
-                {
-                    cubemapProperty = new MaterialCubemapProperty(
-                        objectType,
-                        GetCoordinateIndex(objectType),
-                        slot,
-                        materialName,
-                        propertyName,
-                        texID);
-                    MaterialCubemapPropertyList.Add(cubemapProperty);
-                    propertyAdded = true;
-                }
-                else
-                {
-                    previousTexID = cubemapProperty.TexID;
-                    previousOriginalState =
-                        cubemapProperty.CubemapOriginalState.CaptureCheckpoint();
-                    cubemapProperty.TexID = texID;
-                }
-
-                if (SetCubemapWithProperty(go, cubemapProperty))
-                    return true;
-
-                RollbackMaterialCubemapSet(
-                    go,
-                    materialName,
-                    propertyName,
-                    cubemapProperty,
-                    propertyAdded,
-                    previousTexID,
-                    previousOriginalState,
-                    previousAppliedValues,
-                    texID,
-                    textureEntryCreated);
-                textureEntryCreated = false;
-                MaterialEditorPluginBase.Logger.LogWarning(
-                    "Could not apply Cubemap " + materialName + "/" + propertyName
-                    + "; the previous override was preserved.");
-                return false;
-            }
-            catch (Exception exception)
-            {
-                RollbackMaterialCubemapSet(
-                    go,
-                    materialName,
-                    propertyName,
-                    cubemapProperty,
-                    propertyAdded,
-                    previousTexID,
-                    previousOriginalState,
-                    previousAppliedValues,
-                    texID,
-                    textureEntryCreated);
-                textureEntryCreated = false;
-                MaterialEditorPluginBase.Logger.LogWarning(
-                    "Could not apply Cubemap; the previous override was preserved. "
-                    + exception.Message);
-                return false;
-            }
-            finally
-            {
-                if (lease != null)
-                    lease.Dispose();
-                if (storedLease)
-                    PurgeUnusedCubemapLeases();
-            }
+                    Count = () => TextureDictionary.Count,
+                    StoreData = SetAndGetTextureID,
+                    StoreLease = CubemapLeases.Store,
+                    RemoveCreated = RemoveFailedCubemapData,
+                    PurgeLeases = PurgeUnusedCubemapLeases
+                }, MaterialCubemapPropertyList, existing,
+                texId => new MaterialCubemapProperty(objectType, GetCoordinateIndex(objectType), slot, material.NameFormatted(), propertyName, texId),
+                CubemapRecordAccess, candidate => SetCubemapWithProperty(go, candidate));
+            if (!result.Succeeded)
+                MaterialEditorPluginBase.Logger?.LogWarning("Cubemap import: " + result.Stage + ": " + result.Diagnostic);
+            return result.Succeeded;
         }
 
-        private void RollbackMaterialCubemapSet(
-            GameObject gameObject,
-            string materialName,
-            string propertyName,
-            MaterialCubemapProperty cubemapProperty,
-            bool propertyAdded,
-            int? previousTexID,
-            MaterialCubemapOriginalState.Checkpoint previousOriginalState,
-            Dictionary<Material, Cubemap> previousAppliedValues,
-            int texID,
-            bool textureEntryCreated)
+        private static readonly MaterialCubemapRecordAccess<MaterialCubemapProperty> CubemapRecordAccess =
+            new MaterialCubemapRecordAccess<MaterialCubemapProperty>
+            {
+                GetId = x => x.TexID,
+                SetId = (x, id) => x.TexID = id,
+                Original = x => x.CubemapOriginalState
+            };
+
+        private void RemoveFailedCubemapData(int texId)
         {
-            try
-            {
-                MaterialCubemapOriginalSnapshot.RestoreByMaterialReference(
-                    gameObject,
-                    materialName,
-                    propertyName,
-                    previousAppliedValues);
-            }
-            catch (Exception exception)
-            {
-                MaterialEditorPluginBase.Logger.LogWarning(
-                    "Could not fully restore the previous Cubemap material value. "
-                    + exception.Message);
-            }
-
-            if (cubemapProperty != null)
-            {
-                if (propertyAdded)
-                {
-                    MaterialCubemapPropertyList.Remove(cubemapProperty);
-                    cubemapProperty.ClearCubemapOriginalSnapshot();
-                }
-                else
-                {
-                    cubemapProperty.TexID = previousTexID;
-                    cubemapProperty.CubemapOriginalState.RestoreCheckpoint(
-                        previousOriginalState,
-                        true);
-                }
-            }
-
-            if (textureEntryCreated)
-            {
-                CubemapLeases.Release(texID);
-                TextureContainer container;
-                if (TextureDictionary.TryGetValue(texID, out container))
-                {
-                    try
-                    {
-                        if (container != null)
-                            container.Dispose();
-                    }
-                    finally
-                    {
-                        TextureDictionary.Remove(texID);
-                    }
-                }
-            }
-            PurgeUnusedCubemapLeases();
+            CubemapLeases.Release(texId);
+            TextureContainer container;
+            if (!TextureDictionary.TryGetValue(texId, out container)) return;
+            try { container?.Dispose(); }
+            finally { TextureDictionary.Remove(texId); }
         }
+
 
         /// <summary>
         /// Get the persisted native Cubemap value, or null when no override exists.

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.TextureShader.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Edits.TextureShader.cs
@@ -114,14 +114,12 @@ namespace KK_Plugins.MaterialEditor
             var coordinateIndex = GetCoordinateIndex(objectType);
             var materialName = material.NameFormatted();
             var existingProperty = MaterialTexturePropertyList.FirstOrDefault(x => x.ObjectType == objectType && x.CoordinateIndex == coordinateIndex && x.Slot == slot && x.Property == propertyName && x.MaterialName == materialName);
-            MaterialTextureProperty candidateProperty = null;
-            var committed = false;
-
-            try
-            {
+            var result = MaterialTextureImportTransaction.Execute(
+                go, materialName, propertyName, () =>
+                {
                 var texID = SetAndGetTextureID(data);
                 var animationDefinition = MEAnimationUtil.LoadAnimationDefFromBytes(texID, data, SetAndGetTextureID);
-                candidateProperty = new MaterialTextureProperty(
+                return new MaterialTextureProperty(
                     objectType,
                     coordinateIndex,
                     slot,
@@ -133,59 +131,23 @@ namespace KK_Plugins.MaterialEditor
                     existingProperty == null ? null : existingProperty.Scale,
                     existingProperty == null ? null : existingProperty.ScaleOriginal,
                     animationDefinition);
-
-                if (!SetTextureWithProperty(go, candidateProperty))
-                    return false;
-
-                CommitTextureImport(existingProperty, candidateProperty);
-                committed = true;
-                return true;
-            }
-            finally
-            {
-                if (!committed)
+                },
+                candidate => SetTextureWithProperty(go, candidate),
+                candidate => CommitTextureImport(existingProperty, candidate),
+                candidate =>
                 {
-                    if (candidateProperty != null)
-                        AnimationControllerMap.Remove(candidateProperty);
+                    if (candidate != null) AnimationControllerMap.Remove(candidate);
                     PurgeUnusedTextures();
-                }
-            }
+                });
+            if (!result.Succeeded)
+                MaterialEditorPluginBase.Logger?.LogWarning("Texture import: " + result.Stage + ": " + result.Diagnostic);
+            return result.Succeeded;
         }
 
-        private void CommitTextureImport(MaterialTextureProperty existingProperty, MaterialTextureProperty candidateProperty)
-        {
-            if (existingProperty == null)
-            {
-                MaterialTexturePropertyList.Add(candidateProperty);
-                return;
-            }
-
-            var previousTexID = existingProperty.TexID;
-            var previousAnimationDefinition = existingProperty.TexAnimationDef;
-            var hadPreviousController = AnimationControllerMap.TryGetValue(existingProperty, out var previousController);
-            var hasCandidateController = AnimationControllerMap.TryGetValue(candidateProperty, out var candidateController);
-            try
-            {
-                existingProperty.TexID = candidateProperty.TexID;
-                existingProperty.TexAnimationDef = candidateProperty.TexAnimationDef;
-                AnimationControllerMap.Remove(candidateProperty);
-                if (hasCandidateController)
-                    AnimationControllerMap[existingProperty] = candidateController;
-                else
-                    AnimationControllerMap.Remove(existingProperty);
-            }
-            catch
-            {
-                existingProperty.TexID = previousTexID;
-                existingProperty.TexAnimationDef = previousAnimationDefinition;
-                AnimationControllerMap.Remove(candidateProperty);
-                if (hadPreviousController)
-                    AnimationControllerMap[existingProperty] = previousController;
-                else
-                    AnimationControllerMap.Remove(existingProperty);
-                throw;
-            }
-        }
+        private void CommitTextureImport(MaterialTextureProperty existingProperty, MaterialTextureProperty candidateProperty) =>
+            MaterialTextureImportTransaction.Commit(MaterialTexturePropertyList, AnimationControllerMap,
+                existingProperty, candidateProperty, x => x.TexID, (x, id) => x.TexID = id,
+                x => x.TexAnimationDef, (x, animation) => x.TexAnimationDef = animation);
 
         /// <summary>
         /// Get the saved material property value or null if none is saved

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Persistence.Properties.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Persistence.Properties.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using System.Linq;
+using MaterialEditorAPI;
+using UnityEngine;
+
+namespace KK_Plugins.MaterialEditor
+{
+    public partial class MaterialEditorCharaController
+    {
+        private sealed class CharacterLoadContext
+        {
+            internal MaterialEditLoadContext Data;
+            internal List<ObjectType> ObjectTypes;
+            internal int? DestinationCoordinate;
+            internal MaterialEditorCharaController DuplicateSource;
+            internal int Coordinate(ObjectType type, int saved) =>
+                DestinationCoordinate ?? (type == ObjectType.Character ? 0 : saved);
+        }
+
+        private void LoadMaterialShaderList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialShader>(nameof(MaterialShaderList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialShaderList.Add(new MaterialShader(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
+            });
+        }
+
+        private void LoadRendererPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<RendererProperty>(nameof(RendererPropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    RendererPropertyList.Add(new RendererProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadProjectorPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<ProjectorProperty>(nameof(ProjectorPropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    ProjectorPropertyList.Add(new ProjectorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadMaterialNamePropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialNameProperty>(nameof(MaterialNamePropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialNamePropertyList.Add(new MaterialNameProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
+            });
+        }
+
+        private void LoadMaterialFloatPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialFloatProperty>(nameof(MaterialFloatPropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialFloatPropertyList.Add(new MaterialFloatProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadMaterialKeywordPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialKeywordProperty>(nameof(MaterialKeywordPropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialKeywordPropertyList.Add(new MaterialKeywordProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadMaterialColorPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialColorProperty>(nameof(MaterialColorPropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialColorPropertyList.Add(new MaterialColorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadMaterialVectorPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialVectorProperty>(nameof(MaterialVectorPropertyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialVectorPropertyList.Add(new MaterialVectorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
+            });
+        }
+
+        private void LoadMaterialTexturePropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialTextureProperty>(nameof(MaterialTexturePropertyList), loadedProperty =>
+            {
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType) && !loadedProperty.NullCheck())
+                {
+                    int? texID = null;
+                    if (loadedProperty.TexID != null && context.Data.TextureIds.TryGetValue((int)loadedProperty.TexID, out var importTextID))
+                        texID = importTextID;
+                    MEAnimationUtil.RemapTexID(loadedProperty.TexAnimationDef, context.Data.TextureIds);
+                    int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                    MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, texID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
+                    MaterialTexturePropertyList.Add(newTextureProperty);
+                }
+            });
+        }
+
+        private void LoadMaterialCubemapPropertyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialCubemapProperty>(nameof(MaterialCubemapPropertyList), loadedProperty =>
+            {
+                if (!context.ObjectTypes.Contains(loadedProperty.ObjectType) || loadedProperty.NullCheck())
+                    return;
+
+                int importTexID;
+                if (!context.Data.TextureIds.TryGetValue(loadedProperty.TexID.Value, out importTexID))
+                    return;
+                var coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                var newCubemapProperty = new MaterialCubemapProperty(
+                    loadedProperty.ObjectType,
+                    coordinateIndex,
+                    loadedProperty.Slot,
+                    loadedProperty.MaterialName,
+                    loadedProperty.Property,
+                    importTexID);
+
+                if (context.DuplicateSource != null)
+                {
+                    var sourceProperty = context.DuplicateSource.MaterialCubemapPropertyList.FirstOrDefault(x =>
+                        x.ObjectType == loadedProperty.ObjectType
+                        && x.CoordinateIndex == coordinateIndex
+                        && x.Slot == loadedProperty.Slot
+                        && x.MaterialName == loadedProperty.MaterialName
+                        && x.Property == loadedProperty.Property);
+                    GameObject sourceGameObject = null;
+                    if (sourceProperty != null
+                        && (sourceProperty.ObjectType == ObjectType.Character
+                            || sourceProperty.ObjectType == ObjectType.Hair
+                            || sourceProperty.CoordinateIndex == context.DuplicateSource.CurrentCoordinateIndex))
+                        sourceGameObject = context.DuplicateSource.FindGameObject(
+                            sourceProperty.ObjectType,
+                            sourceProperty.Slot);
+                    newCubemapProperty.InheritCubemapOriginalSnapshot(
+                        sourceProperty,
+                        sourceGameObject);
+                }
+                MaterialCubemapPropertyList.Add(newCubemapProperty);
+            });
+        }
+
+        private void LoadMaterialCopyList(CharacterLoadContext context)
+        {
+            context.Data.Read<MaterialCopy>(nameof(MaterialCopyList), loadedProperty =>
+            {
+                int coordinateIndex = context.Coordinate(loadedProperty.ObjectType, loadedProperty.CoordinateIndex);
+                if (context.ObjectTypes.Contains(loadedProperty.ObjectType))
+                    MaterialCopyList.Add(new MaterialCopy(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
+            });
+        }
+
+    }
+}

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Persistence.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Persistence.cs
@@ -73,62 +73,26 @@ namespace KK_Plugins.MaterialEditor
                 else
                     data.data.Add(TexDicSaveKey, null);
 
-                if (coordinateRendererPropertyList.Count > 0)
-                    data.data.Add(nameof(RendererPropertyList), MessagePackSerializer.Serialize(coordinateRendererPropertyList));
-                else
-                    data.data.Add(nameof(RendererPropertyList), null);
-
-                if (coordinateProjectorPropertyList.Count > 0)
-                    data.data.Add(nameof(ProjectorPropertyList), MessagePackSerializer.Serialize(coordinateProjectorPropertyList));
-                else
-                    data.data.Add(nameof(ProjectorPropertyList), null);
-
-                if (coordinateMaterialNamePropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialNamePropertyList), MessagePackSerializer.Serialize(coordinateMaterialNamePropertyList));
-                else
-                    data.data.Add(nameof(MaterialNamePropertyList), null);
-
-                if (coordinateMaterialFloatPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(coordinateMaterialFloatPropertyList));
-                else
-                    data.data.Add(nameof(MaterialFloatPropertyList), null);
-
-                if (coordinateMaterialKeywordPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialKeywordPropertyList), MessagePackSerializer.Serialize(coordinateMaterialKeywordPropertyList));
-                else
-                    data.data.Add(nameof(MaterialKeywordPropertyList), null);
-
-                if (coordinateMaterialColorPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialColorPropertyList), MessagePackSerializer.Serialize(coordinateMaterialColorPropertyList));
-                else
-                    data.data.Add(nameof(MaterialColorPropertyList), null);
-
-                if (coordinateMaterialVectorPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialVectorPropertyList), MessagePackSerializer.Serialize(coordinateMaterialVectorPropertyList));
-                else
-                    data.data.Add(nameof(MaterialVectorPropertyList), null);
-
-                if (coordinateMaterialTexturePropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialTexturePropertyList), MessagePackSerializer.Serialize(coordinateMaterialTexturePropertyList));
-                else
-                    data.data.Add(nameof(MaterialTexturePropertyList), null);
-
-                if (coordinateMaterialCubemapPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialCubemapPropertyList), MessagePackSerializer.Serialize(coordinateMaterialCubemapPropertyList));
-                else
-                    data.data.Add(nameof(MaterialCubemapPropertyList), null);
-
-                if (coordinateMaterialShaderList.Count > 0)
-                    data.data.Add(nameof(MaterialShaderList), MessagePackSerializer.Serialize(coordinateMaterialShaderList));
-                else
-                    data.data.Add(nameof(MaterialShaderList), null);
-
-                if (coordinateMaterialCopyList.Count > 0)
-                    data.data.Add(nameof(MaterialCopyList), MessagePackSerializer.Serialize(coordinateMaterialCopyList));
-                else
-                    data.data.Add(nameof(MaterialCopyList), null);
+                WriteRecords(nameof(RendererPropertyList), coordinateRendererPropertyList);
+                WriteRecords(nameof(ProjectorPropertyList), coordinateProjectorPropertyList);
+                WriteRecords(nameof(MaterialNamePropertyList), coordinateMaterialNamePropertyList);
+                WriteRecords(nameof(MaterialFloatPropertyList), coordinateMaterialFloatPropertyList);
+                WriteRecords(nameof(MaterialKeywordPropertyList), coordinateMaterialKeywordPropertyList);
+                WriteRecords(nameof(MaterialColorPropertyList), coordinateMaterialColorPropertyList);
+                WriteRecords(nameof(MaterialVectorPropertyList), coordinateMaterialVectorPropertyList);
+                WriteRecords(nameof(MaterialTexturePropertyList), coordinateMaterialTexturePropertyList);
+                WriteRecords(nameof(MaterialCubemapPropertyList), coordinateMaterialCubemapPropertyList);
+                WriteRecords(nameof(MaterialShaderList), coordinateMaterialShaderList);
+                WriteRecords(nameof(MaterialCopyList), coordinateMaterialCopyList);
 
                 SetCoordinateExtendedData(coordinate, data);
+
+                void WriteRecords<T>(string key, List<T> records)
+                {
+                    // Keep empty fields present as null in the saved data.
+                    data.data.Add(key,
+                        records.Count > 0 ? MessagePackSerializer.Serialize(records) : null);
+                }
             }
 
             base.OnCoordinateBeingSaved(coordinate);
@@ -157,104 +121,7 @@ namespace KK_Plugins.MaterialEditor
         {
             RemoveMaterialCopies(ChaControl.gameObject);
 
-            List<ObjectType> objectTypesToLoad = new List<ObjectType>();
-
-            var loadFlags = MakerAPI.GetCharacterLoadFlags();
-            if (loadFlags == null)
-            {
-                RendererPropertyList.Clear();
-                ProjectorPropertyList.Clear();
-                MaterialNamePropertyList.Clear();
-                MaterialFloatPropertyList.Clear();
-                MaterialKeywordPropertyList.Clear();
-                MaterialColorPropertyList.Clear();
-                MaterialVectorPropertyList.Clear();
-                MaterialTexturePropertyList.Clear();
-                MaterialCubemapPropertyList.Clear();
-                MaterialShaderList.Clear();
-                MaterialCopyList.Clear();
-                AnimationControllerMap.Clear();
-
-                objectTypesToLoad.Add(ObjectType.Accessory);
-                objectTypesToLoad.Add(ObjectType.Character);
-                objectTypesToLoad.Add(ObjectType.Clothing);
-                objectTypesToLoad.Add(ObjectType.Hair);
-            }
-            else
-            {
-                bool changed = false;
-
-                if (loadFlags.Face || loadFlags.Body)
-                {
-                    RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialVectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialCubemapPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-                    MaterialCopyList.RemoveAll(x => x.ObjectType == ObjectType.Character);
-
-                    objectTypesToLoad.Add(ObjectType.Character);
-
-                    changed = true;
-                }
-                if (loadFlags.Clothes)
-                {
-                    RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialVectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialCubemapPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    MaterialCopyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing);
-                    objectTypesToLoad.Add(ObjectType.Clothing);
-
-                    RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialVectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialCubemapPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    MaterialCopyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory);
-                    objectTypesToLoad.Add(ObjectType.Accessory);
-
-                    changed = true;
-                }
-                if (loadFlags.Hair)
-                {
-                    RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    ProjectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialVectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialCubemapPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    MaterialCopyList.RemoveAll(x => x.ObjectType == ObjectType.Hair);
-                    objectTypesToLoad.Add(ObjectType.Hair);
-
-                    changed = true;
-                }
-
-                if (changed)
-                {
-                    PurgeUnusedAnimation();
-                }
-            }
+            var objectTypesToLoad = PrepareCharacterLoad();
 
             //Don't destroy the textures in H mode because they will still be needed
             if (KoikatuAPI.GetCurrentGameMode() != GameMode.MainGame)
@@ -279,8 +146,7 @@ namespace KK_Plugins.MaterialEditor
 #endif
                         ;
                     duplicateSourceController = MaterialEditorPlugin.GetCharaController(chaCtrl);
-                    foreach (var kvp in duplicateSourceController.TextureDictionary)
-                        importDictionary[kvp.Key] = SetAndGetTextureID(kvp.Value.Data);
+                    importDictionary = MaterialEditLoadContext.ImportTextures(duplicateSourceController.TextureDictionary, x => x.Data, SetAndGetTextureID);
                     DuplicatingFrom = null;
                 }
                 else
@@ -289,8 +155,7 @@ namespace KK_Plugins.MaterialEditor
                     var importDictionaryTemp = TextureSaveHandler.Instance.Load<Dictionary<int, TextureContainer>>(data, TexDicSaveKey, true);
                     try
                     {
-                        foreach (var kvp in importDictionaryTemp)
-                            importDictionary[kvp.Key] = SetAndGetTextureID(kvp.Value.Data);
+                        importDictionary = MaterialEditLoadContext.ImportTextures(importDictionaryTemp, x => x.Data, SetAndGetTextureID);
                     }
                     finally
                     {
@@ -298,251 +163,39 @@ namespace KK_Plugins.MaterialEditor
                     }
                 }
 
-                //Debug for dumping all textures
-                //int counter = 1;
-                //foreach (var tex in TextureDictionary.Values)
-                //{
-                //    string filename = Path.Combine(MaterialEditorPlugin.ExportPath, $"_Export_{ChaControl.GetCharacterName()}_{counter}.png");
-                //    MaterialEditorPlugin.SaveTex(tex.Texture, filename);
-                //    MaterialEditorPlugin.Logger.LogInfo($"Exported {filename}");
-                //    counter++;
-                //}
-
-                if (data.data.TryGetValue(nameof(MaterialShaderList), out var shaderProperties) && shaderProperties != null)
+                var context = new CharacterLoadContext
                 {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialShader>>((byte[])shaderProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialShaderList.Add(new MaterialShader(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
-                    }
-                }
+                    Data = new MaterialEditLoadContext(data, importDictionary),
+                    ObjectTypes = objectTypesToLoad,
+                    DuplicateSource = duplicateSourceController
+                };
+                LoadMaterialShaderList(context);
 
-                if (data.data.TryGetValue(nameof(RendererPropertyList), out var rendererProperties) && rendererProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<RendererProperty>>((byte[])rendererProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            RendererPropertyList.Add(new RendererProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadRendererPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(ProjectorPropertyList), out var projectorProperties) && projectorProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<ProjectorProperty>>((byte[])projectorProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            ProjectorPropertyList.Add(new ProjectorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.ProjectorName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadProjectorPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialNamePropertyList), out var materialNameProperties) && materialNameProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialNameProperty>>((byte[])materialNameProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialNamePropertyList.Add(new MaterialNameProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
-                    }
-                }
+                LoadMaterialNamePropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialFloatPropertyList), out var materialFloatProperties) && materialFloatProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialFloatProperty>>((byte[])materialFloatProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialFloatPropertyList.Add(new MaterialFloatProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialFloatPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialKeywordPropertyList), out var materialKeywordProperties) && materialKeywordProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialKeywordProperty>>((byte[])materialKeywordProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialKeywordPropertyList.Add(new MaterialKeywordProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialKeywordPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialColorPropertyList), out var materialColorProperties) && materialColorProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialColorProperty>>((byte[])materialColorProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialColorPropertyList.Add(new MaterialColorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialColorPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialVectorPropertyList), out var materialVectorProperties) && materialVectorProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialVectorProperty>>((byte[])materialVectorProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialVectorPropertyList.Add(new MaterialVectorProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialVectorPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialTexturePropertyList), out var materialTextureProperties) && materialTextureProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialTextureProperty>>((byte[])materialTextureProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType) && !loadedProperty.NullCheck())
-                        {
-                            int? texID = null;
-                            if (loadedProperty.TexID != null && importDictionary.TryGetValue((int)loadedProperty.TexID, out var importTextID))
-                                texID = importTextID;
-                            MEAnimationUtil.RemapTexID(loadedProperty.TexAnimationDef, importDictionary);
-                            int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                            MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, texID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
-                            MaterialTexturePropertyList.Add(newTextureProperty);
-                        }
-                    }
-                }
+                LoadMaterialTexturePropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialCubemapPropertyList), out var materialCubemapProperties) && materialCubemapProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialCubemapProperty>>((byte[])materialCubemapProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (!objectTypesToLoad.Contains(loadedProperty.ObjectType) || loadedProperty.NullCheck())
-                            continue;
+                LoadMaterialCubemapPropertyList(context);
 
-                        int importTexID;
-                        if (!importDictionary.TryGetValue(loadedProperty.TexID.Value, out importTexID))
-                            continue;
-                        var coordinateIndex = loadedProperty.ObjectType == ObjectType.Character
-                            ? 0
-                            : loadedProperty.CoordinateIndex;
-                        var newCubemapProperty = new MaterialCubemapProperty(
-                            loadedProperty.ObjectType,
-                            coordinateIndex,
-                            loadedProperty.Slot,
-                            loadedProperty.MaterialName,
-                            loadedProperty.Property,
-                            importTexID);
-
-                        if (duplicateSourceController != null)
-                        {
-                            var sourceProperty = duplicateSourceController.MaterialCubemapPropertyList.FirstOrDefault(x =>
-                                x.ObjectType == loadedProperty.ObjectType
-                                && x.CoordinateIndex == coordinateIndex
-                                && x.Slot == loadedProperty.Slot
-                                && x.MaterialName == loadedProperty.MaterialName
-                                && x.Property == loadedProperty.Property);
-                            GameObject sourceGameObject = null;
-                            if (sourceProperty != null
-                                && (sourceProperty.ObjectType == ObjectType.Character
-                                    || sourceProperty.ObjectType == ObjectType.Hair
-                                    || sourceProperty.CoordinateIndex == duplicateSourceController.CurrentCoordinateIndex))
-                                sourceGameObject = duplicateSourceController.FindGameObject(
-                                    sourceProperty.ObjectType,
-                                    sourceProperty.Slot);
-                            newCubemapProperty.InheritCubemapOriginalSnapshot(
-                                sourceProperty,
-                                sourceGameObject);
-                        }
-                        MaterialCubemapPropertyList.Add(newCubemapProperty);
-                    }
-                }
-
-                if (data.data.TryGetValue(nameof(MaterialCopyList), out var materialCopyData) && materialCopyData != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialCopy>>((byte[])materialCopyData);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        int coordinateIndex = loadedProperty.ObjectType == ObjectType.Character ? 0 : loadedProperty.CoordinateIndex;
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialCopyList.Add(new MaterialCopy(loadedProperty.ObjectType, coordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
-                    }
-                }
+                LoadMaterialCopyList(context);
             }
         }
 
         private void LoadCoordinateExtSaveData(ChaFileCoordinate coordinate)
         {
-            List<ObjectType> objectTypesToLoad = new List<ObjectType>();
-
-            var loadFlags = MakerAPI.GetCoordinateLoadFlags();
-            if (loadFlags == null)
-            {
-                RendererPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialNamePropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialFloatPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialKeywordPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialColorPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialVectorPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialTexturePropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialCubemapPropertyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialShaderList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-                MaterialCopyList.RemoveAll(x => (x.ObjectType == ObjectType.Clothing || x.ObjectType == ObjectType.Accessory) && x.CoordinateIndex == CurrentCoordinateIndex);
-
-                objectTypesToLoad.Add(ObjectType.Accessory);
-                objectTypesToLoad.Add(ObjectType.Clothing);
-
-                PurgeUnusedAnimation();
-            }
-            else
-            {
-                if (loadFlags.Clothes)
-                {
-                    RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialVectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialCubemapPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialCopyList.RemoveAll(x => x.ObjectType == ObjectType.Clothing && x.CoordinateIndex == CurrentCoordinateIndex);
-                    objectTypesToLoad.Add(ObjectType.Clothing);
-                }
-                if (loadFlags.Accessories)
-                {
-                    RendererPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialNamePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialFloatPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialKeywordPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialColorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialVectorPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialTexturePropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialCubemapPropertyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialShaderList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    MaterialCopyList.RemoveAll(x => x.ObjectType == ObjectType.Accessory && x.CoordinateIndex == CurrentCoordinateIndex);
-                    objectTypesToLoad.Add(ObjectType.Accessory);
-                }
-
-                if (loadFlags.Clothes || loadFlags.Accessories)
-                {
-                    PurgeUnusedAnimation();
-                }
-            }
+            var objectTypesToLoad = PrepareCoordinateLoad();
 
             var data = GetCoordinateExtendedData(coordinate);
             if (data?.data != null)
@@ -550,130 +203,33 @@ namespace KK_Plugins.MaterialEditor
                 var importDictionary = new Dictionary<int, int>();
 
                 if (data.data.TryGetValue(TexDicSaveKey, out var texDic) && texDic != null)
-                    foreach (var x in MessagePackSerializer.Deserialize<Dictionary<int, byte[]>>((byte[])texDic))
-                        importDictionary[x.Key] = SetAndGetTextureID(x.Value);
+                    importDictionary = MaterialEditLoadContext.ImportTextures(MessagePackSerializer.Deserialize<Dictionary<int, byte[]>>((byte[])texDic), x => x, SetAndGetTextureID);
 
-                if (data.data.TryGetValue(nameof(MaterialShaderList), out var materialShaders) && materialShaders != null)
+                var context = new CharacterLoadContext
                 {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialShader>>((byte[])materialShaders);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialShaderList.Add(new MaterialShader(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.ShaderName, loadedProperty.ShaderNameOriginal, loadedProperty.RenderQueue, loadedProperty.RenderQueueOriginal));
-                    }
-                }
+                    Data = new MaterialEditLoadContext(data, importDictionary),
+                    ObjectTypes = objectTypesToLoad,
+                    DestinationCoordinate = CurrentCoordinateIndex
+                };
+                LoadMaterialShaderList(context);
 
-                if (data.data.TryGetValue(nameof(RendererPropertyList), out var rendererProperties) && rendererProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<RendererProperty>>((byte[])rendererProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            RendererPropertyList.Add(new RendererProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.RendererName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadRendererPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialNamePropertyList), out var materialNameProperties) && materialNameProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialNameProperty>>((byte[])materialNameProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialNamePropertyList.Add(new MaterialNameProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.Renderer, loadedProperty.MaterialName, loadedProperty.Value));
-                    }
-                }
+                LoadMaterialNamePropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialFloatPropertyList), out var materialFloatProperties) && materialFloatProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialFloatProperty>>((byte[])materialFloatProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialFloatPropertyList.Add(new MaterialFloatProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialFloatPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialKeywordPropertyList), out var materialKeywordProperties) && materialKeywordProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialKeywordProperty>>((byte[])materialKeywordProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialKeywordPropertyList.Add(new MaterialKeywordProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialKeywordPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialColorPropertyList), out var materialColorProperties) && materialColorProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialColorProperty>>((byte[])materialColorProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialColorPropertyList.Add(new MaterialColorProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialColorPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialVectorPropertyList), out var materialVectorProperties) && materialVectorProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialVectorProperty>>((byte[])materialVectorProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialVectorPropertyList.Add(new MaterialVectorProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, loadedProperty.Value, loadedProperty.ValueOriginal));
-                    }
-                }
+                LoadMaterialVectorPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialTexturePropertyList), out var materialTextureProperties) && materialTextureProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialTextureProperty>>((byte[])materialTextureProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                        {
-                            int? texID = null;
-                            if (loadedProperty.TexID != null)
-                                texID = importDictionary[(int)loadedProperty.TexID];
-                            MEAnimationUtil.RemapTexID(loadedProperty.TexAnimationDef, importDictionary);
-                            MaterialTextureProperty newTextureProperty = new MaterialTextureProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, texID, loadedProperty.Offset, loadedProperty.OffsetOriginal, loadedProperty.Scale, loadedProperty.ScaleOriginal, loadedProperty.TexAnimationDef);
-                            MaterialTexturePropertyList.Add(newTextureProperty);
-                        }
-                    }
-                }
+                LoadMaterialTexturePropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialCubemapPropertyList), out var materialCubemapProperties) && materialCubemapProperties != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialCubemapProperty>>((byte[])materialCubemapProperties);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType) && !loadedProperty.NullCheck())
-                        {
-                            int? texID = null;
-                            if (loadedProperty.TexID != null)
-                                texID = importDictionary[loadedProperty.TexID.Value];
-                            MaterialCubemapPropertyList.Add(new MaterialCubemapProperty(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.Property, texID));
-                        }
-                    }
-                }
+                LoadMaterialCubemapPropertyList(context);
 
-                if (data.data.TryGetValue(nameof(MaterialCopyList), out var materialCopyData) && materialCopyData != null)
-                {
-                    var properties = MessagePackSerializer.Deserialize<List<MaterialCopy>>((byte[])materialCopyData);
-                    for (var i = 0; i < properties.Count; i++)
-                    {
-                        var loadedProperty = properties[i];
-                        if (objectTypesToLoad.Contains(loadedProperty.ObjectType))
-                            MaterialCopyList.Add(new MaterialCopy(loadedProperty.ObjectType, CurrentCoordinateIndex, loadedProperty.Slot, loadedProperty.MaterialName, loadedProperty.MaterialCopyName));
-                    }
-                }
+                LoadMaterialCopyList(context);
             }
         }
 
@@ -704,161 +260,26 @@ namespace KK_Plugins.MaterialEditor
                 CorrectFace();
 #endif
 
-            //Instantiate all material copies before applying any edits to ensure edits are applied to copies
-            for (var i = 0; i < MaterialCopyList.Count; i++)
-            {
-                var property = MaterialCopyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
+            var scope = new CharacterRestoreScope(clothes, accessories, hair, body);
 
-                CopyMaterial(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.MaterialCopyName);
-            }
+            //Instantiate all material copies before applying any edits to ensure edits are applied to copies
+            RestoreMaterialCopyList(scope);
 
             // Rename materials before applying edits, but after copying materials, to ensure no missing material mishaps occur
             // Do not move this anywhere else
-            for (var i = 0; i < MaterialNamePropertyList.Count; i++)
-            {
-                var property = MaterialNamePropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
+            RestoreMaterialNamePropertyList(scope);
 
-                MaterialAPI.SetName(FindGameObject(property.ObjectType, property.Slot), property.Renderer, property.MaterialName, property.Value);
-            }
-
-            for (var i = 0; i < MaterialShaderList.Count; i++)
-            {
-                var property = MaterialShaderList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-#if KK || EC || KKS
-                if (property.ObjectType == ObjectType.Character && MaterialEditorPlugin.EyeMaterials.Contains(property.MaterialName))
-                {
-                    SetShader(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.ShaderName, true);
-                }
-                else
-#endif
-                {
-                    SetShader(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.ShaderName);
-                }
-                SetRenderQueue(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.RenderQueue);
-            }
+            RestoreMaterialShaderList(scope);
             MigrateLegacyMaterialVectorProperties(clothes, accessories, hair, body);
 
-            for (var i = 0; i < RendererPropertyList.Count; i++)
-            {
-                var property = RendererPropertyList[i];
-#if KK
-                if (property.Property == RendererProperties.UpdateWhenOffscreen) continue;
-#endif
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-                MaterialAPI.SetRendererProperty(FindGameObject(property.ObjectType, property.Slot), property.RendererName, property.Property, property.Value);
-            }
-            for (var i = 0; i < MaterialFloatPropertyList.Count; i++)
-            {
-                var property = MaterialFloatPropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                var go = FindGameObject(property.ObjectType, property.Slot);
-                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-                SetFloat(go, property.MaterialName, property.Property, float.Parse(property.Value));
-            }
-            for (var i = 0; i < MaterialKeywordPropertyList.Count; i++)
-            {
-                var property = MaterialKeywordPropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                var go = FindGameObject(property.ObjectType, property.Slot);
-                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-                SetKeyword(go, property.MaterialName, property.Property, property.Value);
-            }
-            for (var i = 0; i < MaterialColorPropertyList.Count; i++)
-            {
-                var property = MaterialColorPropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                var go = FindGameObject(property.ObjectType, property.Slot);
-                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-                SetColor(go, property.MaterialName, property.Property, property.Value);
-            }
-            for (var i = 0; i < MaterialVectorPropertyList.Count; i++)
-            {
-                var property = MaterialVectorPropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                var go = FindGameObject(property.ObjectType, property.Slot);
-                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-                SetVector(go, property.MaterialName, property.Property, property.Value);
-            }
-            for (var i = 0; i < MaterialTexturePropertyList.Count; i++)
-            {
-                var property = MaterialTexturePropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-                var go = FindGameObject(property.ObjectType, property.Slot);
-                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
-
-                SetTextureWithProperty(go, property);
-                SetTextureOffset(go, property.MaterialName, property.Property, property.Offset);
-                SetTextureScale(go, property.MaterialName, property.Property, property.Scale);
-            }
-            for (var i = 0; i < MaterialCubemapPropertyList.Count; i++)
-            {
-                var property = MaterialCubemapPropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-                var go = FindGameObject(property.ObjectType, property.Slot);
-                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
-
-                SetCubemapWithProperty(go, property);
-            }
-            for (var i = 0; i < ProjectorPropertyList.Count; i++)
-            {
-                var property = ProjectorPropertyList[i];
-                if (property.ObjectType == ObjectType.Clothing && !clothes) continue;
-                if (property.ObjectType == ObjectType.Accessory && !accessories) continue;
-                if (property.ObjectType == ObjectType.Hair && !hair) continue;
-                if ((property.ObjectType == ObjectType.Clothing || property.ObjectType == ObjectType.Accessory) && property.CoordinateIndex != CurrentCoordinateIndex) continue;
-                if (property.ObjectType == ObjectType.Character && !body) continue;
-
-                MaterialAPI.SetProjectorProperty(FindGameObject(property.ObjectType, property.Slot), property.ProjectorName, property.Property, float.Parse(property.Value));
-            }
+            RestoreRendererPropertyList(scope);
+            RestoreMaterialFloatPropertyList(scope);
+            RestoreMaterialKeywordPropertyList(scope);
+            RestoreMaterialColorPropertyList(scope);
+            RestoreMaterialVectorPropertyList(scope);
+            RestoreMaterialTexturePropertyList(scope);
+            RestoreMaterialCubemapPropertyList(scope);
+            RestoreProjectorPropertyList(scope);
 
 
 #if KK || EC || KKS
@@ -1008,19 +429,124 @@ namespace KK_Plugins.MaterialEditor
         /// </summary>
         private int SetAndGetTextureID(byte[] textureBytes)
         {
-            int highestID = 0;
-            foreach (var tex in TextureDictionary)
-                if (tex.Value.Data.SequenceEqualFast(textureBytes))
-                    return tex.Key;
-                else if (tex.Key > highestID)
-                    highestID = tex.Key;
-
-            highestID++;
-            TextureDictionary.Add(
-                highestID,
-                TextureSaveHandler.CreateTextureContainer(textureBytes));
-            return highestID;
+            return TextureSaveHandler.GetOrAddTexture(TextureDictionary, textureBytes);
         }
 
+        private List<ObjectType> PrepareCharacterLoad()
+        {
+            List<ObjectType> objectTypesToLoad = new List<ObjectType>();
+
+            var loadFlags = MakerAPI.GetCharacterLoadFlags();
+            if (loadFlags == null)
+            {
+                RendererPropertyList.Clear();
+                ProjectorPropertyList.Clear();
+                MaterialNamePropertyList.Clear();
+                MaterialFloatPropertyList.Clear();
+                MaterialKeywordPropertyList.Clear();
+                MaterialColorPropertyList.Clear();
+                MaterialVectorPropertyList.Clear();
+                MaterialTexturePropertyList.Clear();
+                MaterialCubemapPropertyList.Clear();
+                MaterialShaderList.Clear();
+                MaterialCopyList.Clear();
+                AnimationControllerMap.Clear();
+
+                objectTypesToLoad.Add(ObjectType.Accessory);
+                objectTypesToLoad.Add(ObjectType.Character);
+                objectTypesToLoad.Add(ObjectType.Clothing);
+                objectTypesToLoad.Add(ObjectType.Hair);
+            }
+            else
+            {
+                bool changed = false;
+
+                if (loadFlags.Face || loadFlags.Body)
+                {
+                    RemovePropertiesForLoad((type, coordinate) => type == ObjectType.Character, true);
+
+                    objectTypesToLoad.Add(ObjectType.Character);
+
+                    changed = true;
+                }
+                if (loadFlags.Clothes)
+                {
+                    RemovePropertiesForLoad((type, coordinate) => type == ObjectType.Clothing, true);
+                    objectTypesToLoad.Add(ObjectType.Clothing);
+
+                    RemovePropertiesForLoad((type, coordinate) => type == ObjectType.Accessory, true);
+                    objectTypesToLoad.Add(ObjectType.Accessory);
+
+                    changed = true;
+                }
+                if (loadFlags.Hair)
+                {
+                    RemovePropertiesForLoad((type, coordinate) => type == ObjectType.Hair, true);
+                    objectTypesToLoad.Add(ObjectType.Hair);
+
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    PurgeUnusedAnimation();
+                }
+            }
+
+            return objectTypesToLoad;
+        }
+
+        private List<ObjectType> PrepareCoordinateLoad()
+        {
+            List<ObjectType> objectTypesToLoad = new List<ObjectType>();
+
+            var loadFlags = MakerAPI.GetCoordinateLoadFlags();
+            if (loadFlags == null)
+            {
+                RemovePropertiesForLoad((type, coordinate) => (type == ObjectType.Clothing || type == ObjectType.Accessory) && coordinate == CurrentCoordinateIndex, false);
+
+                objectTypesToLoad.Add(ObjectType.Accessory);
+                objectTypesToLoad.Add(ObjectType.Clothing);
+
+                PurgeUnusedAnimation();
+            }
+            else
+            {
+                if (loadFlags.Clothes)
+                {
+                    RemovePropertiesForLoad((type, coordinate) => type == ObjectType.Clothing && coordinate == CurrentCoordinateIndex, false);
+                    objectTypesToLoad.Add(ObjectType.Clothing);
+                }
+                if (loadFlags.Accessories)
+                {
+                    RemovePropertiesForLoad((type, coordinate) => type == ObjectType.Accessory && coordinate == CurrentCoordinateIndex, false);
+                    objectTypesToLoad.Add(ObjectType.Accessory);
+                }
+
+                if (loadFlags.Clothes || loadFlags.Accessories)
+                {
+                    PurgeUnusedAnimation();
+                }
+            }
+
+            return objectTypesToLoad;
+        }
+
+        private void RemovePropertiesForLoad(Func<ObjectType, int, bool> remove, bool includeProjectors)
+        {
+            RendererPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialNamePropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialFloatPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialKeywordPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialColorPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialVectorPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialTexturePropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialCubemapPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialShaderList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            MaterialCopyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+            // Coordinate loading historically excludes projector records.
+            if (includeProjectors)
+                ProjectorPropertyList.RemoveAll(x => remove(x.ObjectType, x.CoordinateIndex));
+        }
     }
 }

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Restore.Properties.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.Restore.Properties.cs
@@ -1,0 +1,215 @@
+using ExtensibleSaveFormat;
+using KKAPI;
+using KKAPI.Chara;
+using KKAPI.Maker;
+using MaterialEditorAPI;
+using MessagePack;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UniRx;
+using UnityEngine;
+using static MaterialEditorAPI.MaterialAPI;
+using static MaterialEditorAPI.MaterialEditorPluginBase;
+#if !EC
+using KKAPI.Studio;
+#endif
+#if AI || HS2
+using AIChara;
+#endif
+#if PH
+using ChaFileCoordinate = Character.CustomParameter;
+using ChaControl = Human;
+#endif
+namespace KK_Plugins.MaterialEditor
+{
+    public partial class MaterialEditorCharaController
+    {
+        private struct CharacterRestoreScope
+        {
+            internal readonly bool Body;
+            private readonly bool _clothes;
+            private readonly bool _accessories;
+            private readonly bool _hair;
+
+            internal CharacterRestoreScope(bool clothes, bool accessories, bool hair, bool body)
+            {
+                _clothes = clothes;
+                _accessories = accessories;
+                _hair = hair;
+                Body = body;
+            }
+
+            internal bool Includes(ObjectType type, int coordinate, int currentCoordinate)
+            {
+                if (type == ObjectType.Clothing && !_clothes) return false;
+                if (type == ObjectType.Accessory && !_accessories) return false;
+                if (type == ObjectType.Hair && !_hair) return false;
+                return (type != ObjectType.Clothing && type != ObjectType.Accessory)
+                    || coordinate == currentCoordinate;
+            }
+        }
+
+        private void RestoreMaterialCopyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialCopyList.Count; i++)
+            {
+                var property = MaterialCopyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                CopyMaterial(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.MaterialCopyName);
+            }
+        }
+
+        private void RestoreMaterialNamePropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialNamePropertyList.Count; i++)
+            {
+                var property = MaterialNamePropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                MaterialAPI.SetName(FindGameObject(property.ObjectType, property.Slot), property.Renderer, property.MaterialName, property.Value);
+            }
+        }
+
+        private void RestoreMaterialShaderList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialShaderList.Count; i++)
+            {
+                var property = MaterialShaderList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+#if KK || EC || KKS
+                if (property.ObjectType == ObjectType.Character && MaterialEditorPlugin.EyeMaterials.Contains(property.MaterialName))
+                {
+                    SetShader(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.ShaderName, true);
+                }
+                else
+#endif
+                {
+                    SetShader(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.ShaderName);
+                }
+                SetRenderQueue(FindGameObject(property.ObjectType, property.Slot), property.MaterialName, property.RenderQueue);
+            }
+        }
+
+        private void RestoreRendererPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < RendererPropertyList.Count; i++)
+            {
+                var property = RendererPropertyList[i];
+#if KK
+                if (property.Property == RendererProperties.UpdateWhenOffscreen) continue;
+#endif
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                MaterialAPI.SetRendererProperty(FindGameObject(property.ObjectType, property.Slot), property.RendererName, property.Property, property.Value);
+            }
+        }
+
+        private void RestoreMaterialFloatPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialFloatPropertyList.Count; i++)
+            {
+                var property = MaterialFloatPropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                var go = FindGameObject(property.ObjectType, property.Slot);
+                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                SetFloat(go, property.MaterialName, property.Property, float.Parse(property.Value));
+            }
+        }
+
+        private void RestoreMaterialKeywordPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialKeywordPropertyList.Count; i++)
+            {
+                var property = MaterialKeywordPropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                var go = FindGameObject(property.ObjectType, property.Slot);
+                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                SetKeyword(go, property.MaterialName, property.Property, property.Value);
+            }
+        }
+
+        private void RestoreMaterialColorPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialColorPropertyList.Count; i++)
+            {
+                var property = MaterialColorPropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                var go = FindGameObject(property.ObjectType, property.Slot);
+                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                SetColor(go, property.MaterialName, property.Property, property.Value);
+            }
+        }
+
+        private void RestoreMaterialVectorPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialVectorPropertyList.Count; i++)
+            {
+                var property = MaterialVectorPropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                var go = FindGameObject(property.ObjectType, property.Slot);
+                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                SetVector(go, property.MaterialName, property.Property, property.Value);
+            }
+        }
+
+        private void RestoreProjectorPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < ProjectorPropertyList.Count; i++)
+            {
+                var property = ProjectorPropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+
+                MaterialAPI.SetProjectorProperty(FindGameObject(property.ObjectType, property.Slot), property.ProjectorName, property.Property, float.Parse(property.Value));
+            }
+        }
+
+        private void RestoreMaterialTexturePropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialTexturePropertyList.Count; i++)
+            {
+                var property = MaterialTexturePropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+                var go = FindGameObject(property.ObjectType, property.Slot);
+                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
+
+                SetTextureWithProperty(go, property);
+                SetTextureOffset(go, property.MaterialName, property.Property, property.Offset);
+                SetTextureScale(go, property.MaterialName, property.Property, property.Scale);
+            }
+        }
+
+        private void RestoreMaterialCubemapPropertyList(CharacterRestoreScope scope)
+        {
+            for (var i = 0; i < MaterialCubemapPropertyList.Count; i++)
+            {
+                var property = MaterialCubemapPropertyList[i];
+                if (!scope.Includes(property.ObjectType, property.CoordinateIndex, CurrentCoordinateIndex)) continue;
+                if (property.ObjectType == ObjectType.Character && !scope.Body) continue;
+                var go = FindGameObject(property.ObjectType, property.Slot);
+                if (Instance.CheckBlacklist(property.MaterialName, property.Property)) continue;
+
+                SetCubemapWithProperty(go, property);
+            }
+        }
+    }
+}

--- a/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.CharaController.cs
@@ -100,62 +100,26 @@ namespace KK_Plugins.MaterialEditor
                 else
                     data.data.Add(TexDicSaveKey, null);
 
-                if (RendererPropertyList.Count > 0)
-                    data.data.Add(nameof(RendererPropertyList), MessagePackSerializer.Serialize(RendererPropertyList));
-                else
-                    data.data.Add(nameof(RendererPropertyList), null);
-
-                if (ProjectorPropertyList.Count > 0)
-                    data.data.Add(nameof(ProjectorPropertyList), MessagePackSerializer.Serialize(ProjectorPropertyList));
-                else
-                    data.data.Add(nameof(ProjectorPropertyList), null);
-
-                if (MaterialNamePropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialNamePropertyList), MessagePackSerializer.Serialize(MaterialNamePropertyList));
-                else
-                    data.data.Add(nameof(MaterialNamePropertyList), null);
-
-                if (MaterialFloatPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialFloatPropertyList), MessagePackSerializer.Serialize(MaterialFloatPropertyList));
-                else
-                    data.data.Add(nameof(MaterialFloatPropertyList), null);
-
-                if (MaterialKeywordPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialKeywordPropertyList), MessagePackSerializer.Serialize(MaterialKeywordPropertyList));
-                else
-                    data.data.Add(nameof(MaterialKeywordPropertyList), null);
-
-                if (MaterialColorPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialColorPropertyList), MessagePackSerializer.Serialize(MaterialColorPropertyList));
-                else
-                    data.data.Add(nameof(MaterialColorPropertyList), null);
-
-                if (MaterialVectorPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialVectorPropertyList), MessagePackSerializer.Serialize(MaterialVectorPropertyList));
-                else
-                    data.data.Add(nameof(MaterialVectorPropertyList), null);
-
-                if (MaterialTexturePropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialTexturePropertyList), MessagePackSerializer.Serialize(MaterialTexturePropertyList));
-                else
-                    data.data.Add(nameof(MaterialTexturePropertyList), null);
-
-                if (MaterialCubemapPropertyList.Count > 0)
-                    data.data.Add(nameof(MaterialCubemapPropertyList), MessagePackSerializer.Serialize(MaterialCubemapPropertyList));
-                else
-                    data.data.Add(nameof(MaterialCubemapPropertyList), null);
-
-                if (MaterialShaderList.Count > 0)
-                    data.data.Add(nameof(MaterialShaderList), MessagePackSerializer.Serialize(MaterialShaderList));
-                else
-                    data.data.Add(nameof(MaterialShaderList), null);
-
-                if (MaterialCopyList.Count > 0)
-                    data.data.Add(nameof(MaterialCopyList), MessagePackSerializer.Serialize(MaterialCopyList));
-                else
-                    data.data.Add(nameof(MaterialCopyList), null);
+                WriteRecords(nameof(RendererPropertyList), RendererPropertyList);
+                WriteRecords(nameof(ProjectorPropertyList), ProjectorPropertyList);
+                WriteRecords(nameof(MaterialNamePropertyList), MaterialNamePropertyList);
+                WriteRecords(nameof(MaterialFloatPropertyList), MaterialFloatPropertyList);
+                WriteRecords(nameof(MaterialKeywordPropertyList), MaterialKeywordPropertyList);
+                WriteRecords(nameof(MaterialColorPropertyList), MaterialColorPropertyList);
+                WriteRecords(nameof(MaterialVectorPropertyList), MaterialVectorPropertyList);
+                WriteRecords(nameof(MaterialTexturePropertyList), MaterialTexturePropertyList);
+                WriteRecords(nameof(MaterialCubemapPropertyList), MaterialCubemapPropertyList);
+                WriteRecords(nameof(MaterialShaderList), MaterialShaderList);
+                WriteRecords(nameof(MaterialCopyList), MaterialCopyList);
 
                 SetExtendedData(data);
+
+                void WriteRecords<T>(string key, List<T> records)
+                {
+                    // Keep empty fields present as null in the saved data.
+                    data.data.Add(key,
+                        records.Count > 0 ? MessagePackSerializer.Serialize(records) : null);
+                }
             }
         }
 

--- a/src/MaterialEditor.Core/Core.MaterialEditor.TextureSaveHandler.cs
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.TextureSaveHandler.cs
@@ -317,5 +317,20 @@ namespace KK_Plugins.MaterialEditor
                     return false;
             return true;
         }
+
+        // Preserve the first equal payload and allocate above the highest existing ID.
+        internal static int GetOrAddTexture(Dictionary<int, TextureContainer> textures, byte[] data)
+        {
+            int highestId = 0;
+            foreach (var texture in textures)
+                if (texture.Value.Data.SequenceEqualFast(data))
+                    return texture.Key;
+                else if (texture.Key > highestId)
+                    highestId = texture.Key;
+
+            highestId++;
+            textures.Add(highestId, CreateTextureContainer(data));
+            return highestId;
+        }
     }
 }

--- a/src/MaterialEditor.Core/Core.MaterialEditor.projitems
+++ b/src/MaterialEditor.Core/Core.MaterialEditor.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>Core.MaterialEditor</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Restore.Properties.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\MaterialEditLoadContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.Persistence.Properties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaRepository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.MaterialEditor.CharaController.cs" />

--- a/src/MaterialEditor.Core/Persistence/MaterialEditLoadContext.cs
+++ b/src/MaterialEditor.Core/Persistence/MaterialEditLoadContext.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using ExtensibleSaveFormat;
+using MessagePack;
+
+namespace MaterialEditorAPI
+{
+    /// <summary>One game persistence scope. Owns source, ID mapping and per-record diagnostics.</summary>
+    internal sealed class MaterialEditLoadContext
+    {
+        internal readonly PluginData Source;
+        internal readonly Dictionary<int, int> TextureIds;
+
+        internal MaterialEditLoadContext(PluginData source, Dictionary<int, int> textureIds)
+        {
+            Source = source;
+            TextureIds = textureIds;
+        }
+
+        internal static Dictionary<int, int> ImportTextures<T>(IEnumerable<KeyValuePair<int, T>> source,
+            Func<T, byte[]> readBytes, Func<byte[], int> store)
+        {
+            var ids = new Dictionary<int, int>();
+            ApplyRecords("TextureDictionary", source, entry => ids[entry.Key] = store(readBytes(entry.Value)));
+            return ids;
+        }
+
+        internal int? RemapTexture(int? id)
+        {
+            if (!id.HasValue) return null;
+            int mapped;
+            if (TextureIds.TryGetValue(id.Value, out mapped)) return mapped;
+            throw new InvalidOperationException("Missing imported texture ID " + id.Value);
+        }
+
+        internal void Read<T>(string family, Action<T> accept)
+        {
+            object bytes;
+            if (Source?.data == null || !Source.data.TryGetValue(family, out bytes) || bytes == null) return;
+            List<T> records;
+            try { records = MessagePackSerializer.Deserialize<List<T>>((byte[])bytes); }
+            catch (Exception ex) { Report(family, ex); return; }
+            ApplyRecords(family, records, accept);
+        }
+
+        internal static void ApplyRecords<T>(string family, IEnumerable<T> records, Action<T> accept)
+        {
+            if (records == null) return;
+            foreach (var record in records)
+            {
+                try { accept(record); }
+                catch (Exception ex) { Report(family, ex); }
+            }
+        }
+
+        private static void Report(string family, Exception error) =>
+            MaterialEditorPluginBase.Logger?.LogWarning("Skipped invalid " + family + " record: " + error.Message);
+    }
+}


### PR DESCRIPTION
## Description
- Share Texture2D/Cubemap import transactions between Chara and Studio, keeping commit and rollback logic together.
- Organize persistence loading and restoration into focused steps.
- Keep save fields explicit, with a local function handling serialization and empty-list values. No separate serialization helper class.

## Motivation and Context
Replaces the closed #406 and follows the merged #405. This is the complete second stage in one commit, without later maintenance or UI changes. Public APIs, save formats and application order are preserved.

## How Has This Been Tested?
Rebuilt API, KK, KKS, EC, AI, HS2 and PH successfully. Verified save field names, order and null handling. Existing warnings remain; this revised stage has not been tested in game.

## Screenshots (if appropriate):
No visual changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)